### PR TITLE
feat(backend): add X-Request-ID header for distributed tracing

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,6 @@
 import cors from "cors";
-import express, { Request, Response } from "express";
+import express, { Request, Response, NextFunction } from "express";
+import { randomUUID } from "node:crypto";
 import { buildCorsOptions } from "./middleware/corsOptions";
 import {
   createBounty,
@@ -22,12 +23,47 @@ import {
   submitBountySchema,
   zodErrorMessage,
 } from "./validation/schemas";
-import { requestContextMiddleware } from "./middleware/requestContext";
+import { logStructured } from "./logger";
 import { limiter } from "./utils";
 import {
   captureRawBody,
   createGitHubWebhookSignatureMiddleware,
 } from "./webhooks/signatureVerification";
+
+const INCOMING_REQUEST_ID = /^[a-zA-Z0-9-]{1,128}$/;
+
+function resolveRequestId(req: Request): string {
+  const raw = req.headers["x-request-id"];
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (INCOMING_REQUEST_ID.test(trimmed)) {
+      return trimmed;
+    }
+  }
+  return randomUUID();
+}
+
+function requestContextMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const requestId = resolveRequestId(req);
+  req.requestId = requestId;
+  res.setHeader("X-Request-ID", requestId);
+
+  const start = process.hrtime.bigint();
+
+  res.on("finish", () => {
+    const durationNs = process.hrtime.bigint() - start;
+    const durationMs = Number(durationNs) / 1e6;
+    logStructured("info", "http_request", {
+      requestId,
+      method: req.method,
+      path: req.path || "/",
+      status: res.statusCode,
+      durationMs: Math.round(durationMs * 1000) / 1000,
+    });
+  });
+
+  next();
+}
 
 export const app = express();
 


### PR DESCRIPTION
Inlines request ID middleware into `backend/src/app.ts` for distributed tracing.

- Middleware reads `X-Request-ID` from headers, validates against `/^[a-zA-Z0-9-]{1,128}$/`
- Reuses client-supplied ID if valid, otherwise generates UUID
- Every response includes `X-Request-ID` header
- Structured logging with `requestId`, `method`, `path`, `status`, `durationMs`

Closes #79 