### PR TITLE
feat: add GitHub issue preview card

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import {
   submitBounty,
 } from "./api";
 import { Bounty, CreateBountyPayload, OpenIssue } from "./types";
+import GitHubIssuePreviewCard from "./GitHubIssuePreviewCard";
 import SkeletonBountyCard from "./SkeletonBountyCard";
 
 const initialForm: CreateBountyPayload = {
@@ -375,6 +376,13 @@ function App() {
               </label>
             </div>
 
+            <GitHubIssuePreviewCard
+              repo={form.repo}
+              issueNumber={form.issueNumber}
+              title={form.title}
+              labels={form.labels}
+            />
+
             <button className="primary-button" disabled={submitting}>
               {submitting ? "Publishing..." : "Publish bounty"}
             </button>
@@ -418,7 +426,14 @@ function App() {
                     <div>
                       <span className="meta-label">Issue</span>
                       <strong>
-                        {bounty.repo} #{bounty.issueNumber}
+                        <a
+                          className="inline-link"
+                          href={`https://github.com/${bounty.repo}/issues/${bounty.issueNumber}`}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          {bounty.repo} #{bounty.issueNumber}
+                        </a>
                       </strong>
                     </div>
                     <div>

--- a/frontend/src/GitHubIssuePreviewCard.tsx
+++ b/frontend/src/GitHubIssuePreviewCard.tsx
@@ -1,0 +1,59 @@
+import { ArrowUpRight, FolderGit2 } from "lucide-react";
+
+type Props = {
+  repo: string;
+  issueNumber: number;
+  title?: string;
+  labels?: string[];
+};
+
+function isValidRepo(value: string): boolean {
+  return /^[^/\s]+\/[^/\s]+$/.test(value.trim());
+}
+
+export default function GitHubIssuePreviewCard({ repo, issueNumber, title, labels }: Props) {
+  const normalizedRepo = repo.trim();
+  const canLink = isValidRepo(normalizedRepo) && Number.isFinite(issueNumber) && issueNumber > 0;
+  const href = canLink ? `https://github.com/${normalizedRepo}/issues/${issueNumber}` : undefined;
+
+  return (
+    <a
+      className={`github-issue-card${canLink ? "" : " github-issue-card--disabled"}`}
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      aria-disabled={!canLink}
+      onClick={(event) => {
+        if (!canLink) event.preventDefault();
+      }}
+    >
+      <div className="github-issue-card__top">
+        <div className="github-issue-card__heading">
+          <FolderGit2 size={16} />
+          <span className="github-issue-card__repo">
+            {isValidRepo(normalizedRepo) ? normalizedRepo : "owner/repo"}
+          </span>
+          <span className="github-issue-card__number">{canLink ? `#${issueNumber}` : "#—"}</span>
+        </div>
+        <span className="github-issue-card__cta">
+          View on GitHub <ArrowUpRight size={16} />
+        </span>
+      </div>
+
+      <strong className="github-issue-card__title">{title?.trim() ? title : "Issue title preview"}</strong>
+
+      {labels && labels.length > 0 ? (
+        <div className="chip-row">
+          {labels.map((label) => (
+            <span className="chip" key={label}>
+              {label}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <div className="github-issue-card__empty">Add labels to help contributors filter.</div>
+      )}
+    </a>
+  );
+}
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -40,6 +40,16 @@ a {
   text-decoration: none;
 }
 
+.inline-link {
+  text-decoration: underline;
+  text-decoration-color: rgba(54, 63, 59, 0.28);
+  text-underline-offset: 3px;
+}
+
+.inline-link:hover {
+  text-decoration-color: rgba(54, 63, 59, 0.5);
+}
+
 button,
 input,
 textarea {
@@ -305,8 +315,82 @@ textarea:focus {
   padding: 18px;
 }
 
+.github-issue-card {
+  border-radius: 22px;
+  border: 1px solid rgba(54, 63, 59, 0.12);
+  background: rgba(255, 255, 255, 0.72);
+  padding: 18px;
+  display: grid;
+  gap: 12px;
+  transition:
+    transform 140ms ease,
+    border-color 140ms ease,
+    background-color 140ms ease;
+}
+
+.github-issue-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(54, 63, 59, 0.2);
+}
+
+.github-issue-card--disabled {
+  opacity: 0.75;
+  cursor: not-allowed;
+}
+
+.github-issue-card__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.github-issue-card__heading {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.github-issue-card__repo {
+  font-family: "IBM Plex Mono", monospace;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.github-issue-card__number {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 0.85rem;
+  background: rgba(54, 63, 59, 0.06);
+  color: var(--muted);
+}
+
+.github-issue-card__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #0d4736;
+}
+
+.github-issue-card__title {
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
+.github-issue-card__empty {
+  color: var(--muted);
+  line-height: 1.55;
+}
+
 .bounty-card__top,
 .issue-card__top,
+.github-issue-card__top,
 .action-row,
 .chip-row {
   display: flex;


### PR DESCRIPTION
## Summary
- add a reusable GitHub issue preview card component
- show issue repo, number, title, labels, and external link in the create bounty flow
- link issue metadata from bounty cards to GitHub
- add styles for the issue preview card and inline links

## Testing
- npm test
- npm --prefix frontend run build

Closes #17