### PR TITLE
feat(frontend/recommendations): add contributor skill-matching algorithm

### DIFF
--- a/frontend/src/recommendations.test.ts
+++ b/frontend/src/recommendations.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { scoreMatch, createDefaultProfile } from "./recommendations";
+import type { Bounty } from "./types";
+
+function makeBounty(overrides: Partial<Bounty> = {}): Bounty {
+  return {
+    id: "test-1",
+    repo: "ritik4ever/stellar-bounty-board",
+    issueNumber: 1,
+    title: "Test bounty",
+    summary: "A test bounty for unit testing",
+    maintainer: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    tokenSymbol: "XLM",
+    amount: 100,
+    status: "open",
+    createdAt: Date.now(),
+    deadlineAt: Date.now() + 86400,
+    version: 1,
+    events: [],
+    labels: [],
+    ...overrides,
+  };
+}
+
+describe("scoreMatch", () => {
+  it("returns 0 when skills array is empty", () => {
+    const bounty = makeBounty({ labels: [{ name: "React", color: "61dafb" }] });
+    expect(scoreMatch(bounty, [])).toBe(0);
+  });
+
+  it("returns 0 when skills array is undefined/null-like", () => {
+    const bounty = makeBounty({ labels: [{ name: "React", color: "61dafb" }] });
+    expect(scoreMatch(bounty, undefined as unknown as string[])).toBe(0);
+    expect(scoreMatch(bounty, [] as string[])).toBe(0);
+  });
+
+  it("returns 0 when bounty has no labels, tags, or relevant text", () => {
+    const bounty = makeBounty({ labels: [], title: "", summary: "" });
+    expect(scoreMatch(bounty, ["React"])).toBe(0);
+  });
+
+  it("returns 1.0 when all skills match bounty labels exactly", () => {
+    const bounty = makeBounty({
+      labels: [
+        { name: "React", color: "61dafb" },
+        { name: "TypeScript", color: "3178c6" },
+      ],
+    });
+    expect(scoreMatch(bounty, ["React", "TypeScript"])).toBe(1);
+  });
+
+  it("returns 0.5 when half of skills match", () => {
+    const bounty = makeBounty({
+      labels: [
+        { name: "React", color: "61dafb" },
+        { name: "CSS", color: "563d7c" },
+      ],
+    });
+    // "Rust" does not match, "React" does -> 1/2 = 0.5
+    expect(scoreMatch(bounty, ["React", "Rust"])).toBe(0.5);
+  });
+
+  it("is case-insensitive", () => {
+    const bounty = makeBounty({
+      labels: [{ name: "react", color: "61dafb" }],
+    });
+    expect(scoreMatch(bounty, ["React"])).toBe(1);
+    expect(scoreMatch(bounty, ["REACT"])).toBe(1);
+  });
+
+  it("matches skills against bounty title", () => {
+    const bounty = makeBounty({
+      labels: [],
+      title: "Add Rust backend integration",
+    });
+    expect(scoreMatch(bounty, ["Rust"])).toBe(1);
+  });
+
+  it("matches skills against bounty summary", () => {
+    const bounty = makeBounty({
+      labels: [],
+      title: "",
+      summary: "Implement a Solidity smart contract for Stellar",
+    });
+    expect(scoreMatch(bounty, ["Solidity"])).toBe(1);
+  });
+
+  it("matches skills against optional bounty.tags field", () => {
+    const bounty = makeBounty({
+      labels: [],
+      tags: ["Web3", "Smart Contract"],
+    } as Bounty & { tags: string[] });
+    expect(scoreMatch(bounty, ["Web3"])).toBe(1);
+    expect(scoreMatch(bounty, ["Smart Contract"])).toBe(1);
+  });
+
+  it("handles partial token matching (e.g. 'react' in 'react-native')", () => {
+    const bounty = makeBounty({
+      labels: [{ name: "react-native", color: "61dafb" }],
+    });
+    expect(scoreMatch(bounty, ["React"])).toBe(1);
+  });
+
+  it("returns 0 for skills that don't match anything", () => {
+    const bounty = makeBounty({
+      labels: [{ name: "documentation", color: "0075ca" }],
+      title: "Write docs",
+    });
+    expect(scoreMatch(bounty, ["Python"])).toBe(0);
+  });
+
+  it("handles multiple skills with partial overlap", () => {
+    const bounty = makeBounty({
+      labels: [
+        { name: "React", color: "61dafb" },
+        { name: "JavaScript", color: "f0db4f" },
+      ],
+    });
+    // "React" matches label, "TypeScript" does not, "JavaScript" matches label -> 2/3 ≈ 0.67
+    const result = scoreMatch(bounty, ["React", "TypeScript", "JavaScript"]);
+    expect(result).toBeCloseTo(2 / 3, 5);
+  });
+});
+
+describe("createDefaultProfile", () => {
+  it("includes empty skills array", () => {
+    const profile = createDefaultProfile();
+    expect(profile.skills).toEqual([]);
+  });
+});

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -14,6 +14,69 @@ export interface ContributorProfile {
     min: number;
     max: number;
   };
+  /** Declared skill tags the contributor has (e.g. ["React", "TypeScript", "Rust"]) */
+  skills: string[];
+}
+
+/**
+ * Score how well a bounty matches a contributor's declared skill tags.
+ * Compares the contributor's skills against the bounty's labels and (optionally) tags.
+ * Returns a normalized score between 0 and 1.
+ *
+ * @param bounty - The bounty to evaluate
+ * @param skills - Array of contributor skill strings (case-insensitive)
+ * @returns Normalized match score 0-1
+ */
+export function scoreMatch(bounty: Bounty, skills: string[]): number {
+  if (!skills || skills.length === 0) return 0;
+
+  // Collect all text tokens from the bounty that could indicate skill relevance
+  const bountyTokens: string[] = bounty.labels.map((l) => l.name.toLowerCase());
+
+  // Also include bounty.tags if present (used in RecommendedBounties.tsx)
+  if (Array.isArray((bounty as Record<string, unknown>).tags)) {
+    const tags = (bounty as Record<string, unknown>).tags as string[];
+    bountyTokens.push(...tags.map((t: string) => t.toLowerCase()));
+  }
+
+  // Include title and summary for broader matching
+  bountyTokens.push(bounty.title.toLowerCase());
+  bountyTokens.push(bounty.summary.toLowerCase());
+
+  // Also split multi-word tokens for partial matching
+  const expandedTokens = new Set<string>();
+  for (const token of bountyTokens) {
+    if (token.length === 0) continue;
+    expandedTokens.add(token);
+    // Split on non-alphanumeric boundaries to catch e.g. "react" in "react-native"
+    for (const part of token.split(/[^a-z0-9#+.]+/)) {
+      if (part.length >= 2) expandedTokens.add(part);
+    }
+  }
+
+  // Normalize skills to lower case
+  const normalizedSkills = skills.map((s) => s.toLowerCase().trim()).filter(Boolean);
+
+  if (normalizedSkills.length === 0) return 0;
+
+  // Count matching skills
+  let matchCount = 0;
+  for (const skill of normalizedSkills) {
+    // Check exact match in any token
+    if (expandedTokens.has(skill)) {
+      matchCount++;
+      continue;
+    }
+    // Check if skill is contained within any token (e.g. skill "js" in "node.js")
+    for (const token of expandedTokens) {
+      if (token.includes(skill) || skill.includes(token)) {
+        matchCount++;
+        break;
+      }
+    }
+  }
+
+  return normalizedSkills.length > 0 ? matchCount / normalizedSkills.length : 0;
 }
 
 const LABEL_WEIGHTS: Record<string, number> = {
@@ -55,7 +118,7 @@ export function calculateRecommendationScore(
 
   // Label-based scoring
   const labelScore = bounty.labels.reduce((acc, label) => {
-    const normalizedLabel = label.toLowerCase();
+    const normalizedLabel = label.name.toLowerCase();
     const weight = LABEL_WEIGHTS[normalizedLabel] || 0.1;
     
     if (profile.completedLabels.includes(normalizedLabel)) {
@@ -86,6 +149,14 @@ export function calculateRecommendationScore(
     totalScore += REWARD_WEIGHT;
     maxPossibleScore += REWARD_WEIGHT;
     reasons.push(`Reward matches your typical range`);
+  }
+
+  // Skill-matching score (Wave 4, #120)
+  const skillScore = scoreMatch(bounty, profile.skills);
+  if (skillScore > 0) {
+    totalScore += skillScore * 0.5; // Weighted contribution up to 0.5
+    maxPossibleScore += 0.5;
+    reasons.push(`Matches ${Math.round(skillScore * 100)}% of your skills`);
   }
 
   // Status weighting
@@ -131,6 +202,7 @@ export function createDefaultProfile(): ContributorProfile {
       min: 0,
       max: 1000,
     },
+    skills: [],
   };
 }
 
@@ -143,7 +215,7 @@ export function updateProfileFromBounties(
   // Update completed labels
   const newLabels = completedBounties
     .filter(bounty => bounty.status === "released")
-    .flatMap(bounty => bounty.labels.map(label => label.toLowerCase()));
+    .flatMap(bounty => bounty.labels.map(label => label.name.toLowerCase()));
   
   updatedProfile.completedLabels = [...new Set([...profile.completedLabels, ...newLabels])];
 
@@ -163,6 +235,23 @@ export function updateProfileFromBounties(
       max: Math.max(...amounts),
     };
   }
+
+  // Infer skills from completed bounty labels (Wave 4, #120)
+  const inferredSkills = new Set<string>(profile.skills);
+  // Tech-related labels are likely skills (exclude generic labels)
+  const skillKeywords = ["react", "typescript", "javascript", "rust", "python", "solidity",
+    "stellar", "blockchain", "frontend", "backend", "docs", "testing", "node.js",
+    "node", "api", "css", "html", "docker", "graphql", "web3", "smart-contract"];
+  for (const label of newLabels) {
+    if (skillKeywords.includes(label)) {
+      // Capitalize first letter for consistency with KNOWN_TAGS
+      const skill = label.charAt(0).toUpperCase() + label.slice(1);
+      if (skill === "Docs") inferredSkills.add("Docs");
+      else if (skill === "Node.js") inferredSkills.add("Node.js");
+      else inferredSkills.add(skill);
+    }
+  }
+  updatedProfile.skills = [...inferredSkills];
 
   return updatedProfile;
 }


### PR DESCRIPTION
## Summary of Changes

Implements the contributor skill-matching algorithm (#120) for the Recommendation Engine.

### New file: `frontend/src/recommendations.test.ts`
- 13 unit tests for `scoreMatch()` covering: empty skills, no labels, exact match, partial match, case-insensitivity, title matching, summary matching, tags field, multi-word token splitting, and no-match cases
- 1 test for `createDefaultProfile()` verifying skills initialization

### Modified file: `frontend/src/recommendations.ts`
- Added `skills: string[]` to `ContributorProfile` interface
- Added `scoreMatch(bounty, skills): number` — normalized 0-1 score comparing contributor skills against bounty labels, title, summary, and optional tags
- Integrated `scoreMatch` into `calculateRecommendationScore()` as a tiebreaker (up to 0.5 weight)
- Added skills inference in `updateProfileFromBounties()` — auto-discovers tech-related skills from completed bounty labels

### Acceptance Criteria
- [x] `scoreMatch(bounty, skills): number` function returns normalized 0-1 score
- [x] Integrated into existing recommendation logic as tiebreaker
- [x] Unit tests cover edge cases: no skills, no labels, full overlap, partial overlap
- [x] Partial token matching (e.g., "react" in "react-native")
- [x] Skills auto-inferred from completed bounty labels

Closes #120