### PR TITLE
Add expiration status badge color states

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,6 +46,7 @@ import BountyDetailPage from "./BountyDetailPage";
 import UsdAmount from "./UsdAmount";
 
 import SkeletonBountyCard from "./SkeletonBountyCard";
+import { getExpirationStatusBadge } from "./expirationStatus";
 
 const STELLAR_PUBLIC_KEY_HINT = "Expected Stellar public key (starts with G and is 56 characters).";
 const STELLAR_PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
@@ -170,6 +171,16 @@ function BountyAmount({ bounty }: { bounty: Bounty }) {
       <strong>{bounty.amount} {bounty.tokenSymbol}</strong>
       {usdAmount && <span>{usdAmount}</span>}
     </div>
+  );
+}
+
+function ExpirationStatusPill({ bounty }: { bounty: Bounty }) {
+  const badge = getExpirationStatusBadge(bounty.status, bounty.deadlineAt);
+
+  return (
+    <span className={badge.className} title={badge.title} aria-label={badge.ariaLabel}>
+      {badge.label}
+    </span>
   );
 }
 
@@ -1108,13 +1119,7 @@ placeholder="help wanted, backend"
                 >
                   <div className="bounty-card__top">
                     <div>
-                      <span
-                        className={`status-pill status-pill--${bounty.status}`}
-                        title={statusCopy[bounty.status].description}
-                        aria-label={`${statusCopy[bounty.status].label}: ${statusCopy[bounty.status].description}`}
-                      >
-                        {statusCopy[bounty.status].label}
-                      </span>
+                      <ExpirationStatusPill bounty={bounty} />
                       <h3>{bounty.title}</h3>
                     </div>
 
@@ -1347,7 +1352,7 @@ placeholder="help wanted, backend"
                 <article className="bounty-card" key={bounty.id}>
                   <div className="bounty-card__top">
                     <div>
-                      <span className={`status-pill status-pill--${bounty.status}`}>{bounty.status}</span>
+                      <ExpirationStatusPill bounty={bounty} />
                       <h3>{bounty.title}</h3>
                     </div>
                     <BountyAmount bounty={bounty} />

--- a/frontend/src/expirationStatus.test.ts
+++ b/frontend/src/expirationStatus.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { getExpirationStatusBadge } from "./expirationStatus";
+
+const NOW = 1_700_000_000;
+const DAY_SECONDS = 24 * 60 * 60;
+
+describe("getExpirationStatusBadge", () => {
+  it("returns a green badge for open bounties with more than 7 days remaining", () => {
+    expect(getExpirationStatusBadge("open", NOW + 8 * DAY_SECONDS, NOW)).toMatchInlineSnapshot(`
+      {
+        "ariaLabel": "Open: more than 7 days left",
+        "className": "status-pill status-pill--expiration-green",
+        "label": "Open - more than 7 days left",
+        "title": "Open: more than 7 days left",
+        "tone": "green",
+      }
+    `);
+  });
+
+  it("returns a yellow badge for active bounties with 1-7 days remaining", () => {
+    expect(getExpirationStatusBadge("reserved", NOW + 3 * DAY_SECONDS, NOW)).toMatchInlineSnapshot(`
+      {
+        "ariaLabel": "Reserved: 1-7 days left",
+        "className": "status-pill status-pill--expiration-yellow",
+        "label": "Reserved - 1-7 days left",
+        "title": "Reserved: 1-7 days left",
+        "tone": "yellow",
+      }
+    `);
+  });
+
+  it("returns a red badge for active bounties with less than 24 hours remaining", () => {
+    expect(getExpirationStatusBadge("open", NOW + 12 * 60 * 60, NOW)).toMatchInlineSnapshot(`
+      {
+        "ariaLabel": "Open: less than 24 hours left",
+        "className": "status-pill status-pill--expiration-red",
+        "label": "Open - less than 24 hours left",
+        "title": "Open: less than 24 hours left",
+        "tone": "red",
+      }
+    `);
+  });
+
+  it("returns a grey badge for terminal bounty states", () => {
+    expect(getExpirationStatusBadge("released", NOW + 8 * DAY_SECONDS, NOW)).toMatchInlineSnapshot(`
+      {
+        "ariaLabel": "Released: closed",
+        "className": "status-pill status-pill--expiration-grey",
+        "label": "Released - closed",
+        "title": "Released: closed",
+        "tone": "grey",
+      }
+    `);
+  });
+
+  it("returns a blue badge for disputed bounties", () => {
+    expect(getExpirationStatusBadge("disputed", NOW + 8 * DAY_SECONDS, NOW)).toMatchInlineSnapshot(`
+      {
+        "ariaLabel": "Disputed: under dispute",
+        "className": "status-pill status-pill--expiration-blue",
+        "label": "Disputed - under dispute",
+        "title": "Disputed: under dispute",
+        "tone": "blue",
+      }
+    `);
+  });
+});

--- a/frontend/src/expirationStatus.ts
+++ b/frontend/src/expirationStatus.ts
@@ -1,0 +1,70 @@
+import { BountyStatus } from "./types";
+
+const DAY_SECONDS = 24 * 60 * 60;
+
+export type ExpirationBadgeStatus = BountyStatus | "disputed";
+export type ExpirationBadgeTone = "green" | "yellow" | "red" | "grey" | "blue" | "default";
+
+export interface ExpirationStatusBadge {
+  tone: ExpirationBadgeTone;
+  className: string;
+  label: string;
+  title: string;
+  ariaLabel: string;
+}
+
+const STATUS_LABELS: Record<ExpirationBadgeStatus, string> = {
+  open: "Open",
+  reserved: "Reserved",
+  submitted: "Submitted",
+  released: "Released",
+  refunded: "Refunded",
+  expired: "Expired",
+  disputed: "Disputed",
+};
+
+function makeBadge(status: ExpirationBadgeStatus, tone: ExpirationBadgeTone, detail: string): ExpirationStatusBadge {
+  const label = `${STATUS_LABELS[status]} - ${detail}`;
+  const title = `${STATUS_LABELS[status]}: ${detail}`;
+
+  return {
+    tone,
+    className:
+      tone === "default"
+        ? `status-pill status-pill--${status}`
+        : `status-pill status-pill--expiration-${tone}`,
+    label,
+    title,
+    ariaLabel: title,
+  };
+}
+
+export function getExpirationStatusBadge(
+  status: ExpirationBadgeStatus,
+  deadlineAt: number,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): ExpirationStatusBadge {
+  if (status === "disputed") {
+    return makeBadge(status, "blue", "under dispute");
+  }
+
+  if (status === "expired" || status === "released" || status === "refunded") {
+    return makeBadge(status, "grey", "closed");
+  }
+
+  if (status !== "open" && status !== "reserved") {
+    return makeBadge(status, "default", "in review");
+  }
+
+  const secondsRemaining = deadlineAt - nowSeconds;
+
+  if (secondsRemaining < DAY_SECONDS) {
+    return makeBadge(status, "red", "less than 24 hours left");
+  }
+
+  if (secondsRemaining <= 7 * DAY_SECONDS) {
+    return makeBadge(status, "yellow", "1-7 days left");
+  }
+
+  return makeBadge(status, "green", "more than 7 days left");
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1058,6 +1058,31 @@ select {
   color: #8b4035;
 }
 
+.status-pill--expiration-green {
+  background: #e4f6ec;
+  color: #25634b;
+}
+
+.status-pill--expiration-yellow {
+  background: #fff0d8;
+  color: #8a5219;
+}
+
+.status-pill--expiration-red {
+  background: #f7e5e2;
+  color: #893f36;
+}
+
+.status-pill--expiration-grey {
+  background: rgba(54, 63, 59, 0.08);
+  color: var(--muted);
+}
+
+.status-pill--expiration-blue {
+  background: #e4eefb;
+  color: #234a7c;
+}
+
 .amount-chip {
   background: var(--ink);
   color: #fff7ef;


### PR DESCRIPTION
Closes #376

## Root cause
The bounty card rendered a generic status pill from `bounty.status`, so contributors could not scan deadline urgency quickly. Color alone also would not be enough for accessibility unless the visible text carried the same meaning.

## Approach
- Added a focused `getExpirationStatusBadge` helper that maps status + deadline into a badge tone and visible label.
- Wired the bounty cards to render labels such as `Open - more than 7 days left`, `Reserved - 1-7 days left`, and `Open - less than 24 hours left`.
- Added CSS tones for green, yellow, red, grey, and blue.
- Added inline Vitest snapshot coverage for every requested color state.

## Security
- UI-only change: no wallet, signing, payout, API, or storage behavior changed.
- Badge text is derived from enum-like status values and numeric timestamps; it does not render user-provided HTML.
- The helper is isolated and deterministic, which keeps future status changes easier to review.

## Validation
- `npm --prefix frontend test -- expirationStatus.test.ts`

`npm --prefix frontend run build` is currently blocked by an unrelated existing syntax error in `frontend/src/api.ts:158` before this badge code is checked.

Disclosure: This PR was prepared with AI assistance through Codex. I reviewed the diff and am submitting it under my GitHub account.