### PR TITLE
feat(backend/worker): add health-check endpoint at /worker/health

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -101,6 +101,14 @@ app.get("/api/health", (_req: Request, res: Response) => {
   });
 });
 
+app.get("/worker/health", (_req: Request, res: Response) => {
+  res.json({
+    service: "stellar-bounty-board-worker",
+    status: "ok",
+    timestamp: new Date().toISOString(),
+  });
+});
+
 app.get("/api/bounties", (req: Request, res: Response) => {
   const q = typeof req.query.q === "string" ? req.query.q : undefined;
   res.json({ data: listBounties({ q }) });


### PR DESCRIPTION
Closes #92

## Summary
Add `GET /worker/health` endpoint that returns service status for the worker process, following the same pattern as the existing `GET /api/health` endpoint.

## Changes
- `backend/src/app.ts`: new route returns `{ service, status, timestamp }`

## Testing
- Follows the same pattern as the existing `/api/health` route (already tested)