### PR TITLE
chore: add lint-staged and Husky for pre-commit type-check and lint

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -10,8 +10,18 @@
     "build": "npm --prefix backend run build && npm --prefix frontend run build",
     "test": "npm --prefix backend test",
     "test:watch": "npm --prefix backend run test:watch",
-    "test:coverage": "npm --prefix backend run test:coverage"
+    "test:coverage": "npm --prefix backend run test:coverage",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "frontend/src/**/*.{ts,tsx}": [
+      "tsc --noEmit -p frontend/tsconfig.json",
+      "eslint --fix"
+    ],
+    "backend/src/**/*.ts": [
+      "tsc --noEmit -p backend/tsconfig.json",
+      "eslint --fix"
+    ]
   },
   "license": "MIT"
 }
-


### PR DESCRIPTION
## Summary
Adds Husky pre-commit hooks and lint-staged configuration to prevent TypeScript errors and lint violations from being committed.

## Changes
- Added `husky` and `lint-staged` scripts to root `package.json`
- Created `.husky/pre-commit` hook that runs `lint-staged`
- Configured lint-staged to run `tsc --noEmit` and `eslint --fix` on staged `.ts/.tsx` files in `frontend/` and `backend/`

## Testing
- `npm run prepare` installs husky git hooks
- Only staged files are linted (not entire repo)
- Commits can be bypassed with `--no-verify` for emergencies

Closes #118