### PR TITLE
Add live USD conversion for bounty amounts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,7 +38,7 @@ import SubmissionChecklistModal, { type SubmissionFormData } from "./SubmissionC
 import { BountyRecommendation, ContributorProfile, createDefaultProfile, generateRecommendations, updateProfileFromBounties } from "./recommendations";
 import RecommendedBounties from "./RecommendedBounties";
 import { statusCopy, actionCopy, readInitialFilters, FilterState, statusOptions, statusGlossary, sortOptions } from "./constants";
-import { filterBounties, getRewardBounds, getActiveRewardLabel, getContributorMetrics, getUniqueRepos, getRepoMetrics, sortBounties, debounce, SortOption, SortState, xlmToUsd } from "./utils";
+import { filterBounties, getRewardBounds, getActiveRewardLabel, getContributorMetrics, getUniqueRepos, getRepoMetrics, sortBounties, debounce, SortOption, SortState } from "./utils";
 import { Bounty, CreateBountyPayload, OpenIssue, BountyStatus } from "./types";
 
 import GitHubIssuePreviewCard from "./GitHubIssuePreviewCard";
@@ -141,34 +141,10 @@ function formatTimestamp(value?: number): string {
 }
 
 function BountyAmount({ bounty }: { bounty: Bounty }) {
-  const [usdAmount, setUsdAmount] = useState<string | null>(null);
-
-  useEffect(() => {
-    let active = true;
-
-    if (bounty.tokenSymbol.toUpperCase() !== "XLM") {
-      setUsdAmount(null);
-      return () => {
-        active = false;
-      };
-    }
-
-    setUsdAmount(null);
-    void xlmToUsd(bounty.amount).then((value) => {
-      if (active) {
-        setUsdAmount(value);
-      }
-    });
-
-    return () => {
-      active = false;
-    };
-  }, [bounty.amount, bounty.tokenSymbol]);
-
   return (
     <div className="amount-chip">
       <strong>{bounty.amount} {bounty.tokenSymbol}</strong>
-      {usdAmount && <span>{usdAmount}</span>}
+      <UsdAmount amount={bounty.amount} tokenSymbol={bounty.tokenSymbol} />
     </div>
   );
 }

--- a/frontend/src/BountyDetailPage.tsx
+++ b/frontend/src/BountyDetailPage.tsx
@@ -1,4 +1,9 @@
 
+import { ReactNode, useCallback, useState } from "react";
+import { ArrowUpRight, Check, Clock, Copy } from "lucide-react";
+import UsdAmount from "./UsdAmount";
+import { Bounty, BountyEvent, BountyStatus } from "./types";
+
 type BountyAction = "reserve" | "submit" | "release" | "refund";
 
 type Props = {
@@ -50,7 +55,7 @@ function CopyButton({ text, label }: { text: string; label: string }) {
       >
         {copied ? <Check size={14} /> : <Copy size={14} />}
       </button>
-      {copied && <span className="copy-tooltip">Copied!</span>}
+      {copied && <span className="copy-tooltip">Copied</span>}
     </span>
   );
 }
@@ -156,16 +161,17 @@ export default function BountyDetailPage({
               </div>
               <div className="amount-chip">
                 {bounty.amount} {bounty.tokenSymbol}
-                {bounty.tokenSymbol === "XLM" && (
-                  <UsdAmount amount={bounty.amount} />
-                )}
+                <UsdAmount amount={bounty.amount} tokenSymbol={bounty.tokenSymbol} />
               </div>
             </div>
 
             <div className="meta-grid meta-grid--detail">
               <div>
                 <span className="meta-label">Bounty ID</span>
-
+                <strong className="copy-row">
+                  {bounty.id}
+                  <CopyButton text={bounty.id} label="bounty ID" />
+                </strong>
               </div>
               <div>
                 <span className="meta-label">Issue</span>
@@ -190,7 +196,10 @@ export default function BountyDetailPage({
               </div>
               <div>
                 <span className="meta-label">Maintainer</span>
-
+                <strong className="copy-row">
+                  {bounty.maintainer}
+                  <CopyButton text={bounty.maintainer} label="maintainer wallet address" />
+                </strong>
               </div>
               <div>
                 <span className="meta-label">Contributor</span>

--- a/frontend/src/RecommendedBounties.tsx
+++ b/frontend/src/RecommendedBounties.tsx
@@ -69,9 +69,7 @@ function BountyRecommendationCard({ recommendation }: { recommendation: BountyRe
         </div>
         <div className="amount-chip">
           {bounty.amount} {bounty.tokenSymbol}
-          {bounty.tokenSymbol === "XLM" && (
-            <UsdAmount amount={bounty.amount} />
-          )}
+          <UsdAmount amount={bounty.amount} tokenSymbol={bounty.tokenSymbol} />
         </div>
       </div>
 
@@ -135,7 +133,7 @@ export default function RecommendedBounties({ recommendations, loading }: Recomm
       ? recommendations
       : recommendations.filter(({ bounty }) => {
           const haystack = [
-            ...bounty.labels,
+            ...bounty.labels.map((label) => label.name),
             ...(bounty.tags ?? []),
           ].map((t) => t.toLowerCase());
           return haystack.some((t) => t.includes(activeTag.toLowerCase()));

--- a/frontend/src/UsdAmount.test.tsx
+++ b/frontend/src/UsdAmount.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import UsdAmount from "./UsdAmount";
+import { resetXlmToUsdCache } from "./utils";
+
+describe("UsdAmount", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    resetXlmToUsdCache();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders a loading state before resolving live XLM/USD conversion", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ stellar: { usd: 0.125 } }),
+    });
+
+    render(<UsdAmount amount={40} tokenSymbol="XLM" />);
+
+    expect(screen.getByText("USD loading...")).toBeInTheDocument();
+    expect(await screen.findByText("($5.00)")).toBeInTheDocument();
+  });
+
+  it("renders USDC amounts as 1:1 USD values without fetching a price", async () => {
+    render(<UsdAmount amount={12.34} tokenSymbol="USDC" />);
+
+    expect(await screen.findByText("($12.34)")).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/UsdAmount.tsx
+++ b/frontend/src/UsdAmount.tsx
@@ -1,24 +1,48 @@
 import { useEffect, useState } from "react";
-import { xlmToUsd } from "./utils";
+import { tokenAmountToUsd } from "./utils";
 
 interface UsdAmountProps {
   amount: number;
+  tokenSymbol?: string;
 }
 
-export default function UsdAmount({ amount }: UsdAmountProps) {
-  const [usdValue, setUsdValue] = useState<string>("");
+type ConversionState =
+  | { status: "loading"; value: "" }
+  | { status: "ready"; value: string }
+  | { status: "unavailable"; value: string }
+  | { status: "unsupported"; value: "" };
+
+export default function UsdAmount({ amount, tokenSymbol = "XLM" }: UsdAmountProps) {
+  const [usdValue, setUsdValue] = useState<ConversionState>({
+    status: "loading",
+    value: "",
+  });
 
   useEffect(() => {
     let active = true;
-    xlmToUsd(amount).then((value) => {
-      if (active) setUsdValue(value);
+    setUsdValue({ status: "loading", value: "" });
+
+    tokenAmountToUsd(amount, tokenSymbol).then((value) => {
+      if (!active) return;
+      if (value === null) {
+        setUsdValue({ status: "unsupported", value: "" });
+      } else if (value === "USD unavailable") {
+        setUsdValue({ status: "unavailable", value });
+      } else {
+        setUsdValue({ status: "ready", value });
+      }
     });
+
     return () => {
       active = false;
     };
-  }, [amount]);
+  }, [amount, tokenSymbol]);
 
-  if (!usdValue) return null;
+  if (usdValue.status === "unsupported") return null;
 
-  return <span className="usd-amount">({usdValue})</span>;
+  if (usdValue.status === "loading") {
+    return <span className="usd-amount">USD loading...</span>;
+  }
+
+  return <span className="usd-amount">({usdValue.value})</span>;
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -148,7 +148,7 @@ async function requestBlob(path: string, options: RequestOptions = {}): Promise<
   throw formatRetryError(retryLabel, retryAttempts, message);
 }
 
-
+export async function listBounties(signal?: AbortSignal): Promise<Bounty[]> {
   const body = await requestJson<{ data: Bounty[] }>("/bounties", {
     retry: true,
     retryLabel: "Loading bounties",
@@ -162,6 +162,15 @@ export async function createBounty(payload: CreateBountyPayload): Promise<Bounty
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
+  });
+  return body.data;
+}
+
+export async function getBounty(id: string, signal?: AbortSignal): Promise<Bounty> {
+  const body = await requestJson<{ data: Bounty }>(`/bounties/${id}`, {
+    retry: true,
+    retryLabel: "Loading bounty",
+    signal,
   });
   return body.data;
 }

--- a/frontend/src/recommendations.test.ts
+++ b/frontend/src/recommendations.test.ts
@@ -1,1 +1,31 @@
 
+import { describe, expect, it } from "vitest";
+import { scoreMatch } from "./recommendations";
+import { Bounty } from "./types";
+
+const baseBounty: Bounty = {
+  id: "bounty-1",
+  repo: "ritik4ever/stellar-bounty-board",
+  issueNumber: 288,
+  title: "Add live USD conversion",
+  summary: "Fetch XLM/USD and display the converted value",
+  maintainer: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  tokenSymbol: "XLM",
+  amount: 100,
+  labels: [{ name: "frontend", color: "0e8a16" }],
+  status: "open",
+  createdAt: 1,
+  deadlineAt: 2,
+  version: 1,
+  events: [],
+};
+
+describe("scoreMatch", () => {
+  it("scores matching contributor skills against bounty labels", () => {
+    expect(scoreMatch(baseBounty, ["frontend"])).toBe(1);
+  });
+
+  it("returns zero when there is no skill overlap", () => {
+    expect(scoreMatch(baseBounty, ["rust"])).toBe(0);
+  });
+});

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -18,67 +18,6 @@ export interface ContributorProfile {
   skills: string[];
 }
 
-/**
- * Score how well a bounty matches a contributor's declared skill tags.
- * Compares the contributor's skills against the bounty's labels and (optionally) tags.
- * Returns a normalized score between 0 and 1.
- *
- * @param bounty - The bounty to evaluate
- * @param skills - Array of contributor skill strings (case-insensitive)
- * @returns Normalized match score 0-1
- */
-export function scoreMatch(bounty: Bounty, skills: string[]): number {
-  if (!skills || skills.length === 0) return 0;
-
-  // Collect all text tokens from the bounty that could indicate skill relevance
-  const bountyTokens: string[] = bounty.labels.map((l) => l.name.toLowerCase());
-
-  // Also include bounty.tags if present (used in RecommendedBounties.tsx)
-  if (Array.isArray((bounty as Record<string, unknown>).tags)) {
-    const tags = (bounty as Record<string, unknown>).tags as string[];
-    bountyTokens.push(...tags.map((t: string) => t.toLowerCase()));
-  }
-
-  // Include title and summary for broader matching
-  bountyTokens.push(bounty.title.toLowerCase());
-  bountyTokens.push(bounty.summary.toLowerCase());
-
-  // Also split multi-word tokens for partial matching
-  const expandedTokens = new Set<string>();
-  for (const token of bountyTokens) {
-    if (token.length === 0) continue;
-    expandedTokens.add(token);
-    // Split on non-alphanumeric boundaries to catch e.g. "react" in "react-native"
-    for (const part of token.split(/[^a-z0-9#+.]+/)) {
-      if (part.length >= 2) expandedTokens.add(part);
-    }
-  }
-
-  // Normalize skills to lower case
-  const normalizedSkills = skills.map((s) => s.toLowerCase().trim()).filter(Boolean);
-
-  if (normalizedSkills.length === 0) return 0;
-
-  // Count matching skills
-  let matchCount = 0;
-  for (const skill of normalizedSkills) {
-    // Check exact match in any token
-    if (expandedTokens.has(skill)) {
-      matchCount++;
-      continue;
-    }
-    // Check if skill is contained within any token (e.g. skill "js" in "node.js")
-    for (const token of expandedTokens) {
-      if (token.includes(skill) || skill.includes(token)) {
-        matchCount++;
-        break;
-      }
-    }
-  }
-
-  return normalizedSkills.length > 0 ? matchCount / normalizedSkills.length : 0;
-}
-
 const LABEL_WEIGHTS: Record<string, number> = {
   "help wanted": 0.8,
   "good first issue": 0.9,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -36,6 +36,7 @@ export interface Bounty {
   tokenSymbol: string;
   amount: number;
   labels: GithubLabel[];
+  tags?: string[];
 
   status: BountyStatus;
   createdAt: number;

--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { xlmToUsd, resetXlmToUsdCache } from "./utils";
+import { tokenAmountToUsd, xlmToUsd, resetXlmToUsdCache } from "./utils";
 
 describe("xlmToUsd", () => {
   const fetchMock = vi.fn();
@@ -43,5 +43,28 @@ describe("xlmToUsd", () => {
     fetchMock.mockRejectedValue(new Error("network unavailable"));
 
     await expect(xlmToUsd(100)).resolves.toBe("USD unavailable");
+  });
+
+  it("falls back to the last known XLM/USD rate when refresh fails", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stellar: { usd: 0.1 } }),
+      });
+      await expect(xlmToUsd(100)).resolves.toBe("$10.00");
+
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      fetchMock.mockRejectedValueOnce(new Error("network unavailable"));
+
+      await expect(xlmToUsd(50)).resolves.toBe("$5.00");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("converts USDC amounts at a 1:1 USD rate without fetching XLM prices", async () => {
+    await expect(tokenAmountToUsd(21.8, "USDC")).resolves.toBe("$21.80");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -156,16 +156,14 @@ export function getActiveRewardLabel(
 const XLM_USD_PRICE_URL =
   "https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd";
 const XLM_USD_CACHE_MS = 5 * 60 * 1000;
+const XLM_USD_FETCH_TIMEOUT_MS = 5000;
 
 let cachedXlmUsdRate: { rate: number; fetchedAt: number } | null = null;
+let pendingXlmUsdRateRequest: Promise<number> | null = null;
 
 async function fetchXlmUsdRate(): Promise<number> {
-  if (cachedXlmUsdRate && Date.now() - cachedXlmUsdRate.fetchedAt < XLM_USD_CACHE_MS) {
-    return cachedXlmUsdRate.rate;
-  }
-
   const controller = new AbortController();
-  const timeoutId = window.setTimeout(() => controller.abort(), 5000);
+  const timeoutId = window.setTimeout(() => controller.abort(), XLM_USD_FETCH_TIMEOUT_MS);
 
   try {
     const response = await fetch(XLM_USD_PRICE_URL, { signal: controller.signal });
@@ -187,22 +185,56 @@ async function fetchXlmUsdRate(): Promise<number> {
   }
 }
 
-export async function xlmToUsd(amount: number): Promise<string> {
+export async function getXlmUsdRate(): Promise<number | null> {
+  if (cachedXlmUsdRate && Date.now() - cachedXlmUsdRate.fetchedAt < XLM_USD_CACHE_MS) {
+    return cachedXlmUsdRate.rate;
+  }
+
+  pendingXlmUsdRateRequest ??= fetchXlmUsdRate().finally(() => {
+    pendingXlmUsdRateRequest = null;
+  });
+
   try {
-    const rate = await fetchXlmUsdRate();
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(amount * rate);
+    return await pendingXlmUsdRateRequest;
   } catch {
+    return cachedXlmUsdRate?.rate ?? null;
+  }
+}
+
+export function formatUsdValue(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export async function xlmToUsd(amount: number): Promise<string> {
+  const rate = await getXlmUsdRate();
+  if (rate === null) {
     return "USD unavailable";
+  }
+  return formatUsdValue(amount * rate);
+}
+
+export async function tokenAmountToUsd(
+  amount: number,
+  tokenSymbol: string
+): Promise<string | null> {
+  switch (tokenSymbol.toUpperCase()) {
+    case "USDC":
+      return formatUsdValue(amount);
+    case "XLM":
+      return xlmToUsd(amount);
+    default:
+      return null;
   }
 }
 
 export function resetXlmToUsdCache(): void {
   cachedXlmUsdRate = null;
+  pendingXlmUsdRateRequest = null;
 }
 
 export function getContributorMetrics(bounties: Bounty[], contributorAddress?: string) {
@@ -247,40 +279,9 @@ export function getContributorMetrics(bounties: Bounty[], contributorAddress?: s
   };
 }
 
-let cachedRate: number | null = null;
-let cacheTimestamp: number = 0;
-let pendingRequest: Promise<number | null> | null = null;
-const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
-
 /**
  * Fetches the current XLM/USD rate from CoinGecko with a 5-minute cache.
  */
 export async function getXlmRate(): Promise<number | null> {
-  const now = Date.now();
-  if (cachedRate !== null && now - cacheTimestamp < CACHE_DURATION) {
-    return cachedRate;
-  }
-
-  if (pendingRequest) return pendingRequest;
-
-  pendingRequest = (async () => {
-    try {
-      const response = await fetch(
-        "https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd"
-      );
-      if (!response.ok) throw new Error("API response not ok");
-      const data = await response.json();
-      cachedRate = data.stellar.usd;
-      cacheTimestamp = Date.now();
-      return cachedRate;
-    } catch (error) {
-      console.error("Failed to fetch XLM/USD rate:", error);
-      // Fallback to last known rate if available
-      return cachedRate;
-    } finally {
-      pendingRequest = null;
-    }
-  })();
-
-  return pendingRequest;
+  return getXlmUsdRate();
 }


### PR DESCRIPTION
## Summary
- fetch XLM/USD from CoinGecko with a 5-minute module-level cache and last-known-rate fallback
- show a loading state while USD conversion is resolving and keep USDC display at 1:1
- reuse `UsdAmount` across list, recommendations, and detail views
- fix small pre-existing frontend build/test blockers that prevented local validation: restore `listBounties`/`getBounty` exports, detail-page imports/copy metadata, duplicate `scoreMatch`, and empty recommendation test file

Closes #288

## Validation
- `npm test -- --run`
- `npm run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added copy-to-clipboard functionality for bounty IDs and maintainer details
  * Extended USD conversion support to handle multiple token types (XLM and USDC)
  * Improved loading states and feedback during currency conversion operations

* **Improvements**
  * Refined bounty recommendation matching algorithm for better accuracy

* **Tests**
  * Added comprehensive test coverage for USD conversion and bounty matching logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->