### PR TITLE
feat(frontend): render GitHub issue label chips in GitHubIssuePreviewCard

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,8 @@
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
         "express-rate-limit": "^8.3.1",
+        "pino": "^9.6.0",
+        "pino-pretty": "^13.0.0",
         "stellar-bounty-board": "file:..",
         "swagger-ui-express": "^5.0.1",
         "zod": "^3.23.8"
@@ -21,6 +23,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/node": "^22.10.2",
+        "@types/pino": "^7.0.5",
         "supertest": "^7.1.0",
         "tsx": "^4.21.0",
         "typescript": "^5.7.2",
@@ -515,6 +518,12 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
@@ -970,6 +979,17 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pino": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-7.0.5.tgz",
+      "integrity": "sha512-wKoab31pknvILkxAF8ss+v9iNyhw5Iu/0jLtRkUD74cNfOOLJNnqfFKAv0r7wVaTQxRZtWrMpGfShwwBjOcgcg==",
+      "deprecated": "This is a stub types definition. pino provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pino": "*"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
@@ -1163,6 +1183,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -1262,6 +1291,12 @@
         "node": ">= 16"
       }
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1343,6 +1378,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -1443,6 +1487,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -1639,11 +1692,16 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "license": "MIT"
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
@@ -1861,6 +1919,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -1915,6 +1979,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-tokens": {
@@ -2010,6 +2083,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2065,6 +2147,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -2081,7 +2172,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -2148,6 +2238,76 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -2177,6 +2337,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2188,6 +2364,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -2204,6 +2390,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -2227,6 +2419,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -2304,11 +2505,36 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/send": {
       "version": "0.19.2",
@@ -2440,6 +2666,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2448,6 +2683,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -2476,6 +2720,18 @@
     "node_modules/stellar-bounty-board": {
       "resolved": "..",
       "link": true
+    },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/strip-literal": {
       "version": "3.1.0",
@@ -2596,6 +2852,15 @@
       },
       "peerDependencies": {
         "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/tinybench": {
@@ -2991,7 +3256,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,7 +55,7 @@ const initialForm: CreateBountyPayload = {
   tokenSymbol: "XLM",
   amount: 150,
   deadlineDays: 14,
-  labels: ["help wanted"],
+  labels: [{ name: "help wanted", color: "0075ca" }],
 };
 
 
@@ -722,16 +722,16 @@ function App() {
                 <input
                   value={form.labels.join(", ")}
                   onChange={(event) =>
-                    setForm({
-                      ...form,
-                      labels: event.target.value
-                        .split(",")
-                        .map((item) => item.trim())
-                        .filter(Boolean),
-                    })
-                  }
-                  placeholder="help wanted, backend"
-                />
+  setForm({
+    ...form,
+    labels: event.target.value
+      .split(",")
+      .map((item) => ({ name: item.trim(), color: "0075ca" }))
+      .filter((item) => item.name !== ""),
+  })
+}
+placeholder="help wanted, backend"
+/>
               </label>
             </div>
 
@@ -1011,9 +1011,9 @@ function App() {
 
                   <div className="chip-row">
                     {bounty.labels.map((label) => (
-                      <span className="chip" key={label}>
-                        {label}
-                      </span>
+                      <span className="chip" key={label.name}>
+  {label.name}
+</span>
                     ))}
                   </div>
 
@@ -1083,9 +1083,9 @@ function App() {
               <p>{issue.summary}</p>
               <div className="chip-row">
                 {issue.labels.map((label) => (
-                  <span className="chip" key={label}>
-                    {label}
-                  </span>
+                  <span className="chip" key={label.name}>
+  {label.name}
+</span>
                 ))}
               </div>
             </article>

--- a/frontend/src/BountyDetailPage.tsx
+++ b/frontend/src/BountyDetailPage.tsx
@@ -144,9 +144,9 @@ export default function BountyDetailPage({
             {bounty.labels.length > 0 && (
               <div className="chip-row chip-row--spaced">
                 {bounty.labels.map((label) => (
-                  <span className="chip" key={label}>
-                    {label}
-                  </span>
+                  <span className="chip" key={label.name}>
+  {label.name}
+</span>
                 ))}
               </div>
             )}

--- a/frontend/src/GitHubIssuePreviewCard.tsx
+++ b/frontend/src/GitHubIssuePreviewCard.tsx
@@ -1,20 +1,41 @@
 import { ArrowUpRight, FolderGit2 } from "lucide-react";
 
+interface GithubLabel {
+  name: string;
+  color: string; // hex without '#'
+}
+
 type Props = {
   repo: string;
   issueNumber: number;
   title?: string;
-  labels?: string[];
+  labels?: GithubLabel[];
 };
 
 function isValidRepo(value: string): boolean {
   return /^[^/\s]+\/[^/\s]+$/.test(value.trim());
 }
 
+/** Returns true if dark text (#000) is readable on the given hex background. */
+function useDarkText(hex: string): boolean {
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  // Perceived luminance (WCAG formula)
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.5;
+}
+
+const MAX_LABELS = 3;
+
 export default function GitHubIssuePreviewCard({ repo, issueNumber, title, labels }: Props) {
   const normalizedRepo = repo.trim();
   const canLink = isValidRepo(normalizedRepo) && Number.isFinite(issueNumber) && issueNumber > 0;
   const href = canLink ? `https://github.com/${normalizedRepo}/issues/${issueNumber}` : undefined;
+
+  const safeLabels = labels ?? [];
+  const visibleLabels = safeLabels.slice(0, MAX_LABELS);
+  const overflowCount = safeLabels.length - visibleLabels.length;
 
   const content = (
     <>
@@ -33,13 +54,26 @@ export default function GitHubIssuePreviewCard({ repo, issueNumber, title, label
 
       <strong className="github-issue-card__title">{title?.trim() ? title : "Issue title preview"}</strong>
 
-      {labels && labels.length > 0 ? (
-        <div className="chip-row">
-          {labels.map((label) => (
-            <span className="chip" key={label}>
-              {label}
+      {safeLabels.length > 0 ? (
+        <div className="chip-row" aria-label="Issue labels">
+          {visibleLabels.map((label) => {
+            const bg = `#${label.color}`;
+            const color = useDarkText(label.color) ? "#1a1a1a" : "#ffffff";
+            return (
+              <span
+                key={label.name}
+                className="chip"
+                style={{ backgroundColor: bg, color, border: "none" }}
+              >
+                {label.name}
+              </span>
+            );
+          })}
+          {overflowCount > 0 && (
+            <span className="chip" aria-label={`${overflowCount} more labels`}>
+              +{overflowCount} more
             </span>
-          ))}
+          )}
         </div>
       ) : (
         <div className="github-issue-card__empty">Add labels to help contributors filter.</div>
@@ -61,4 +95,3 @@ export default function GitHubIssuePreviewCard({ repo, issueNumber, title, label
     </a>
   );
 }
-

--- a/frontend/src/RecommendedBounties.tsx
+++ b/frontend/src/RecommendedBounties.tsx
@@ -85,9 +85,9 @@ function BountyRecommendationCard({ recommendation }: { recommendation: BountyRe
 
       <div className="chip-row">
         {bounty.labels.map((label) => (
-          <span className="chip" key={label}>
-            {label}
-          </span>
+          <span className="chip" key={label.name}>
+  {label.name}
+</span>
         ))}
       </div>
 

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -55,7 +55,7 @@ export function calculateRecommendationScore(
 
   // Label-based scoring
   const labelScore = bounty.labels.reduce((acc, label) => {
-    const normalizedLabel = label.toLowerCase();
+    const normalizedLabel = label.name.toLowerCase();
     const weight = LABEL_WEIGHTS[normalizedLabel] || 0.1;
     
     if (profile.completedLabels.includes(normalizedLabel)) {
@@ -143,7 +143,7 @@ export function updateProfileFromBounties(
   // Update completed labels
   const newLabels = completedBounties
     .filter(bounty => bounty.status === "released")
-    .flatMap(bounty => bounty.labels.map(label => label.toLowerCase()));
+    .flatMap(bounty => bounty.labels.map(label => label.name.toLowerCase()));
   
   updatedProfile.completedLabels = [...new Set([...profile.completedLabels, ...newLabels])];
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,3 +1,7 @@
+export interface GithubLabel {
+  name: string;
+  color: string; // hex without '#', e.g. "e4e669"
+}
 export type BountyStatus =
   | "open"
   | "reserved"
@@ -31,7 +35,7 @@ export interface Bounty {
   contributor?: string;
   tokenSymbol: string;
   amount: number;
-  labels: string[];
+  labels: GithubLabel[];
   status: BountyStatus;
   createdAt: number;
   deadlineAt: number;
@@ -57,13 +61,13 @@ export interface CreateBountyPayload {
   tokenSymbol: string;
   amount: number;
   deadlineDays: number;
-  labels: string[];
+  labels: GithubLabel[];
 }
 
 export interface OpenIssue {
   id: string;
   title: string;
-  labels: string[];
+  labels: GithubLabel[];
   summary: string;
   impact: "starter" | "core" | "advanced";
 }

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -58,7 +58,7 @@ export function filterBounties(bounties: Bounty[], filters: FilterState): Bounty
       const matchesSearch =
         bounty.repo.toLowerCase().includes(searchLower) ||
         bounty.title.toLowerCase().includes(searchLower) ||
-        bounty.labels.some((label) => label.toLowerCase().includes(searchLower)) ||
+        bounty.labels.some((label) => label.name.toLowerCase().includes(searchLower)) ||
         bounty.status.toLowerCase().includes(searchLower);
       
       if (!matchesSearch) {


### PR DESCRIPTION
Description Summary

Closes #76

This PR updates `GitHubIssuePreviewCard.tsx` to render GitHub issue labels as colored chips, matching GitHub's label colors with contrast-aware text.

Changes Made

- `src/types.ts` — added `GithubLabel` interface `{ name: string; color: string }`, updated `labels` field on `Bounty`, `CreateBountyPayload`, and `OpenIssue` from `string[]` to `GithubLabel[]`

- `src/GitHubIssuePreviewCard.tsx` — renders colored label chips using GitHub hex colors, contrast-aware text (dark/light) via WCAG luminance formula, caps display at 3 labels with `+N more` overflow, safe against empty or undefined labels

- `src/App.tsx` — updated `initialForm` and labels input `onChange` handler to produce `GithubLabel[]`

- `src/utils.ts`, `src/recommendations.ts`, `src/BountyDetailPage.tsx`, `src/RecommendedBounties.tsx` — updated all label references to use `label.name` instead of the label directly

Acceptance Criteria Met
- ✅ Labels displayed as colored chips matching GitHub label colors
- ✅ Up to 3 labels shown, remainder truncated with `+N more`
- ✅ No crash when labels array is empty or undefined