### PR TITLE
[code] Add aria-live bounty status announcements

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, ReactNode, useEffect, useMemo, useState } from "react";
+import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowUpRight,
   Coins,
@@ -44,6 +44,11 @@ import { Bounty, CreateBountyPayload, OpenIssue, BountyStatus } from "./types";
 import GitHubIssuePreviewCard from "./GitHubIssuePreviewCard";
 import BountyDetailPage from "./BountyDetailPage";
 import UsdAmount from "./UsdAmount";
+import {
+  getBountyStatusAnnouncement,
+  StatusAnnouncement,
+  useStatusAnnouncement,
+} from "./statusAnnouncements";
 
 import SkeletonBountyCard from "./SkeletonBountyCard";
 
@@ -178,6 +183,8 @@ function App() {
   const initialFilters = useMemo(() => readInitialFilters(), []);
   const [form, setForm] = useState<CreateBountyPayload>(initialForm);
   const [bounties, setBounties] = useState<Bounty[]>([]);
+  const bountiesRef = useRef<Bounty[]>([]);
+  const { announcement: statusAnnouncement, announceStatus } = useStatusAnnouncement();
   const [issues, setIssues] = useState<OpenIssue[]>([]);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
@@ -216,8 +223,13 @@ function App() {
       listBounties(signal),
       listOpenIssues(signal),
     ]);
+    const statusMessage = getBountyStatusAnnouncement(bountiesRef.current, bountyData);
     setBounties(bountyData);
+    bountiesRef.current = bountyData;
     setIssues(issueData);
+    if (statusMessage) {
+      announceStatus(statusMessage);
+    }
   }
 
   useEffect(() => {
@@ -612,6 +624,7 @@ function App() {
     <div className="page-shell">
       <div className="glow glow-left" />
       <div className="glow glow-right" />
+      <StatusAnnouncement announcement={statusAnnouncement} />
 
       <header className="hero">
         <button

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -81,6 +81,18 @@ textarea {
   font: inherit;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .page-shell {
   position: relative;
   max-width: 1240px;

--- a/frontend/src/statusAnnouncements.test.tsx
+++ b/frontend/src/statusAnnouncements.test.tsx
@@ -1,0 +1,56 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getBountyStatusAnnouncement,
+  STATUS_ANNOUNCEMENT_CLEAR_MS,
+  StatusAnnouncement,
+  useStatusAnnouncement,
+} from "./statusAnnouncements";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function AnnouncementHarness() {
+  const { announcement, announceStatus } = useStatusAnnouncement();
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => announceStatus("Bounty #42 status changed to Reserved")}
+      >
+        Mock status change
+      </button>
+      <StatusAnnouncement announcement={announcement} />
+    </>
+  );
+}
+
+describe("status announcements", () => {
+  it("formats the first detected bounty status change", () => {
+    const message = getBountyStatusAnnouncement(
+      [{ id: "bounty-1", issueNumber: 42, status: "open" }],
+      [{ id: "bounty-1", issueNumber: 42, status: "reserved" }],
+    );
+
+    expect(message).toBe("Bounty #42 status changed to Reserved");
+  });
+
+  it("announces a mocked status change and clears it after 3 seconds", () => {
+    vi.useFakeTimers();
+
+    render(<AnnouncementHarness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Mock status change" }));
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Bounty #42 status changed to Reserved",
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(STATUS_ANNOUNCEMENT_CLEAR_MS);
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent("");
+  });
+});

--- a/frontend/src/statusAnnouncements.tsx
+++ b/frontend/src/statusAnnouncements.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+import type { BountyStatus } from "./types";
+
+export const STATUS_ANNOUNCEMENT_CLEAR_MS = 3000;
+
+const statusLabels: Record<BountyStatus, string> = {
+  open: "Open",
+  reserved: "Reserved",
+  submitted: "Submitted",
+  released: "Released",
+  refunded: "Refunded",
+  expired: "Expired",
+};
+
+type AnnounceableBounty = {
+  id: string;
+  issueNumber: number;
+  status: BountyStatus;
+};
+
+export function formatStatusAnnouncement(bounty: AnnounceableBounty): string {
+  return `Bounty #${bounty.issueNumber} status changed to ${statusLabels[bounty.status]}`;
+}
+
+export function getBountyStatusAnnouncement(
+  previousBounties: ReadonlyArray<AnnounceableBounty>,
+  nextBounties: ReadonlyArray<AnnounceableBounty>,
+): string | null {
+  const previousStatusById = new Map(
+    previousBounties.map((bounty) => [bounty.id, bounty.status]),
+  );
+
+  const changedBounty = nextBounties.find((bounty) => {
+    const previousStatus = previousStatusById.get(bounty.id);
+    return previousStatus !== undefined && previousStatus !== bounty.status;
+  });
+
+  return changedBounty ? formatStatusAnnouncement(changedBounty) : null;
+}
+
+export function useStatusAnnouncement(clearMs = STATUS_ANNOUNCEMENT_CLEAR_MS) {
+  const [announcement, setAnnouncement] = useState("");
+
+  useEffect(() => {
+    if (!announcement) return;
+
+    const timer = window.setTimeout(() => setAnnouncement(""), clearMs);
+    return () => window.clearTimeout(timer);
+  }, [announcement, clearMs]);
+
+  return {
+    announcement,
+    announceStatus: setAnnouncement,
+  };
+}
+
+export function StatusAnnouncement({ announcement }: { announcement: string }) {
+  return (
+    <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+      {announcement}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #383

Replaces #403 after branch naming cleanup.

## Root cause
The board refreshes bounty data during live sessions, but it did not compare previous and next bounty statuses and had no screen-reader-only status message for those changes.

## What changed
- Added a small status announcement module for formatting, change detection, timed clearing, and live-region rendering.
- Added a hidden polite live region to the app layout.
- Compared previous bounty statuses during refresh so polling/manual refreshes announce real status transitions.
- Added an sr-only utility and Vitest coverage for the mocked status-change announcement and 3-second clear.

## Security review
The announcement text is generated from a bounty issue number plus a local status enum label and rendered as plain React text. It does not include maintainer/contributor addresses, transaction hashes, secrets, or user-provided HTML, so the change does not expand data exposure or injection risk.

## Verification
- PASS: npm --prefix frontend test -- statusAnnouncements.test.tsx
- PASS: git diff --check
- Known existing blocker: npm --prefix frontend run build still fails before this change at frontend/src/api.ts(158,1): error TS1128: Declaration or statement expected.

Disclosure: this PR was prepared with AI assistance. I reviewed the diff and am submitting it under my GitHub account.