### PR TITLE
Fix labeler configuration schema

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,4 @@
 frontend:
+  - changed-files:
+      - any-glob-to-any-file: "frontend/**"
 


### PR DESCRIPTION
## Summary

- Update `.github/labeler.yml` to the `actions/labeler@v5` array-of-config-options schema.
- Keep the existing `frontend` label behavior scoped to `frontend/**` changes.

## Why

The current `pull_request_target` labeler workflow fetches `.github/labeler.yml` from the base repository via the API and fails with:

`found unexpected type for label 'frontend' (should be array of config options)`

That blocks fork PR checks such as #391 even when the fork branch contains the corrected config.

## Validation

- Parsed `.github/labeler.yml` and verified `frontend` is an array.
- `git diff --check`
