### PR TITLE
feat(backend/validation): add GitHub PR URL format validation in subm…

### DIFF
--- a/backend/src/validation/prUrl.ts
+++ b/backend/src/validation/prUrl.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+const GITHUB_PR_URL_REGEX = /^https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/pull\/\d+$/;
+
+export const githubPrUrlSchema = z
+  .string()
+  .trim()
+  .url()
+  .refine(
+    (url) => {
+      try {
+        const parsedUrl = new URL(url);
+        return parsedUrl.hostname === "github.com";
+      } catch {
+        return false;
+      }
+    },
+    { message: "Submission URL must be from github.com" },
+  )
+  .refine(
+    (url) => {
+      try {
+        const parsedUrl = new URL(url);
+        const pathParts = parsedUrl.pathname.split("/").filter(Boolean);
+        return pathParts.length >= 3 && pathParts[2] === "pull";
+      } catch {
+        return false;
+      }
+    },
+    { message: "Submission URL must contain /pull/ segment" },
+  )
+  .refine(
+    (url) => GITHUB_PR_URL_REGEX.test(url),
+    { message: "Submission URL must follow format https://github.com/<owner>/<repo>/pull/<number>" },
+  );

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -1,6 +1,8 @@
 import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 
+import { githubPrUrlSchema } from "./prUrl";
+
 extendZodWithOpenApi(z);
 
 const STELLAR_ACCOUNT_REGEX = /^G[A-Z2-7]{55}$/;
@@ -106,14 +108,10 @@ export const submitBountySchema = z
     contributor: stellarAccountSchema.openapi({
       description: "Must match the contributor who reserved the bounty.",
     }),
-    submissionUrl: z
-      .string()
-      .trim()
-      .url("Submission URL must be a valid URL.")
-      .openapi({
-        example: "https://github.com/owner/repo/pull/99",
-        description: "Link to the pull request or deliverable.",
-      }),
+    submissionUrl: githubPrUrlSchema.openapi({
+      example: "https://github.com/owner/repo/pull/99",
+      description: "Link to the pull request or deliverable.",
+    }),
     notes: z
       .string()
       .trim()


### PR DESCRIPTION
Invalid URLs return 400 with field-level error, non-GitHub URLs are rejected, URLs without /pull/ segment are rejected, valid PR URLs pass through unchanged.

closes: #89 