### PR TITLE
feat: add retry and backoff for safe frontend reads

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,38 +1,108 @@
 import { Bounty, CreateBountyPayload, OpenIssue } from "./types";
 
 const API_BASE = import.meta.env.VITE_API_URL ?? "/api";
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+const READ_RETRY_ATTEMPTS = 3;
+const READ_RETRY_BASE_DELAY_MS = 300;
+
+type ApiBody<T> = T & { error?: string };
+
+type RequestOptions = RequestInit & {
+  retry?: boolean;
+  retryAttempts?: number;
+  retryLabel?: string;
+};
 
 async function parseResponse<T>(response: Response): Promise<T> {
-  const body = (await response.json().catch(() => ({}))) as T & { error?: string };
+  const body = (await response.json().catch(() => ({}))) as ApiBody<T>;
   if (!response.ok) {
     throw new Error(body.error ?? "Unexpected API error");
   }
   return body;
 }
 
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function isRetryableResponse(response: Response): boolean {
+  return RETRYABLE_STATUSES.has(response.status);
+}
+
+function isRetryableError(error: unknown): boolean {
+  return error instanceof TypeError;
+}
+
+function formatRetryError(label: string, attempts: number, reason?: string): Error {
+  const suffix = reason ? ` Last error: ${reason}` : "";
+  return new Error(
+    `${label} failed after ${attempts} attempts due to a temporary backend issue. Please try again in a moment.${suffix}`,
+  );
+}
+
+async function requestJson<T>(path: string, options: RequestOptions = {}): Promise<T> {
+  const { retry = false, retryAttempts = READ_RETRY_ATTEMPTS, retryLabel = "Request", ...init } = options;
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= retryAttempts; attempt += 1) {
+    try {
+      const response = await fetch(`${API_BASE}${path}`, init);
+
+      if (retry && isRetryableResponse(response) && attempt < retryAttempts) {
+        await wait(READ_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
+        continue;
+      }
+
+      if (retry && isRetryableResponse(response) && attempt === retryAttempts) {
+        const body = (await response.json().catch(() => ({}))) as ApiBody<T>;
+        throw formatRetryError(retryLabel, retryAttempts, body.error ?? `HTTP ${response.status}`);
+      }
+
+      return parseResponse<T>(response);
+    } catch (error) {
+      lastError = error;
+
+      if (!retry || !isRetryableError(error)) {
+        throw error;
+      }
+
+      if (attempt === retryAttempts) {
+        const message = error instanceof Error ? error.message : undefined;
+        throw formatRetryError(retryLabel, retryAttempts, message);
+      }
+
+      await wait(READ_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
+    }
+  }
+
+  const message = lastError instanceof Error ? lastError.message : undefined;
+  throw formatRetryError(retryLabel, retryAttempts, message);
+}
+
 export async function listBounties(): Promise<Bounty[]> {
-  const response = await fetch(`${API_BASE}/bounties`);
-  const body = await parseResponse<{ data: Bounty[] }>(response);
+  const body = await requestJson<{ data: Bounty[] }>("/bounties", {
+    retry: true,
+    retryLabel: "Loading bounties",
+  });
   return body.data;
 }
 
 export async function createBounty(payload: CreateBountyPayload): Promise<Bounty> {
-  const response = await fetch(`${API_BASE}/bounties`, {
+  const body = await requestJson<{ data: Bounty }>("/bounties", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
   });
-  const body = await parseResponse<{ data: Bounty }>(response);
   return body.data;
 }
 
 export async function reserveBounty(id: string, contributor: string): Promise<Bounty> {
-  const response = await fetch(`${API_BASE}/bounties/${id}/reserve`, {
+  const body = await requestJson<{ data: Bounty }>(`/bounties/${id}/reserve`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ contributor }),
   });
-  const body = await parseResponse<{ data: Bounty }>(response);
   return body.data;
 }
 
@@ -42,38 +112,37 @@ export async function submitBounty(
   submissionUrl: string,
   notes?: string,
 ): Promise<Bounty> {
-  const response = await fetch(`${API_BASE}/bounties/${id}/submit`, {
+  const body = await requestJson<{ data: Bounty }>(`/bounties/${id}/submit`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ contributor, submissionUrl, notes }),
   });
-  const body = await parseResponse<{ data: Bounty }>(response);
   return body.data;
 }
 
 export async function releaseBounty(id: string, maintainer: string): Promise<Bounty> {
-  const response = await fetch(`${API_BASE}/bounties/${id}/release`, {
+  const body = await requestJson<{ data: Bounty }>(`/bounties/${id}/release`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ maintainer }),
   });
-  const body = await parseResponse<{ data: Bounty }>(response);
   return body.data;
 }
 
 export async function refundBounty(id: string, maintainer: string): Promise<Bounty> {
-  const response = await fetch(`${API_BASE}/bounties/${id}/refund`, {
+  const body = await requestJson<{ data: Bounty }>(`/bounties/${id}/refund`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ maintainer }),
   });
-  const body = await parseResponse<{ data: Bounty }>(response);
   return body.data;
 }
 
 export async function listOpenIssues(): Promise<OpenIssue[]> {
-  const response = await fetch(`${API_BASE}/open-issues`);
-  const body = await parseResponse<{ data: OpenIssue[] }>(response);
+  const body = await requestJson<{ data: OpenIssue[] }>("/open-issues", {
+    retry: true,
+    retryLabel: "Loading open issues",
+  });
   return body.data;
 }
 


### PR DESCRIPTION
## Summary
- add a shared JSON request helper for frontend API calls
- retry safe read requests with simple exponential backoff for temporary failures
- keep write actions single-attempt and return clearer retry-aware errors after retries are exhausted

## What changed
- add retry/backoff handling for `listBounties()` and `listOpenIssues()`
- retry only on temporary failures such as network errors and 429/5xx responses
- leave `createBounty()`, `reserveBounty()`, `submitBounty()`, `releaseBounty()`, and `refundBounty()` as non-retrying writes
- improve final error messages for failed read requests after all retry attempts

## Validation
- `npm --prefix frontend run build`

Closes #28