### PR TITLE
feat(backend/services): add bounty auto-expiration cron job for stale…

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,8 @@
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
         "express-rate-limit": "^8.3.1",
+        "pino": "^9.6.0",
+        "pino-pretty": "^13.0.0",
         "stellar-bounty-board": "file:..",
         "swagger-ui-express": "^5.0.1",
         "zod": "^3.23.8"
@@ -21,6 +23,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/node": "^22.10.2",
+        "@types/pino": "^7.0.5",
         "supertest": "^7.1.0",
         "tsx": "^4.21.0",
         "typescript": "^5.7.2",
@@ -515,6 +518,12 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
@@ -970,6 +979,17 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pino": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-7.0.5.tgz",
+      "integrity": "sha512-wKoab31pknvILkxAF8ss+v9iNyhw5Iu/0jLtRkUD74cNfOOLJNnqfFKAv0r7wVaTQxRZtWrMpGfShwwBjOcgcg==",
+      "deprecated": "This is a stub types definition. pino provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pino": "*"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
@@ -1163,6 +1183,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -1262,6 +1291,12 @@
         "node": ">= 16"
       }
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1343,6 +1378,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -1443,6 +1487,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -1639,11 +1692,16 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "license": "MIT"
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
@@ -1861,6 +1919,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -1915,6 +1979,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-tokens": {
@@ -2010,6 +2083,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2065,6 +2147,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -2081,7 +2172,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -2148,6 +2238,76 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -2177,6 +2337,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2188,6 +2364,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -2204,6 +2390,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -2227,6 +2419,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -2304,11 +2505,36 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/send": {
       "version": "0.19.2",
@@ -2440,6 +2666,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2448,6 +2683,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -2476,6 +2720,18 @@
     "node_modules/stellar-bounty-board": {
       "resolved": "..",
       "link": true
+    },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/strip-literal": {
       "version": "3.1.0",
@@ -2596,6 +2852,15 @@
       },
       "peerDependencies": {
         "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/tinybench": {
@@ -2991,7 +3256,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {

--- a/backend/src/services/reservationExpirationJob.ts
+++ b/backend/src/services/reservationExpirationJob.ts
@@ -1,0 +1,183 @@
+/**
+ * reservationExpirationJob.ts
+ *
+ * Cron job that runs on a configurable interval and expires stale bounty
+ * reservations — returning them to "open" so other contributors can claim them.
+ *
+ * Configuration (via environment variables):
+ *   RESERVATION_TTL_DAYS       — how many days before a reservation expires (default: 7)
+ *   EXPIRATION_CRON_INTERVAL_MS — polling interval in milliseconds (default: 3_600_000 = 1 hour)
+ */
+
+import { listBounties, type BountyRecord } from "./bountyStore";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { logger } from "../logger";
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+function getReservationTtlSeconds(): number {
+  const days = Number(process.env.RESERVATION_TTL_DAYS ?? "7");
+  if (!Number.isFinite(days) || days <= 0) {
+    logger.warn(
+      { RESERVATION_TTL_DAYS: process.env.RESERVATION_TTL_DAYS },
+      "[ExpirationJob] Invalid RESERVATION_TTL_DAYS — falling back to 7 days",
+    );
+    return 7 * 24 * 60 * 60;
+  }
+  return Math.floor(days * 24 * 60 * 60);
+}
+
+function getCronIntervalMs(): number {
+  const ms = Number(process.env.EXPIRATION_CRON_INTERVAL_MS ?? "3600000");
+  if (!Number.isFinite(ms) || ms <= 0) {
+    logger.warn(
+      { EXPIRATION_CRON_INTERVAL_MS: process.env.EXPIRATION_CRON_INTERVAL_MS },
+      "[ExpirationJob] Invalid EXPIRATION_CRON_INTERVAL_MS — falling back to 1 hour",
+    );
+    return 60 * 60 * 1000;
+  }
+  return Math.floor(ms);
+}
+
+function getStorePath(): string {
+  if (process.env.BOUNTY_STORE_PATH?.trim()) {
+    return path.resolve(process.env.BOUNTY_STORE_PATH.trim());
+  }
+  return path.resolve(__dirname, "../../data/bounties.json");
+}
+
+// ── Core expiration logic ─────────────────────────────────────────────────────
+
+export interface ExpirationResult {
+  expiredCount: number;
+  expiredBountyIds: string[];
+  checkedAt: number;
+}
+
+/**
+ * Scan all reserved bounties and expire those whose reservation has been
+ * held longer than `ttlSeconds` without a submission.
+ *
+ * Returns a summary of what was expired.
+ */
+export function expireStaleReservations(ttlSeconds?: number): ExpirationResult {
+  const effectiveTtl = ttlSeconds ?? getReservationTtlSeconds();
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const checkedAt = nowSeconds;
+
+  const bounties = listBounties();
+  const stale = bounties.filter(
+    (b): b is BountyRecord & { reservedAt: number; contributor: string } =>
+      b.status === "reserved" &&
+      typeof b.reservedAt === "number" &&
+      nowSeconds - b.reservedAt > effectiveTtl,
+  );
+
+  if (stale.length === 0) {
+    logger.info(
+      { ttlDays: effectiveTtl / 86400, checkedCount: bounties.length },
+      "[ExpirationJob] No stale reservations found",
+    );
+    return { expiredCount: 0, expiredBountyIds: [], checkedAt };
+  }
+
+  // Read the raw store file and patch it directly to avoid circular imports
+  const storePath = getStorePath();
+  const raw: BountyRecord[] = JSON.parse(fs.readFileSync(storePath, "utf8"));
+
+  const staleIds = new Set(stale.map((b) => b.id));
+  const updated = raw.map((record) => {
+    if (!staleIds.has(record.id)) return record;
+
+    logger.info(
+      {
+        bountyId: record.id,
+        contributor: record.contributor,
+        reservedAt: record.reservedAt,
+        ttlDays: effectiveTtl / 86400,
+        staleSinceSeconds: nowSeconds - (record.reservedAt ?? 0),
+      },
+      "[ExpirationJob] Expiring stale reservation",
+    );
+
+    return {
+      ...record,
+      status: "open" as const,
+      contributor: undefined,
+      reservedAt: undefined,
+      version: (record.version ?? 1) + 1,
+      events: [
+        ...(record.events ?? []),
+        {
+          type: "expired" as const,
+          timestamp: nowSeconds,
+          details: {
+            reason: "reservation_ttl_exceeded",
+            ttlSeconds: effectiveTtl,
+          },
+        },
+      ],
+    };
+  });
+
+  fs.writeFileSync(storePath, JSON.stringify(updated, null, 2));
+
+  const expiredBountyIds = stale.map((b) => b.id);
+  logger.info(
+    { expiredCount: expiredBountyIds.length, expiredBountyIds },
+    "[ExpirationJob] Stale reservations expired",
+  );
+
+  return { expiredCount: expiredBountyIds.length, expiredBountyIds, checkedAt };
+}
+
+// ── Scheduler ─────────────────────────────────────────────────────────────────
+
+let _timer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start the auto-expiration cron job.
+ *
+ * @param intervalMs  Override the polling interval (useful in tests).
+ * @param ttlSeconds  Override the reservation TTL (useful in tests).
+ */
+export function startExpirationJob(intervalMs?: number, ttlSeconds?: number): void {
+  if (_timer) {
+    logger.warn("[ExpirationJob] Already running — ignoring duplicate start");
+    return;
+  }
+
+  const effectiveInterval = intervalMs ?? getCronIntervalMs();
+  const effectiveTtl = ttlSeconds ?? getReservationTtlSeconds();
+
+  logger.info(
+    {
+      intervalMs: effectiveInterval,
+      ttlDays: effectiveTtl / 86400,
+    },
+    "[ExpirationJob] Starting bounty auto-expiration cron",
+  );
+
+  // Run immediately on start then on every interval
+  expireStaleReservations(effectiveTtl);
+
+  _timer = setInterval(() => {
+    try {
+      expireStaleReservations(effectiveTtl);
+    } catch (err) {
+      logger.error({ err }, "[ExpirationJob] Unexpected error during expiration run");
+    }
+  }, effectiveInterval);
+}
+
+/**
+ * Stop the cron job (useful in tests and graceful shutdown).
+ */
+export function stopExpirationJob(): void {
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+    logger.info("[ExpirationJob] Cron stopped");
+  }
+}

--- a/backend/test/reservationExpirationJob.test.ts
+++ b/backend/test/reservationExpirationJob.test.ts
@@ -1,0 +1,215 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CONTRIBUTOR, MAINTAINER } from "./fixtures";
+
+// ── Test store setup ──────────────────────────────────────────────────────────
+
+let storeFile: string;
+
+beforeEach(() => {
+  storeFile = path.join(os.tmpdir(), `expiration-test-${randomUUID()}.json`);
+  fs.writeFileSync(storeFile, "[]", "utf8");
+  process.env.BOUNTY_STORE_PATH = storeFile;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete process.env.BOUNTY_STORE_PATH;
+  delete process.env.RESERVATION_TTL_DAYS;
+  delete process.env.EXPIRATION_CRON_INTERVAL_MS;
+  try { fs.unlinkSync(storeFile); } catch { /* best-effort */ }
+  try { fs.unlinkSync(storeFile.replace(/\.json$/i, ".audit.json")); } catch { /* best-effort */ }
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function loadStore() {
+  return import("../src/services/bountyStore");
+}
+
+async function loadJob() {
+  return import("../src/services/reservationExpirationJob");
+}
+
+function nowSeconds() {
+  return Math.floor(Date.now() / 1000);
+}
+
+function makeReservedBounty(reservedSecondsAgo: number) {
+  const now = nowSeconds();
+  return {
+    id: `BNT-TEST-${randomUUID()}`,
+    repo: "test/repo",
+    issueNumber: 1,
+    title: "Test bounty",
+    summary: "A test bounty for expiration.",
+    maintainer: MAINTAINER,
+    contributor: CONTRIBUTOR,
+    tokenSymbol: "XLM",
+    amount: 100,
+    labels: [],
+    status: "reserved" as const,
+    createdAt: now - reservedSecondsAgo - 100,
+    deadlineAt: now + 9999999,
+    reservedAt: now - reservedSecondsAgo,
+    version: 1,
+    events: [
+      { type: "created" as const, timestamp: now - reservedSecondsAgo - 100 },
+      { type: "reserved" as const, timestamp: now - reservedSecondsAgo, actor: CONTRIBUTOR },
+    ],
+    reservationTimeoutSeconds: 999999999,
+  };
+}
+
+// ── expireStaleReservations ───────────────────────────────────────────────────
+
+describe("expireStaleReservations", () => {
+  it("does not expire a fresh reservation (reserved 1 day ago, TTL 7 days)", async () => {
+    const store = await loadStore();
+    const bounty = store.createBounty({
+      repo: "test/repo", issueNumber: 1, title: "Fresh bounty",
+      summary: "Summary long enough for validation purposes here.",
+      maintainer: MAINTAINER, tokenSymbol: "XLM", amount: 50,
+      deadlineDays: 30, labels: [],
+    });
+    store.reserveBounty(bounty.id, CONTRIBUTOR);
+
+    const { expireStaleReservations } = await loadJob();
+    const result = expireStaleReservations(7 * 24 * 60 * 60);
+
+    expect(result.expiredCount).toBe(0);
+    expect(result.expiredBountyIds).toHaveLength(0);
+
+    const after = store.listBounties().find((b) => b.id === bounty.id);
+    expect(after?.status).toBe("reserved");
+  });
+
+  it("expires a stale reservation (reserved 8 days ago, TTL 7 days)", async () => {
+    // Write a stale bounty directly to the store file
+    const eightDaysAgo = nowSeconds() - 8 * 24 * 60 * 60;
+    const stale = makeReservedBounty(8 * 24 * 60 * 60);
+    fs.writeFileSync(storeFile, JSON.stringify([stale], null, 2));
+
+    const { expireStaleReservations } = await loadJob();
+    const result = expireStaleReservations(7 * 24 * 60 * 60);
+
+    expect(result.expiredCount).toBe(1);
+    expect(result.expiredBountyIds).toContain(stale.id);
+
+    const raw = JSON.parse(fs.readFileSync(storeFile, "utf8"));
+    const updated = raw.find((b: { id: string }) => b.id === stale.id);
+    expect(updated.status).toBe("open");
+    expect(updated.contributor).toBeUndefined();
+    expect(updated.reservedAt).toBeUndefined();
+    expect(updated.version).toBe(2);
+    expect(updated.events.at(-1).type).toBe("expired");
+    expect(updated.events.at(-1).details.reason).toBe("reservation_ttl_exceeded");
+  });
+
+  it("logs the bounty ID and contributor address for each expired reservation", async () => {
+    const stale = makeReservedBounty(8 * 24 * 60 * 60);
+    fs.writeFileSync(storeFile, JSON.stringify([stale], null, 2));
+
+    const { expireStaleReservations } = await loadJob();
+    const result = expireStaleReservations(7 * 24 * 60 * 60);
+
+    // The bounty ID must appear in the result for logging verification
+    expect(result.expiredBountyIds[0]).toBe(stale.id);
+    expect(result.expiredCount).toBe(1);
+  });
+
+  it("expires multiple stale reservations in a single run", async () => {
+    const stale1 = makeReservedBounty(8 * 24 * 60 * 60);
+    const stale2 = makeReservedBounty(10 * 24 * 60 * 60);
+    const fresh = makeReservedBounty(1 * 24 * 60 * 60);
+    fs.writeFileSync(storeFile, JSON.stringify([stale1, stale2, fresh], null, 2));
+
+    const { expireStaleReservations } = await loadJob();
+    const result = expireStaleReservations(7 * 24 * 60 * 60);
+
+    expect(result.expiredCount).toBe(2);
+    expect(result.expiredBountyIds).toContain(stale1.id);
+    expect(result.expiredBountyIds).toContain(stale2.id);
+    expect(result.expiredBountyIds).not.toContain(fresh.id);
+
+    const raw = JSON.parse(fs.readFileSync(storeFile, "utf8"));
+    const freshUpdated = raw.find((b: { id: string }) => b.id === fresh.id);
+    expect(freshUpdated.status).toBe("reserved");
+  });
+
+  it("respects RESERVATION_TTL_DAYS env var", async () => {
+    process.env.RESERVATION_TTL_DAYS = "3";
+    const stale = makeReservedBounty(4 * 24 * 60 * 60); // 4 days > 3 day TTL
+    fs.writeFileSync(storeFile, JSON.stringify([stale], null, 2));
+
+    const { expireStaleReservations } = await loadJob();
+    // Call without explicit TTL so it reads from env
+    const result = expireStaleReservations();
+
+    expect(result.expiredCount).toBe(1);
+    expect(result.expiredBountyIds).toContain(stale.id);
+  });
+
+  it("does not touch submitted bounties", async () => {
+    const store = await loadStore();
+    const bounty = store.createBounty({
+      repo: "test/repo", issueNumber: 2, title: "Submitted bounty",
+      summary: "Summary long enough for validation purposes here.",
+      maintainer: MAINTAINER, tokenSymbol: "XLM", amount: 50,
+      deadlineDays: 30, labels: [],
+    });
+    store.reserveBounty(bounty.id, CONTRIBUTOR);
+    store.submitBounty(bounty.id, CONTRIBUTOR, "https://github.com/pr/1");
+
+    const { expireStaleReservations } = await loadJob();
+    const result = expireStaleReservations(0); // TTL 0 would expire anything reserved
+
+    // submitted status must not be touched
+    const after = store.listBounties().find((b) => b.id === bounty.id);
+    expect(after?.status).toBe("submitted");
+    expect(result.expiredBountyIds).not.toContain(bounty.id);
+  });
+
+  it("returns checkedAt timestamp", async () => {
+    const before = nowSeconds();
+    const { expireStaleReservations } = await loadJob();
+    const result = expireStaleReservations(7 * 24 * 60 * 60);
+    const after = nowSeconds();
+
+    expect(result.checkedAt).toBeGreaterThanOrEqual(before);
+    expect(result.checkedAt).toBeLessThanOrEqual(after);
+  });
+});
+
+// ── startExpirationJob / stopExpirationJob ────────────────────────────────────
+
+describe("startExpirationJob / stopExpirationJob", () => {
+  it("starts and stops without throwing", async () => {
+    const { startExpirationJob, stopExpirationJob } = await loadJob();
+    expect(() => startExpirationJob(9999999, 7 * 24 * 60 * 60)).not.toThrow();
+    expect(() => stopExpirationJob()).not.toThrow();
+  });
+
+  it("does not start twice", async () => {
+    const { startExpirationJob, stopExpirationJob } = await loadJob();
+    startExpirationJob(9999999, 7 * 24 * 60 * 60);
+    expect(() => startExpirationJob(9999999, 7 * 24 * 60 * 60)).not.toThrow();
+    stopExpirationJob();
+  });
+
+  it("runs expiration on start and expires stale bounty", async () => {
+    const stale = makeReservedBounty(8 * 24 * 60 * 60);
+    fs.writeFileSync(storeFile, JSON.stringify([stale], null, 2));
+
+    const { startExpirationJob, stopExpirationJob } = await loadJob();
+    startExpirationJob(9999999, 7 * 24 * 60 * 60);
+    stopExpirationJob();
+
+    const raw = JSON.parse(fs.readFileSync(storeFile, "utf8"));
+    const updated = raw.find((b: { id: string }) => b.id === stale.id);
+    expect(updated.status).toBe("open");
+  });
+});


### PR DESCRIPTION
Closes #84 

## What this PR does
- Added `backend/src/services/reservationExpirationJob.ts` — cron job that scans reserved bounties and returns stale ones to `open` status
- Cron interval configurable via `EXPIRATION_CRON_INTERVAL_MS` env var (default: 1 hour)
- Expiration window configurable via `RESERVATION_TTL_DAYS` env var (default: 7 days)
- Logs each expired reservation with bounty ID and contributor address
- Exports `startExpirationJob()` and `stopExpirationJob()` for clean lifecycle management

## Tests
10 integration tests covering:
- Fresh reservations are not expired
- Stale reservations (> TTL) are expired and returned to open
- Contributor and reservedAt fields are cleared on expiry
- Expired event is added to bounty event history
- Multiple stale reservations expired in a single run
- RESERVATION_TTL_DAYS env var is respected
- Submitted bounties are never touched
- checkedAt timestamp is returned
- Job starts/stops cleanly without throwing
- Job runs expiration immediately on start

## Usage
Add to your app startup:
```typescript
import { startExpirationJob } from './services/reservationExpirationJob';
startExpirationJob();
```