### PR TITLE
feat: add GET /api/bounties/:id endpoint with frontend integration

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -290,6 +290,21 @@ app.get("/api/bounties/:id/events", (req: Request, res: Response) => {
   }
 });
 
+app.get("/api/bounties/:id", (req: Request, res: Response) => {
+  try {
+    const id = parseId(req.params.id);
+    const bounties = listBounties();
+    const bounty = bounties.find((b) => b.id === id);
+    if (!bounty) {
+      jsonError(res, req, 404, "Bounty not found.");
+      return;
+    }
+    res.json({ data: bounty });
+  } catch (error) {
+    sendError(res, req, error, 400);
+  }
+});
+
 app.get("/api/maintainers/:maintainer/metrics", (req: Request, res: Response) => {
   try {
     const { maintainer } = req.params;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import {
 import {
   createBounty,
   exportReleasedPayoutsCsv,
+  getBounty,
   listBounties,
   listOpenIssues,
   refundBounty,
@@ -265,6 +266,8 @@ function App() {
   }, [bounties, profileContributor]);
 
   const [profile, setProfile] = useState(() => createDefaultProfile());
+  const [detailBounty, setDetailBounty] = useState<Bounty | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
   const recommendations = useMemo(() => {
     return generateRecommendations(bounties, profile);
   }, [bounties, profile]);
@@ -364,10 +367,31 @@ function App() {
     return match ? { owner: decodeURIComponent(match[1]), name: decodeURIComponent(match[2]) } : null;
   }, [pathname]);
 
-  const detailBounty = useMemo(() => {
-    if (!detailId) return null;
-    return bounties.find((bounty) => bounty.id === detailId) ?? null;
-  }, [bounties, detailId]);
+  // Fetch single bounty via dedicated API endpoint instead of filtering the full list
+  useEffect(() => {
+    if (!detailId) {
+      setDetailBounty(null);
+      return;
+    }
+    let active = true;
+    setDetailLoading(true);
+    getBounty(detailId)
+      .then((bounty) => {
+        if (active) {
+          setDetailBounty(bounty);
+          setDetailLoading(false);
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setDetailBounty(null);
+          setDetailLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [detailId]);
 
   const filteredBounties = useMemo(() => {
     const effectiveRepoFilter = repoRoute ? `${repoRoute.owner}/${repoRoute.name}` : repoFilter;
@@ -407,7 +431,7 @@ function App() {
     return (
       <BountyDetailPage
         bounty={bounty}
-        loading={loading}
+        loading={detailLoading}
         onBack={() => navigate("/")}
         owner={owner}
         avatarUrl={avatarUrl}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -108,6 +108,14 @@ async function requestBlob(path: string, init: RequestInit = {}): Promise<{ blob
   return { blob, filename };
 }
 
+export async function getBounty(id: string): Promise<Bounty> {
+  const body = await requestJson<{ data: Bounty }>(`/bounties/${id}`, {
+    retry: true,
+    retryLabel: "Loading bounty",
+  });
+  return body.data;
+}
+
 export async function listBounties(): Promise<Bounty[]> {
   const body = await requestJson<{ data: Bounty[] }>("/bounties", {
     retry: true,


### PR DESCRIPTION
Closes #77

## Summary of Changes

### Backend
- Added `GET /api/bounties/:id` route in `backend/src/app.ts` that returns a single bounty by ID or a 404 response
- Properly placed after all `/api/bounties/:id/*` sub-routes (audit-logs, events) to avoid route conflicts

### Frontend
- Added `getBounty(id)` async function in `frontend/src/api.ts` that calls the new endpoint
- Updated `App.tsx` to fetch bounty detail via the dedicated API endpoint instead of filtering the full bounty list
- Added proper loading state (`detailLoading`) for the detail page
- Deep-linking to bounty details now works independently without requiring the full list to be loaded

## Testing
- Backend: new route follows existing patterns (`parseId`, `jsonError`, `sendError`)
- Frontend: uses the same `requestJson` helper with retry logic as other API calls