### PR TITLE
test(contracts): add comprehensive state transition and deadline tests

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,18 @@
+# Stellar Bounty Board Contract
+
+## Error Codes
+
+The contract uses named error codes for all invalid operations. These codes are emitted as panic messages in tests.
+
+- `InvalidAmount` - amount must be positive.
+- `DeadlineMustBeInTheFuture` - a bounty deadline must be later than the current ledger timestamp.
+- `BountyNotOpen` - reserve is only allowed when a bounty is open.
+- `BountyMustBeReserved` - submit is only allowed when a bounty is reserved.
+- `ContributorMismatch` - the submitting contributor must match the reserved contributor.
+- `MaintainerMismatch` - the maintainer must match the bounty maintainer.
+- `BountyMustBeSubmitted` - release is only allowed when a bounty has been submitted.
+- `MissingContributor` - internal failure when a submitted bounty has no contributor.
+- `BountyAlreadyFinalized` - refunds are not allowed for released or already refunded bounties.
+- `BountyNotExpiredYet` - refunds are only allowed after the deadline.
+- `NewDeadlineMustBeGreaterThanCurrentDeadline` - extend_deadline requires a later deadline.
+- `BountyNotFound` - referenced bounty does not exist.

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -9,7 +9,7 @@ use soroban_sdk::{
 };
 
 #[contracttype]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BountyStatus {
     Open,
     Reserved,
@@ -86,6 +86,28 @@ pub struct BountyDeadlineExtended {
     pub new_deadline: u64,
 }
 
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ContractError {
+    InvalidAmount,
+    DeadlineMustBeInTheFuture,
+    BountyNotOpen,
+    BountyMustBeReserved,
+    ContributorMismatch,
+    MaintainerMismatch,
+    BountyMustBeSubmitted,
+    MissingContributor,
+    BountyAlreadyFinalized,
+    BountyNotExpiredYet,
+    DeadlineMustAdvance,
+    CannotExtendFinalizedBounty,
+    BountyNotFound,
+}
+
+fn panic_error(error: ContractError) -> ! {
+    panic!("{:?}", error);
+}
+
 #[contract]
 pub struct StellarBountyBoardContract;
 
@@ -104,10 +126,10 @@ impl StellarBountyBoardContract {
         maintainer.require_auth();
 
         if amount <= 0 {
-            panic!("amount must be positive");
+            panic_error(ContractError::InvalidAmount);
         }
         if deadline <= env.ledger().timestamp() {
-            panic!("deadline must be in the future");
+            panic_error(ContractError::DeadlineMustBeInTheFuture);
         }
 
         let token_client = TokenClient::new(&env, &token);
@@ -160,7 +182,7 @@ impl StellarBountyBoardContract {
         expire_if_needed(&env, &mut bounty);
 
         if bounty.status != BountyStatus::Open {
-            panic!("bounty is not open");
+            panic_error(ContractError::BountyNotOpen);
         }
 
         bounty.contributor = Some(contributor.clone());
@@ -182,10 +204,10 @@ impl StellarBountyBoardContract {
         expire_if_needed(&env, &mut bounty);
 
         if bounty.status != BountyStatus::Reserved {
-            panic!("bounty must be reserved");
+            panic_error(ContractError::BountyMustBeReserved);
         }
         if bounty.contributor != Some(contributor.clone()) {
-            panic!("contributor mismatch");
+            panic_error(ContractError::ContributorMismatch);
         }
 
         bounty.status = BountyStatus::Submitted;
@@ -205,16 +227,16 @@ impl StellarBountyBoardContract {
         let mut bounty = read_bounty(&env, bounty_id);
 
         if bounty.maintainer != maintainer {
-            panic!("maintainer mismatch");
+            panic_error(ContractError::MaintainerMismatch);
         }
         if bounty.status != BountyStatus::Submitted {
-            panic!("bounty must be submitted");
+            panic_error(ContractError::BountyMustBeSubmitted);
         }
 
         let contributor = bounty
             .contributor
             .clone()
-            .unwrap_or_else(|| panic!("missing contributor"));
+            .unwrap_or_else(|| panic_error(ContractError::MissingContributor));
         let token_client = TokenClient::new(&env, &bounty.token);
         let contract_address = env.current_contract_address();
         token_client.transfer(&contract_address, &contributor, &bounty.amount);
@@ -237,18 +259,18 @@ impl StellarBountyBoardContract {
         let mut bounty = read_bounty(&env, bounty_id);
         
         if bounty.maintainer != maintainer {
-            panic!("maintainer mismatch");
+            panic_error(ContractError::MaintainerMismatch);
         }
 
         // Finalized bounties cannot be refunded
         if bounty.status == BountyStatus::Released || bounty.status == BountyStatus::Refunded {
-            panic!("bounty already finalized");
+            panic_error(ContractError::BountyAlreadyFinalized);
         }
 
         // Active/Submitted bounties can ONLY be refunded if expired
         let now = env.ledger().timestamp();
         if now <= bounty.deadline && bounty.deadline != 0 {
-            panic!("bounty not expired yet");
+            panic_error(ContractError::BountyNotExpiredYet);
         }
 
         let token_client = TokenClient::new(&env, &bounty.token);
@@ -271,13 +293,21 @@ impl StellarBountyBoardContract {
     pub fn extend_deadline(env: Env, bounty_id: u64, maintainer: Address, new_deadline: u64) {
         maintainer.require_auth();
         let mut bounty = read_bounty(&env, bounty_id);
+        expire_if_needed(&env, &mut bounty);
 
         if bounty.maintainer != maintainer {
-            panic!("maintainer mismatch");
+            panic_error(ContractError::MaintainerMismatch);
+        }
+
+        if bounty.status == BountyStatus::Released
+            || bounty.status == BountyStatus::Refunded
+            || bounty.status == BountyStatus::Expired
+        {
+            panic_error(ContractError::CannotExtendFinalizedBounty);
         }
 
         if new_deadline <= bounty.deadline {
-            panic!("new deadline must be greater than current deadline");
+            panic_error(ContractError::DeadlineMustAdvance);
         }
 
         bounty.deadline = new_deadline;
@@ -310,7 +340,7 @@ fn read_bounty(env: &Env, bounty_id: u64) -> Bounty {
     env.storage()
         .persistent()
         .get(&DataKey::Bounty(bounty_id))
-        .unwrap_or_else(|| panic!("bounty not found"))
+        .unwrap_or_else(|| panic_error(ContractError::BountyNotFound))
 }
 
 fn write_bounty(env: &Env, bounty_id: u64, bounty: &Bounty) {

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -19,6 +19,80 @@ fn setup_test(env: &Env) -> (StellarBountyBoardContractClient<'static>, Address,
     (client, maintainer, contributor, token_id.address())
 }
 
+fn create_bounty_with_state(
+    env: &Env,
+    client: &StellarBountyBoardContractClient<'static>,
+    maintainer: Address,
+    contributor: Address,
+    token_id: Address,
+    status: BountyStatus,
+) -> u64 {
+    let deadline = env.ledger().timestamp() + 1000;
+    let bounty_id = client.create_bounty(
+        &maintainer,
+        &token_id,
+        &500,
+        &String::from_str(&env, "repo"),
+        &1,
+        &String::from_str(&env, "title"),
+        &deadline,
+    );
+
+    match status {
+        BountyStatus::Open => bounty_id,
+        BountyStatus::Reserved => {
+            client.reserve_bounty(&bounty_id, &contributor);
+            bounty_id
+        }
+        BountyStatus::Submitted => {
+            client.reserve_bounty(&bounty_id, &contributor);
+            client.submit_bounty(&bounty_id, &contributor);
+            bounty_id
+        }
+        BountyStatus::Released => {
+            client.reserve_bounty(&bounty_id, &contributor);
+            client.submit_bounty(&bounty_id, &contributor);
+            client.release_bounty(&bounty_id, &maintainer);
+            bounty_id
+        }
+        BountyStatus::Refunded => {
+            client.reserve_bounty(&bounty_id, &contributor);
+            env.ledger().set_timestamp(deadline + 1);
+            client.refund_bounty(&bounty_id, &maintainer);
+            bounty_id
+        }
+        BountyStatus::Expired => {
+            env.ledger().set_timestamp(deadline + 1);
+            bounty_id
+        }
+    }
+}
+
+macro_rules! invalid_transition_test {
+    ($name:ident, $status:expr, $expected:expr, $action:block) => {
+        #[test]
+        #[should_panic(expected = $expected)]
+        fn $name() {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, maintainer, contributor, token_id) = setup_test(&env);
+            let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+            token_admin.mint(&maintainer, &1000);
+
+            let bounty_id = create_bounty_with_state(
+                &env,
+                &client,
+                maintainer.clone(),
+                contributor.clone(),
+                token_id.clone(),
+                $status,
+            );
+            let action = $action;
+            action(&client, bounty_id, maintainer, contributor);
+        }
+    };
+}
+
 #[test]
 fn test_create_bounty() {
     let env = Env::default();
@@ -71,7 +145,7 @@ fn test_create_bounty() {
 }
 
 #[test]
-#[should_panic(expected = "amount must be positive")]
+#[should_panic(expected = "InvalidAmount")]
 fn test_create_bounty_negative_amount() {
     let env = Env::default();
     env.mock_all_auths();
@@ -130,7 +204,32 @@ fn test_full_lifecycle() {
 }
 
 #[test]
-fn test_refund_flow() {
+#[should_panic(expected = "BountyNotExpiredYet")]
+fn test_refund_reserved_before_deadline_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, maintainer, contributor, token_id) = setup_test(&env);
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin.mint(&maintainer, &1000);
+
+    let deadline = env.ledger().timestamp() + 1000;
+    let bounty_id = client.create_bounty(
+        &maintainer,
+        &token_id,
+        &500,
+        &String::from_str(&env, "repo"),
+        &1,
+        &String::from_str(&env, "title"),
+        &deadline,
+    );
+
+    client.reserve_bounty(&bounty_id, &contributor);
+    client.refund_bounty(&bounty_id, &maintainer);
+}
+
+#[test]
+fn test_refund_after_deadline_reserved_succeeds() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -150,10 +249,8 @@ fn test_refund_flow() {
         &deadline,
     );
 
-    // Refund after expiration
-    env.ledger().with_mut(|li| {
-        li.timestamp = deadline + 1;
-    });
+    client.reserve_bounty(&bounty_id, &contributor);
+    env.ledger().set_timestamp(deadline + 1);
 
     client.refund_bounty(&bounty_id, &maintainer);
     let bounty = client.get_bounty(&bounty_id);
@@ -161,8 +258,152 @@ fn test_refund_flow() {
     assert_eq!(token.balance(&maintainer), 1000);
 }
 
+invalid_transition_test!(reserve_reserved, BountyStatus::Reserved, "BountyNotOpen", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, _maintainer: Address, contributor: Address| {
+        client.reserve_bounty(&bounty_id, &contributor)
+    }
+});
+invalid_transition_test!(reserve_submitted, BountyStatus::Submitted, "BountyNotOpen", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, _maintainer: Address, contributor: Address| {
+        client.reserve_bounty(&bounty_id, &contributor)
+    }
+});
+invalid_transition_test!(reserve_released, BountyStatus::Released, "BountyNotOpen", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, _maintainer: Address, contributor: Address| {
+        client.reserve_bounty(&bounty_id, &contributor)
+    }
+});
+invalid_transition_test!(reserve_refunded, BountyStatus::Refunded, "BountyNotOpen", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, _maintainer: Address, contributor: Address| {
+        client.reserve_bounty(&bounty_id, &contributor)
+    }
+});
+invalid_transition_test!(reserve_expired, BountyStatus::Expired, "BountyNotOpen", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, _maintainer: Address, contributor: Address| {
+        client.reserve_bounty(&bounty_id, &contributor)
+    }
+});
+
+invalid_transition_test!(submit_open, BountyStatus::Open, "BountyMustBeReserved", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, _maintainer: Address, contributor: Address| {
+        client.submit_bounty(&bounty_id, &contributor)
+    }
+});
+invalid_transition_test!(submit_submitted, BountyStatus::Submitted, "BountyMustBeReserved", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, _maintainer: Address, contributor: Address| {
+        client.submit_bounty(&bounty_id, &contributor)
+    }
+});
+invalid_transition_test!(submit_released, BountyStatus::Released, "BountyMustBeReserved", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, _maintainer: Address, contributor: Address| {
+        client.submit_bounty(&bounty_id, &contributor)
+    }
+});
+invalid_transition_test!(submit_refunded, BountyStatus::Refunded, "BountyMustBeReserved", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, _maintainer: Address, contributor: Address| {
+        client.submit_bounty(&bounty_id, &contributor)
+    }
+});
+invalid_transition_test!(submit_expired, BountyStatus::Expired, "BountyMustBeReserved", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, _maintainer: Address, contributor: Address| {
+        client.submit_bounty(&bounty_id, &contributor)
+    }
+});
+
+invalid_transition_test!(release_open, BountyStatus::Open, "BountyMustBeSubmitted", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, maintainer: Address, _contributor: Address| {
+        client.release_bounty(&bounty_id, &maintainer)
+    }
+});
+invalid_transition_test!(release_reserved, BountyStatus::Reserved, "BountyMustBeSubmitted", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, maintainer: Address, _contributor: Address| {
+        client.release_bounty(&bounty_id, &maintainer)
+    }
+});
+invalid_transition_test!(release_released, BountyStatus::Released, "BountyMustBeSubmitted", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, maintainer: Address, _contributor: Address| {
+        client.release_bounty(&bounty_id, &maintainer)
+    }
+});
+invalid_transition_test!(release_refunded, BountyStatus::Refunded, "BountyMustBeSubmitted", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, maintainer: Address, _contributor: Address| {
+        client.release_bounty(&bounty_id, &maintainer)
+    }
+});
+invalid_transition_test!(release_expired, BountyStatus::Expired, "BountyMustBeSubmitted", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, maintainer: Address, _contributor: Address| {
+        client.release_bounty(&bounty_id, &maintainer)
+    }
+});
+
+invalid_transition_test!(refund_open, BountyStatus::Open, "BountyNotExpiredYet", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, maintainer: Address, _contributor: Address| {
+        client.refund_bounty(&bounty_id, &maintainer)
+    }
+});
+invalid_transition_test!(refund_reserved, BountyStatus::Reserved, "BountyNotExpiredYet", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, maintainer: Address, _contributor: Address| {
+        client.refund_bounty(&bounty_id, &maintainer)
+    }
+});
+invalid_transition_test!(refund_submitted, BountyStatus::Submitted, "BountyNotExpiredYet", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, maintainer: Address, _contributor: Address| {
+        client.refund_bounty(&bounty_id, &maintainer)
+    }
+});
+invalid_transition_test!(refund_released, BountyStatus::Released, "BountyAlreadyFinalized", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, maintainer: Address, _contributor: Address| {
+        client.refund_bounty(&bounty_id, &maintainer)
+    }
+});
+invalid_transition_test!(refund_refunded, BountyStatus::Refunded, "BountyAlreadyFinalized", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, maintainer: Address, _contributor: Address| {
+        client.refund_bounty(&bounty_id, &maintainer)
+    }
+});
+
+invalid_transition_test!(extend_released, BountyStatus::Released, "CannotExtendFinalizedBounty", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, maintainer: Address, _contributor: Address| {
+        client.extend_deadline(&bounty_id, &maintainer, &1000000)
+    }
+});
+invalid_transition_test!(extend_refunded, BountyStatus::Refunded, "CannotExtendFinalizedBounty", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, maintainer: Address, _contributor: Address| {
+        client.extend_deadline(&bounty_id, &maintainer, &1000000)
+    }
+});
+invalid_transition_test!(extend_expired, BountyStatus::Expired, "CannotExtendFinalizedBounty", {
+    |client: &StellarBountyBoardContractClient<'static>, bounty_id: u64, maintainer: Address, _contributor: Address| {
+        client.extend_deadline(&bounty_id, &maintainer, &1000000)
+    }
+});
+
 #[test]
-#[should_panic(expected = "bounty must be submitted")]
+#[should_panic(expected = "BountyNotOpen")]
+fn test_concurrent_reservation_race_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, maintainer, contributor, token_id) = setup_test(&env);
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin.mint(&maintainer, &1000);
+
+    let bounty_id = client.create_bounty(
+        &maintainer,
+        &token_id,
+        &500,
+        &String::from_str(&env, "repo"),
+        &1,
+        &String::from_str(&env, "title"),
+        &(env.ledger().timestamp() + 1000),
+    );
+
+    client.reserve_bounty(&bounty_id, &contributor);
+    client.reserve_bounty(&bounty_id, &contributor);
+}
+
+#[test]
+#[should_panic(expected = "BountyMustBeSubmitted")]
 fn test_release_without_submit() {
     let env = Env::default();
     env.mock_all_auths();
@@ -206,16 +447,14 @@ fn test_expiration() {
     );
 
     // Advance time
-    env.ledger().with_mut(|li| {
-        li.timestamp = deadline + 1;
-    });
+    env.ledger().set_timestamp(deadline + 1);
 
     let bounty = client.get_bounty(&bounty_id);
     assert_eq!(bounty.status, BountyStatus::Expired);
 }
 
 #[test]
-#[should_panic(expected = "bounty is not open")]
+#[should_panic(expected = "BountyNotOpen")]
 fn test_reserve_expired_bounty() {
     let env = Env::default();
     env.mock_all_auths();
@@ -236,9 +475,7 @@ fn test_reserve_expired_bounty() {
     );
 
     // Advance time
-    env.ledger().with_mut(|li| {
-        li.timestamp = deadline + 1;
-    });
+    env.ledger().set_timestamp(deadline + 1);
 
     client.reserve_bounty(&bounty_id, &contributor);
 }
@@ -283,7 +520,7 @@ fn test_extend_deadline_success() {
 }
 
 #[test]
-#[should_panic(expected = "maintainer mismatch")]
+#[should_panic(expected = "MaintainerMismatch")]
 fn test_extend_deadline_wrong_caller() {
     let env = Env::default();
     env.mock_all_auths();
@@ -310,7 +547,7 @@ fn test_extend_deadline_wrong_caller() {
 }
 
 #[test]
-#[should_panic(expected = "new deadline must be greater than current deadline")]
+#[should_panic(expected = "DeadlineMustAdvance")]
 fn test_extend_deadline_earlier() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for the Stellar Bounty Board contract's state machine, including invalid state transitions, deadline-based refunds, and concurrent reservation handling. All tests use named error enums and run cleanly with `cargo test`.

## Changes
- **contracts/src/lib.rs**: Added `ContractError` enum with named error codes, replaced string panics with enum-based errors, and added state guards for `extend_deadline`.
- **contracts/src/test.rs**: Added 23 parameterized tests for invalid state transitions (covering all 5 functions × invalid states), deadline refund tests (before/after expiration), and concurrent reservation race condition test.
- **contracts/README.md**: Documented all contract error codes for reference.

## Acceptance Criteria Met
- All 5 functions × all invalid states tested with specific error codes.
- Refund succeeds after deadline expiration (using `env.ledger().set_timestamp()`).
- Refund fails before deadline when bounty is reserved.
- Second reservation attempt fails with meaningful named error (`BountyNotOpen`).
- Tests run cleanly with `cargo test` (35 tests pass).

<img width="794" height="550" alt="Screenshot 2026-04-27 at 15 53 17" src="https://github.com/user-attachments/assets/a0f9c741-91e9-4855-b452-4446c4e2e5ea" />

Closes #123, #103, #102, #121




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced named error codes for validation failures with clearer messaging across bounty operations.

* **Documentation**
  * Added error code reference documentation explaining validation rules for all contract operations.

* **Tests**
  * Expanded test coverage for validation scenarios and error conditions across bounty workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->