### PR TITLE
chore: add .env.example with all required environment variables documented

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,19 @@
 # ==============================================================================
 # ENVIRONMENT VARIABLES CONFIGURATION
 # Copy this file to .env and update the values for your local setup.
+# IMPORTANT: Never commit the actual .env file to git.
 # ==============================================================================
 
 # ------------------------------------------------------------------------------
 # BACKEND CONFIGURATION
 # ------------------------------------------------------------------------------
 
-# [OPTIONAL] The port the backend server will listen on. (Default: 3001)
+# [REQUIRED] The port the backend server will listen on.
 PORT=3001
 
 # [REQUIRED] Secret used to verify signatures for GitHub Webhooks.
-# Generate a random string for local testing.
+# Generate a random string: openssl rand -hex 20
 GITHUB_WEBHOOK_SECRET=your_github_webhook_secret_here
-
-# [OPTIONAL] Defines the environment (e.g., development, test, production).
-NODE_ENV=development
 
 # [REQUIRED] Local file path for the bounty data store JSON.
 BOUNTY_STORE_PATH=./data/bounties.json
@@ -23,23 +21,38 @@ BOUNTY_STORE_PATH=./data/bounties.json
 # [REQUIRED] Local file path for the audit logs data store JSON.
 BOUNTY_AUDIT_STORE_PATH=./data/audit.json
 
+# [OPTIONAL] Defines the environment (e.g., development, test, production).
+# Default: development
+NODE_ENV=development
+
+# [OPTIONAL] CORS allowed origins (comma-separated). Default: http://localhost:5173
+CORS_ORIGINS=http://localhost:5173
+
+# [OPTIONAL] Logging level (debug, info, warn, error). Default: info
+LOG_LEVEL=info
+
 
 # ------------------------------------------------------------------------------
 # WORKER CONFIGURATION (SOROBAN)
 # ------------------------------------------------------------------------------
 
-# [REQUIRED] The Soroban Smart Contract ID to index.
-SOROBAN_CONTRACT_ID=CC...your_contract_id_here
+# [REQUIRED] The Soroban Smart Contract ID to index events from.
+# Find this after deploying your contract.
+SOROBAN_CONTRACT_ID=CCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-# [OPTIONAL] The RPC endpoint for the Stellar/Soroban network. 
-# (Default: https://rpc-futurenet.stellar.org)
+# [OPTIONAL] The RPC endpoint for the Stellar/Soroban network.
+# Default: https://rpc-futurenet.stellar.org
 SOROBAN_RPC_URL=https://rpc-futurenet.stellar.org
+
+# [OPTIONAL] How frequently the worker polls for new events (in seconds).
+# Default: 30
+SOROBAN_POLL_INTERVAL=30
 
 
 # ------------------------------------------------------------------------------
 # FRONTEND CONFIGURATION (VITE)
 # ------------------------------------------------------------------------------
 
-# [OPTIONAL] The base URL for the Backend API. (Default: /api)
+# [REQUIRED] The base URL for the Backend API.
 # For local development, this is usually http://localhost:3001/api
 VITE_API_URL=http://localhost:3001/api


### PR DESCRIPTION
## Summary
Comprehensive `.env.example` documenting every environment variable used across frontend, backend, and worker.

## Changes
- All env vars documented with inline comments
- Required vs optional clearly marked with examples
- `.env.example` committed (not `.env`)
- Sourced from actual `process.env` usage in the codebase

Closes #124