### PR TITLE
feat(backend/validation): add stricter Zod schema with min/max XLM amounts

### DIFF
--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -61,7 +61,16 @@ export const createBountySchema = z
     amount: z.coerce
       .number()
       .positive("Amount must be greater than zero.")
-      .openapi({ example: 100, description: "Payout amount in the specified token." }),
+      .min(1, "Amount must be at least 1 XLM.")
+      .max(10000, "Amount must not exceed 10,000 XLM.")
+      .refine(
+        (val) => {
+          const decimalStr = String(val).split(".")[1];
+          return !decimalStr || decimalStr.length <= 7;
+        },
+        "Amount must have at most 7 decimal places.",
+      )
+      .openapi({ example: 100, description: "Payout amount in the specified token (1–10,000, max 7 decimals)." }),
     deadlineDays: z.coerce
       .number()
       .int()


### PR DESCRIPTION
Closes #87

## Summary
Update the `amount` field in `createBountySchema` to add guardrails for XLM amounts.

## Changes
- **backend/src/validation/schemas.ts**:
  - Minimum: 1 XLM
  - Maximum: 10,000 XLM
  - Max 7 decimal places
  - Clear error messages for each constraint

## Testing
- Existing test fixtures already use `amount: 42.5` which passes all new constraints
- Amounts below 1, above 10000, or with >7 decimals will now be properly rejected