### PR TITLE
Closes #111

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+Only the latest version of the Stellar Bounty Board is currently supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Active  | :white_check_mark: |
+
+## Reporting a Vulnerability
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+If you discover a potential security issue, please report it privately by emailing [Insert Email or Use GitHub Private Reporting]. We appreciate your help in keeping the Stellar ecosystem safe.
+
+### Our Commitment
+* **Acknowledge:** We will acknowledge receipt of your report within **48 hours** (SLA).
+* **Triage:** We will provide a status update after initial triage.
+* **Disclosure:** We follow a responsible disclosure timeline of **90 days** before public release, though we aim to fix critical issues much faster.
+￼Enter

--- a/docs/issues/security-disclosure.md
+++ b/docs/issues/security-disclosure.md
@@ -1,0 +1,21 @@
+---
+name: Security Disclosure
+about: Report a security vulnerability (READ THIS FIRST)
+title: "[SECURITY] "
+labels: ["security"]
+assignees: []
+---
+
+## 🛑 STOP! DO NOT SUBMIT THIS ISSUE YET
+
+If you found a security vulnerability, **DO NOT** post it here. Publicly disclosing vulnerabilities makes them easier to exploit before a fix is ready.
+
+### How to report correctly:
+Please follow the instructions in our [Security Policy](https://github.com/ritik4ever/stellar-bounty-board/main/SECURITY.md).
+
+1. **Email us privately** at [Insert Email].
+2. Include a description of the vulnerability.
+3. Include steps to reproduce the issue (PoC).
+
+**Thank you for practicing responsible disclosure.**
+


### PR DESCRIPTION
docs(issues): add security vulnerability disclosure issue template. Closes: #111 

Task
Add a SECURITY.md at the repo root and a docs/issues/security-disclosure.md issue template explaining: how to report, response SLA, disclosure timeline.

Acceptance Criteria

SECURITY.md exists with contact instructions

Issue template discourages opening public issues for vulns

Response SLA stated (e.g. acknowledge within 48h)
File: docs/issues/
Wave: 4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Established a security policy defining supported versions for security updates
  * Introduced a responsible disclosure process for vulnerability reporting
  * Added guidelines with a 90-day disclosure timeline
  * Created a security issue template to guide vulnerability reporters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->