### PR TITLE
feat(contracts): add extend_deadline function for maintainers (#105)

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -79,6 +79,13 @@ pub struct BountyRefunded {
     pub amount: i128,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BountyDeadlineExtended {
+    pub bounty_id: u64,
+    pub new_deadline: u64,
+}
+
 #[contract]
 pub struct StellarBountyBoardContract;
 
@@ -261,6 +268,30 @@ impl StellarBountyBoardContract {
         );
     }
 
+    pub fn extend_deadline(env: Env, bounty_id: u64, maintainer: Address, new_deadline: u64) {
+        maintainer.require_auth();
+        let mut bounty = read_bounty(&env, bounty_id);
+
+        if bounty.maintainer != maintainer {
+            panic!("maintainer mismatch");
+        }
+
+        if new_deadline <= bounty.deadline {
+            panic!("new deadline must be greater than current deadline");
+        }
+
+        bounty.deadline = new_deadline;
+        write_bounty(&env, bounty_id, &bounty);
+
+        env.events().publish(
+            (symbol_short!("Bounty"), symbol_short!("Extnd")),
+            BountyDeadlineExtended {
+                bounty_id,
+                new_deadline,
+            },
+        );
+    }
+
     pub fn get_bounty(env: Env, bounty_id: u64) -> Bounty {
         let mut bounty = read_bounty(&env, bounty_id);
         expire_if_needed(&env, &mut bounty);
@@ -294,4 +325,3 @@ fn expire_if_needed(env: &Env, bounty: &mut Bounty) {
         bounty.status = BountyStatus::Expired;
     }
 }
-

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -242,3 +242,95 @@ fn test_reserve_expired_bounty() {
 
     client.reserve_bounty(&bounty_id, &contributor);
 }
+
+#[test]
+fn test_extend_deadline_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, maintainer, _, token_id) = setup_test(&env);
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin.mint(&maintainer, &1000);
+
+    let initial_deadline = env.ledger().timestamp() + 1000;
+    let bounty_id = client.create_bounty(
+        &maintainer,
+        &token_id,
+        &500,
+        &String::from_str(&env, "repo"),
+        &1,
+        &String::from_str(&env, "title"),
+        &initial_deadline,
+    );
+
+    let new_deadline = initial_deadline + 5000;
+    client.extend_deadline(&bounty_id, &maintainer, &new_deadline);
+
+    let bounty = client.get_bounty(&bounty_id);
+    assert_eq!(bounty.deadline, new_deadline);
+
+    // Verify event
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+    assert_eq!(last_event.0, client.address);
+    assert_eq!(
+        last_event.1,
+        (symbol_short!("Bounty"), symbol_short!("Extnd")).into_val(&env)
+    );
+    let event_data: BountyDeadlineExtended = last_event.2.into_val(&env);
+    assert_eq!(event_data.bounty_id, bounty_id);
+    assert_eq!(event_data.new_deadline, new_deadline);
+}
+
+#[test]
+#[should_panic(expected = "maintainer mismatch")]
+fn test_extend_deadline_wrong_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, maintainer, contributor, token_id) = setup_test(&env);
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin.mint(&maintainer, &1000);
+
+    let initial_deadline = env.ledger().timestamp() + 1000;
+    let bounty_id = client.create_bounty(
+        &maintainer,
+        &token_id,
+        &500,
+        &String::from_str(&env, "repo"),
+        &1,
+        &String::from_str(&env, "title"),
+        &initial_deadline,
+    );
+
+    let new_deadline = initial_deadline + 5000;
+    
+    // Attempting to extend using the contributor's address instead of the maintainer
+    client.extend_deadline(&bounty_id, &contributor, &new_deadline);
+}
+
+#[test]
+#[should_panic(expected = "new deadline must be greater than current deadline")]
+fn test_extend_deadline_earlier() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, maintainer, _, token_id) = setup_test(&env);
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin.mint(&maintainer, &1000);
+
+    let initial_deadline = env.ledger().timestamp() + 1000;
+    let bounty_id = client.create_bounty(
+        &maintainer,
+        &token_id,
+        &500,
+        &String::from_str(&env, "repo"),
+        &1,
+        &String::from_str(&env, "title"),
+        &initial_deadline,
+    );
+
+    // Attempting to set a deadline earlier than the initial one
+    let earlier_deadline = initial_deadline - 100;
+    client.extend_deadline(&bounty_id, &maintainer, &earlier_deadline);
+}


### PR DESCRIPTION
Closes #105

### **Description**
This PR introduces the ability for bounty maintainers to extend the deadline of an existing bounty without needing to create a new one. It adds an `extend_deadline` function to the smart contract that enforces strict authorization and time constraints.

### **Changes**
* **Smart Contract Logic**: Added `extend_deadline(env: Env, bounty_id: u64, maintainer: Address, new_deadline: u64)` to `contracts/src/lib.rs`.
* **Access Control**: Leveraged `maintainer.require_auth()` and storage checks to ensure only the original creator can modify the bounty's deadline.
* **Time Validation**: Enforced that the `new_deadline` is strictly greater than the current deadline to prevent accidental premature expiration.
* **Event Emission**: Introduced the `BountyDeadlineExtended` event (emitted as `Extnd`) to notify listeners of the change.
* **Testing**: Added success, wrong caller, and earlier deadline scenarios to `contracts/src/test.rs` to thoroughly verify the new constraints.

### **Acceptance Criteria Progress**
- [x] Only maintainer (original creator) can call this function
- [x] New deadline must be greater than old deadline
- [x] Emits a deadline_extended event
- [x] Test covers: success, wrong caller, earlier deadline