### PR TITLE
feat: add bounty status glossary and tooltips

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,9 @@ import {
   FolderGit2,
   HandCoins,
   Rocket,
+  Search,
   ShieldCheck,
+  SlidersHorizontal,
 } from "lucide-react";
 import {
   createBounty,
@@ -16,7 +18,7 @@ import {
   reserveBounty,
   submitBounty,
 } from "./api";
-import { Bounty, CreateBountyPayload, OpenIssue } from "./types";
+import { Bounty, BountyStatus, CreateBountyPayload, OpenIssue } from "./types";
 import SkeletonBountyCard from "./SkeletonBountyCard";
 
 const initialForm: CreateBountyPayload = {
@@ -30,6 +32,16 @@ const initialForm: CreateBountyPayload = {
   deadlineDays: 14,
   labels: ["help wanted"],
 };
+
+const statusOptions: Array<{ value: "all" | BountyStatus; label: string }> = [
+  { value: "all", label: "All statuses" },
+  { value: "open", label: "Open" },
+  { value: "reserved", label: "Reserved" },
+  { value: "submitted", label: "Submitted" },
+  { value: "released", label: "Released" },
+  { value: "refunded", label: "Refunded" },
+  { value: "expired", label: "Expired" },
+];
 
 function formatRelativeDeadline(deadlineAt: number): string {
   const now = Math.floor(Date.now() / 1000);
@@ -52,6 +64,10 @@ function App() {
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<"all" | BountyStatus>("all");
+  const [minReward, setMinReward] = useState("");
+  const [maxReward, setMaxReward] = useState("");
 
   async function refresh(): Promise<void> {
     const [bountyData, issueData] = await Promise.all([listBounties(), listOpenIssues()]);
@@ -98,6 +114,64 @@ function App() {
       shippedRewards: bounties.filter((bounty) => bounty.status === "released").length,
     };
   }, [bounties]);
+
+  const rewardBounds = useMemo(() => {
+    if (bounties.length === 0) {
+      return { lowest: 0, highest: 0 };
+    }
+
+    return {
+      lowest: Math.min(...bounties.map((bounty) => bounty.amount)),
+      highest: Math.max(...bounties.map((bounty) => bounty.amount)),
+    };
+  }, [bounties]);
+
+  const normalizedSearch = searchQuery.trim().toLowerCase();
+  const parsedMinReward = minReward === "" ? null : Number(minReward);
+  const parsedMaxReward = maxReward === "" ? null : Number(maxReward);
+
+  const effectiveMinReward =
+    parsedMinReward !== null && Number.isFinite(parsedMinReward) ? parsedMinReward : null;
+  const effectiveMaxReward =
+    parsedMaxReward !== null && Number.isFinite(parsedMaxReward) ? parsedMaxReward : null;
+
+  const filteredBounties = useMemo(() => {
+    return bounties.filter((bounty) => {
+      const matchesSearch =
+        normalizedSearch.length === 0 ||
+        [
+          bounty.title,
+          bounty.summary,
+          bounty.repo,
+          bounty.status,
+          bounty.issueNumber.toString(),
+          bounty.tokenSymbol,
+          ...bounty.labels,
+        ].some((value) => value.toLowerCase().includes(normalizedSearch));
+
+      const matchesStatus = statusFilter === "all" || bounty.status === statusFilter;
+      const matchesMinReward = effectiveMinReward === null || bounty.amount >= effectiveMinReward;
+      const matchesMaxReward = effectiveMaxReward === null || bounty.amount <= effectiveMaxReward;
+
+      return matchesSearch && matchesStatus && matchesMinReward && matchesMaxReward;
+    });
+  }, [
+    bounties,
+    effectiveMaxReward,
+    effectiveMinReward,
+    normalizedSearch,
+    statusFilter,
+  ]);
+
+  const activeRewardLabel = useMemo(() => {
+    if (effectiveMinReward === null && effectiveMaxReward === null) {
+      return `Any reward (${rewardBounds.lowest}–${rewardBounds.highest} XLM available)`;
+    }
+
+    const lower = effectiveMinReward ?? rewardBounds.lowest;
+    const upper = effectiveMaxReward ?? rewardBounds.highest;
+    return `${lower}–${upper} XLM`;
+  }, [effectiveMaxReward, effectiveMinReward, rewardBounds.highest, rewardBounds.lowest]);
 
   async function handleCreate(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -170,6 +244,13 @@ function App() {
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to refund bounty.");
     }
+  }
+
+  function clearFilters() {
+    setSearchQuery("");
+    setStatusFilter("all");
+    setMinReward("");
+    setMaxReward("");
   }
 
   return (
@@ -360,15 +441,92 @@ function App() {
             <HandCoins size={18} />
           </div>
 
+          <div className="board-filters">
+            <div className="board-filters__header">
+              <div>
+                <span className="panel-kicker">Board filters</span>
+                <p>
+                  Showing <strong>{filteredBounties.length}</strong> of <strong>{bounties.length}</strong>{" "}
+                  bounties
+                </p>
+              </div>
+              <button className="ghost-button filter-reset" type="button" onClick={clearFilters}>
+                Clear filters
+              </button>
+            </div>
+
+            <div className="filter-grid">
+              <label className="filter-field filter-field--search">
+                <span>Search</span>
+                <div className="input-with-icon">
+                  <Search size={16} />
+                  <input
+                    value={searchQuery}
+                    onChange={(event) => setSearchQuery(event.target.value)}
+                    placeholder="Search repo, title, labels, status"
+                  />
+                </div>
+              </label>
+
+              <label className="filter-field">
+                <span>Status</span>
+                <div className="input-with-icon">
+                  <SlidersHorizontal size={16} />
+                  <select
+                    value={statusFilter}
+                    onChange={(event) => setStatusFilter(event.target.value as "all" | BountyStatus)}
+                  >
+                    {statusOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </label>
+
+              <label className="filter-field">
+                <span>Min reward</span>
+                <input
+                  type="number"
+                  min="0"
+                  step="1"
+                  inputMode="numeric"
+                  value={minReward}
+                  onChange={(event) => setMinReward(event.target.value)}
+                  placeholder={rewardBounds.lowest > 0 ? `${rewardBounds.lowest}` : "0"}
+                />
+              </label>
+
+              <label className="filter-field">
+                <span>Max reward</span>
+                <input
+                  type="number"
+                  min="0"
+                  step="1"
+                  inputMode="numeric"
+                  value={maxReward}
+                  onChange={(event) => setMaxReward(event.target.value)}
+                  placeholder={rewardBounds.highest > 0 ? `${rewardBounds.highest}` : "No limit"}
+                />
+              </label>
+            </div>
+
+            <div className="active-range" aria-live="polite">
+              <span className="active-range__label">Active reward range</span>
+              <strong>{activeRewardLabel}</strong>
+            </div>
+          </div>
+
           {loading ? (
             <div className="board-list">
               {Array.from({ length: 3 }).map((_, i) => (
                 <SkeletonBountyCard key={i} />
               ))}
             </div>
-          ) : (
+          ) : filteredBounties.length > 0 ? (
             <div className="board-list">
-              {bounties.map((bounty) => (
+              {filteredBounties.map((bounty) => (
                 <article className="bounty-card" key={bounty.id}>
                   <div className="bounty-card__top">
                     <div>
@@ -444,6 +602,10 @@ function App() {
                 </article>
               ))}
             </div>
+          ) : (
+            <div className="empty-state">
+              No bounties match the current search, status, and reward range filters.
+            </div>
           )}
         </section>
       </main>
@@ -482,4 +644,3 @@ function App() {
 }
 
 export default App;
-

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,6 +43,38 @@ const statusOptions: Array<{ value: "all" | BountyStatus; label: string }> = [
   { value: "expired", label: "Expired" },
 ];
 
+const statusOptionValues = new Set(statusOptions.map((option) => option.value));
+
+function readInitialFilters(): {
+  searchQuery: string;
+  statusFilter: "all" | BountyStatus;
+  minReward: string;
+  maxReward: string;
+} {
+  if (typeof window === "undefined") {
+    return {
+      searchQuery: "",
+      statusFilter: "all",
+      minReward: "",
+      maxReward: "",
+    };
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const rawStatus = params.get("status");
+  const statusFilter =
+    rawStatus && statusOptionValues.has(rawStatus as "all" | BountyStatus)
+      ? (rawStatus as "all" | BountyStatus)
+      : "all";
+
+  return {
+    searchQuery: params.get("search") ?? "",
+    statusFilter,
+    minReward: params.get("minReward") ?? "",
+    maxReward: params.get("maxReward") ?? "",
+  };
+}
+
 function formatRelativeDeadline(deadlineAt: number): string {
   const now = Math.floor(Date.now() / 1000);
   const diff = deadlineAt - now;
@@ -58,16 +90,17 @@ function shortAddress(value: string): string {
 }
 
 function App() {
+  const initialFilters = useMemo(() => readInitialFilters(), []);
   const [form, setForm] = useState<CreateBountyPayload>(initialForm);
   const [bounties, setBounties] = useState<Bounty[]>([]);
   const [issues, setIssues] = useState<OpenIssue[]>([]);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [statusFilter, setStatusFilter] = useState<"all" | BountyStatus>("all");
-  const [minReward, setMinReward] = useState("");
-  const [maxReward, setMaxReward] = useState("");
+  const [searchQuery, setSearchQuery] = useState(initialFilters.searchQuery);
+  const [statusFilter, setStatusFilter] = useState<"all" | BountyStatus>(initialFilters.statusFilter);
+  const [minReward, setMinReward] = useState(initialFilters.minReward);
+  const [maxReward, setMaxReward] = useState(initialFilters.maxReward);
 
   async function refresh(): Promise<void> {
     const [bountyData, issueData] = await Promise.all([listBounties(), listOpenIssues()]);
@@ -101,6 +134,43 @@ function App() {
       active = false;
       window.clearInterval(timer);
     };
+  }, []);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+
+    if (searchQuery.trim() !== "") {
+      params.set("search", searchQuery);
+    }
+
+    if (statusFilter !== "all") {
+      params.set("status", statusFilter);
+    }
+
+    if (minReward !== "") {
+      params.set("minReward", minReward);
+    }
+
+    if (maxReward !== "") {
+      params.set("maxReward", maxReward);
+    }
+
+    const nextSearch = params.toString();
+    const nextUrl = `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ""}${window.location.hash}`;
+    window.history.replaceState(null, "", nextUrl);
+  }, [maxReward, minReward, searchQuery, statusFilter]);
+
+  useEffect(() => {
+    function handlePopState() {
+      const filters = readInitialFilters();
+      setSearchQuery(filters.searchQuery);
+      setStatusFilter(filters.statusFilter);
+      setMinReward(filters.minReward);
+      setMaxReward(filters.maxReward);
+    }
+
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
   }, []);
 
   const metrics = useMemo(() => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { FormEvent, ReactNode, useEffect, useMemo, useState } from "react";
 import {
   ArrowUpRight,
   Coins,
@@ -44,6 +44,89 @@ const statusOptions: Array<{ value: "all" | BountyStatus; label: string }> = [
 ];
 
 const statusOptionValues = new Set(statusOptions.map((option) => option.value));
+
+
+const statusGlossary: Array<{
+  status: BountyStatus;
+  label: string;
+  description: string;
+}> = [
+  {
+    status: "open",
+    label: "Open",
+    description: "Anyone can reserve this bounty and start working.",
+  },
+  {
+    status: "reserved",
+    label: "Reserved",
+    description: "One contributor has claimed it and is preparing a fix.",
+  },
+  {
+    status: "submitted",
+    label: "Submitted",
+    description: "Work is in review while the maintainer checks the submission.",
+  },
+  {
+    status: "released",
+    label: "Released",
+    description: "The submission was approved and the payout was sent.",
+  },
+  {
+    status: "refunded",
+    label: "Refunded",
+    description: "The bounty was canceled and the reward went back to the maintainer.",
+  },
+  {
+    status: "expired",
+    label: "Expired",
+    description: "The deadline passed before the work was completed.",
+  },
+];
+
+const statusCopy: Record<BountyStatus, { label: string; description: string }> = Object.fromEntries(
+  statusGlossary.map(({ status, label, description }) => [status, { label, description }]),
+) as Record<BountyStatus, { label: string; description: string }>;
+
+const actionCopy: Partial<Record<BountyStatus, Array<{ label: string; tone: string; tooltip: string }>>> = {
+  open: [
+    {
+      label: "Reserve",
+      tone: "secondary-button",
+      tooltip: "Claim this bounty so others know you are taking the first pass.",
+    },
+    {
+      label: "Refund",
+      tone: "ghost-button",
+      tooltip: "Cancel the bounty and return the reward to the maintainer.",
+    },
+  ],
+  reserved: [
+    {
+      label: "Submit PR",
+      tone: "secondary-button",
+      tooltip: "Share your pull request or demo link for maintainer review.",
+    },
+    {
+      label: "Refund",
+      tone: "ghost-button",
+      tooltip: "Return the reward if the reserved work will not move forward.",
+    },
+  ],
+  submitted: [
+    {
+      label: "Release payout",
+      tone: "primary-button",
+      tooltip: "Approve the submission and send the reward to the contributor.",
+    },
+  ],
+  expired: [
+    {
+      label: "Refund",
+      tone: "ghost-button",
+      tooltip: "Recover the locked reward after the deadline has passed.",
+    },
+  ],
+};
 
 function readInitialFilters(): {
   searchQuery: string;
@@ -323,6 +406,43 @@ function App() {
     setMaxReward("");
   }
 
+  function renderActionButton(bounty: Bounty, action: { label: string; tone: string; tooltip: string }): ReactNode {
+    const sharedProps = {
+      className: action.tone,
+      title: action.tooltip,
+      "aria-label": `${action.label}: ${action.tooltip}`,
+    };
+
+    switch (action.label) {
+      case "Reserve":
+        return (
+          <button key={action.label} {...sharedProps} onClick={() => void handleReserve(bounty)}>
+            {action.label}
+          </button>
+        );
+      case "Submit PR":
+        return (
+          <button key={action.label} {...sharedProps} onClick={() => void handleSubmit(bounty)}>
+            {action.label}
+          </button>
+        );
+      case "Release payout":
+        return (
+          <button key={action.label} {...sharedProps} onClick={() => void handleRelease(bounty)}>
+            {action.label}
+          </button>
+        );
+      case "Refund":
+        return (
+          <button key={action.label} {...sharedProps} onClick={() => void handleRefund(bounty)}>
+            {action.label}
+          </button>
+        );
+      default:
+        return null;
+    }
+  }
+
   return (
     <div className="page-shell">
       <div className="glow glow-left" />
@@ -588,6 +708,24 @@ function App() {
             </div>
           </div>
 
+          <section className="status-glossary" aria-labelledby="status-glossary-title">
+            <div className="status-glossary__header">
+              <div>
+                <span className="panel-kicker">Contributor guide</span>
+                <h3 id="status-glossary-title">Status quick guide</h3>
+              </div>
+              <span className="status-glossary__hint">Hover or tap pills and buttons for a short explanation.</span>
+            </div>
+            <div className="status-glossary__list">
+              {statusGlossary.map((item) => (
+                <article className="status-glossary__item" key={item.status}>
+                  <span className={`status-pill status-pill--${item.status}`}>{item.label}</span>
+                  <p>{item.description}</p>
+                </article>
+              ))}
+            </div>
+          </section>
+
           {loading ? (
             <div className="board-list">
               {Array.from({ length: 3 }).map((_, i) => (
@@ -600,8 +738,12 @@ function App() {
                 <article className="bounty-card" key={bounty.id}>
                   <div className="bounty-card__top">
                     <div>
-                      <span className={`status-pill status-pill--${bounty.status}`}>
-                        {bounty.status}
+                      <span
+                        className={`status-pill status-pill--${bounty.status}`}
+                        title={statusCopy[bounty.status].description}
+                        aria-label={`${statusCopy[bounty.status].label}: ${statusCopy[bounty.status].description}`}
+                      >
+                        {statusCopy[bounty.status].label}
                       </span>
                       <h3>{bounty.title}</h3>
                     </div>
@@ -641,6 +783,10 @@ function App() {
                     ))}
                   </div>
 
+                  <p className="status-helper">
+                    <strong>{statusCopy[bounty.status].label}:</strong> {statusCopy[bounty.status].description}
+                  </p>
+
                   {bounty.submissionUrl && (
                     <a className="submission-link" href={bounty.submissionUrl} target="_blank" rel="noreferrer">
                       Review submission <ArrowUpRight size={16} />
@@ -648,26 +794,7 @@ function App() {
                   )}
 
                   <div className="action-row">
-                    {bounty.status === "open" && (
-                      <button className="secondary-button" onClick={() => void handleReserve(bounty)}>
-                        Reserve
-                      </button>
-                    )}
-                    {bounty.status === "reserved" && (
-                      <button className="secondary-button" onClick={() => void handleSubmit(bounty)}>
-                        Submit PR
-                      </button>
-                    )}
-                    {bounty.status === "submitted" && (
-                      <button className="primary-button" onClick={() => void handleRelease(bounty)}>
-                        Release payout
-                      </button>
-                    )}
-                    {["open", "reserved", "expired"].includes(bounty.status) && (
-                      <button className="ghost-button" onClick={() => void handleRefund(bounty)}>
-                        Refund
-                      </button>
-                    )}
+                    {(actionCopy[bounty.status] ?? []).map((action) => renderActionButton(bounty, action))}
                   </div>
                 </article>
               ))}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -297,6 +297,106 @@ textarea:focus {
   color: var(--muted);
 }
 
+.board-filters {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 18px;
+  padding: 18px;
+  border-radius: 22px;
+  border: 1px solid rgba(54, 63, 59, 0.1);
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.board-filters__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.board-filters__header p {
+  margin: 6px 0 0;
+  color: var(--muted);
+}
+
+.filter-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.filter-field {
+  display: grid;
+  gap: 8px;
+  color: var(--muted);
+}
+
+.filter-field--search {
+  grid-column: 1 / -1;
+}
+
+.input-with-icon {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(54, 63, 59, 0.14);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.input-with-icon svg {
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.input-with-icon input,
+.input-with-icon select {
+  border: none;
+  background: transparent;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.input-with-icon input:focus,
+.input-with-icon select:focus {
+  outline: none;
+  border-color: transparent;
+}
+
+select {
+  width: 100%;
+  border-radius: 18px;
+  border: 1px solid rgba(54, 63, 59, 0.14);
+  background: rgba(255, 255, 255, 0.72);
+  padding: 14px 16px;
+  color: var(--ink);
+}
+
+.active-range {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: var(--mint-soft);
+  color: #0d4736;
+  flex-wrap: wrap;
+}
+
+.active-range__label {
+  font-family: "IBM Plex Mono", monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+}
+
+.filter-reset {
+  padding-inline: 16px;
+}
+
 .bounty-card,
 .issue-card {
   border-radius: 22px;
@@ -532,8 +632,13 @@ textarea:focus {
   }
 
   .two-up,
-  .meta-grid {
+  .meta-grid,
+  .filter-grid {
     grid-template-columns: 1fr;
+  }
+
+  .filter-field--search {
+    grid-column: auto;
   }
 
   .hero h1 {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -397,6 +397,60 @@ select {
   padding-inline: 16px;
 }
 
+.status-glossary {
+  margin-bottom: 18px;
+  padding: 18px;
+  border-radius: 22px;
+  border: 1px solid rgba(54, 63, 59, 0.1);
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.status-glossary__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+
+.status-glossary__header h3 {
+  margin: 6px 0 0;
+  font-size: 1.1rem;
+}
+
+.status-glossary__hint {
+  color: var(--muted);
+  font-size: 0.92rem;
+  max-width: 28ch;
+}
+
+.status-glossary__list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.status-glossary__item {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(54, 63, 59, 0.08);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.status-glossary__item p,
+.status-helper {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.status-helper {
+  margin-top: 2px;
+}
+
 .bounty-card,
 .issue-card {
   border-radius: 22px;
@@ -633,8 +687,18 @@ select {
 
   .two-up,
   .meta-grid,
-  .filter-grid {
+  .filter-grid,
+  .status-glossary__list {
     grid-template-columns: 1fr;
+  }
+
+  .status-glossary,
+  .board-filters {
+    padding: 16px;
+  }
+
+  .status-glossary__hint {
+    max-width: none;
   }
 
   .filter-field--search {


### PR DESCRIPTION
## Summary
- add a beginner-friendly status quick guide for bounty statuses
- add explanatory help for status pills and action buttons
- keep copy concise and consistent across the board UI
- add responsive styling so the glossary and helper text remain usable on smaller screens

## Validation
- `npm --prefix frontend run build`

## Notes
- uses visible helper copy in addition to native tooltips so status explanations remain accessible on mobile where hover behavior is limited
