### PR TITLE
feat(frontend+ci): status pills filter and PR labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,19 @@
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "frontend/**"
+
+backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "backend/**"
+
+contracts:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "contracts/**"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,22 @@
+name: Label Pull Requests
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Label pull request by changed files
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -120,6 +120,14 @@ const contributorStatuses: Array<BountyStatus | "all"> = [
   "refunded",
   "expired",
 ];
+const boardStatuses: Array<BountyStatus | "all"> = [
+  "all",
+  "open",
+  "reserved",
+  "submitted",
+  "released",
+  "refunded",
+];
 
 type BountyAction = "reserve" | "submit" | "release" | "refund";
 
@@ -999,6 +1007,21 @@ placeholder="help wanted, backend"
               ))}
             </div>
           </section>
+
+          <div className="board-status-pills" role="tablist" aria-label="Filter bounties by status">
+            {boardStatuses.map((status) => (
+              <button
+                key={status}
+                type="button"
+                role="tab"
+                aria-selected={statusFilter === status}
+                className={`filter-chip ${statusFilter === status ? "filter-chip--active" : ""}`}
+                onClick={() => setStatusFilter(status)}
+              >
+                {status === "all" ? "All" : statusCopy[status].label}
+              </button>
+            ))}
+          </div>
 
           {loading ? (
             <div className="board-list">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -627,6 +627,13 @@ select {
   line-height: 1.5;
 }
 
+.board-status-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
 .status-helper {
   margin-top: 2px;
 }


### PR DESCRIPTION
Closes #67
Closes #119
Closes #100
Closes #122

## Changes
- add a status filter pill bar above the bounty list (All/Open/Reserved/Submitted/Released/Refunded)
- keep active pill state synced with existing filter/sort pipeline
- add .github/workflows/labeler.yml using actions/labeler
- add .github/labeler.yml path-to-label mapping for frontend/backend/contracts/docs

## Testing
- unable to run frontend tests: existing JSON parse error in frontend/package.json (trailing comma) blocks npm scripts in this repo state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The board page now includes an interactive status filter section with selectable chips, enabling users to efficiently filter and view bounties based on specific status categories.

* **Chores**
  * Established automated GitHub pull request labeling that automatically applies tags based on modified files in each PR, improving repository organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->