### PR TITLE
feat(backend/validation): add GitHub PR URL format validation in submit route

### DIFF
--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -101,6 +101,8 @@ export const reserveBountySchema = z
   })
   .openapi("ReserveBountyRequest");
 
+export const GITHUB_PR_URL_REGEX = /^https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/pull\/\d+$/;
+
 export const submitBountySchema = z
   .object({
     contributor: stellarAccountSchema.openapi({
@@ -109,10 +111,10 @@ export const submitBountySchema = z
     submissionUrl: z
       .string()
       .trim()
-      .url("Submission URL must be a valid URL.")
+      .regex(GITHUB_PR_URL_REGEX, "Submission URL must be a valid GitHub PR link: https://github.com/<owner>/<repo>/pull/<number>.")
       .openapi({
         example: "https://github.com/owner/repo/pull/99",
-        description: "Link to the pull request or deliverable.",
+        description: "Link to the GitHub pull request.",
       }),
     notes: z
       .string()


### PR DESCRIPTION
Closes #89

## Summary
Add `GITHUB_PR_URL_REGEX` validator to enforce that submission URLs in `submitBountySchema` match the expected GitHub PR format.

## Changes
- **backend/src/validation/schemas.ts**:
  - Exported `GITHUB_PR_URL_REGEX`: `/^https:\/\/github\.com\/[owner]\/[repo]\/pull\/\d+$/`
  - Updated `submissionUrl` field from generic `.url()` to `.regex(GITHUB_PR_URL_REGEX)`
  - Non-GitHub URLs, URLs without `/pull/` segment, and malformed URLs are rejected with a clear error message

## Testing
- Existing tests use valid GitHub PR URLs (`https://github.com/owner/repo-name/pull/1`) which pass validation
- Invalid URLs will now return proper 400 errors