### PR TITLE
Add Stellar secret key log redaction

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,10 @@ Only the latest version of the Stellar Bounty Board is currently supported with 
 
 If you discover a potential security issue, please report it privately by emailing [Insert Email or Use GitHub Private Reporting]. We appreciate your help in keeping the Stellar ecosystem safe.
 
+## Logging Secrets
+Never log Stellar secret keys or seed phrases. Backend logging redacts common secret fields (`secretKey`, `privateKey`, `seed`, `token`, `apiKey`, and related header fields) and any Stellar secret-key shaped value before output. Keep public account IDs visible for debugging, but move any private material through secure storage or request-scoped memory only.
+
 ### Our Commitment
 * **Acknowledge:** We will acknowledge receipt of your report within **48 hours** (SLA).
 * **Triage:** We will provide a status update after initial triage.
 * **Disclosure:** We follow a responsible disclosure timeline of **90 days** before public release, though we aim to fix critical issues much faster.
-￼Enter

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -1,6 +1,71 @@
-import pino from "pino";
+import pino, { type DestinationStream, type LoggerOptions } from "pino";
 
 const isDev = process.env.NODE_ENV !== "production";
+const REDACTED = "[redacted]";
+const STELLAR_SECRET_KEY_PATTERN = /S[A-Z2-7]{55}/g;
+
+function redactStellarSecretText(value: string): string {
+  return value.replace(STELLAR_SECRET_KEY_PATTERN, REDACTED);
+}
+
+function redactLogValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (typeof value === "string") {
+    return redactStellarSecretText(value);
+  }
+
+  if (value instanceof Error) {
+    const redactedError = new Error(redactStellarSecretText(value.message));
+    redactedError.name = value.name;
+    redactedError.stack = value.stack ? redactStellarSecretText(value.stack) : value.stack;
+    return redactedError;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactLogValue(item, seen));
+  }
+
+  if (value && typeof value === "object") {
+    if (seen.has(value)) {
+      return value;
+    }
+
+    seen.add(value);
+
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, redactLogValue(entry, seen)]),
+    );
+  }
+
+  return value;
+}
+
+const loggerOptions: LoggerOptions = {
+  level: process.env.LOG_LEVEL ?? "info",
+  redact: {
+    paths: [
+      "req.headers.authorization",
+      "req.headers.cookie",
+      "*.password",
+      "*.secret",
+      "*.token",
+      "*.apiKey",
+      "*.api_key",
+      "*.Authorization",
+      "*.secretKey",
+      "*.privateKey",
+      "*.seed",
+    ],
+    censor: REDACTED,
+  },
+  hooks: {
+    logMethod(args, method) {
+      (method as (...methodArgs: unknown[]) => void).apply(
+        this,
+        args.map((arg) => redactLogValue(arg)),
+      );
+    },
+  },
+};
 
 /**
  * Pino logger instance.
@@ -8,33 +73,26 @@ const isDev = process.env.NODE_ENV !== "production";
  * - Development: pretty-printed, human-readable output via pino-pretty.
  * - Production:  single-line JSON, ready for log aggregators.
  *
- * Sensitive fields (Authorization, cookie, password, secret, token, api_key)
- * are redacted at the serializer level so they never appear in any log output.
+ * Sensitive fields and Stellar secret keys are redacted before they reach
+ * log output.
  */
-export const logger = pino(
-  {
-    level: process.env.LOG_LEVEL ?? "info",
-    redact: {
-      paths: [
-        "req.headers.authorization",
-        "req.headers.cookie",
-        "*.password",
-        "*.secret",
-        "*.token",
-        "*.apiKey",
-        "*.api_key",
-        "*.Authorization",
-      ],
-      censor: "[redacted]",
-    },
-  },
-  isDev
-    ? pino.transport({
-        target: "pino-pretty",
-        options: { colorize: true, translateTime: "SYS:standard", ignore: "pid,hostname" },
-      })
-    : undefined,
-);
+export function createLogger(destination?: DestinationStream) {
+  if (destination) {
+    return pino(loggerOptions, destination);
+  }
+
+  return pino(
+    loggerOptions,
+    isDev
+      ? pino.transport({
+          target: "pino-pretty",
+          options: { colorize: true, translateTime: "SYS:standard", ignore: "pid,hostname" },
+        })
+      : undefined,
+  );
+}
+
+export const logger = createLogger();
 
 // ── Legacy shim ─────────────────────────────────────────────────────────────
 // Keeps existing callers of `logStructured` working without changes.

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -716,5 +716,26 @@ export interface LeaderboardEntry {
   bountiesCompleted: number;
 }
 
+export function getLeaderboard(limit = 10): LeaderboardEntry[] {
+  const entriesByContributor = new Map<string, LeaderboardEntry>();
 
+  for (const bounty of listBounties()) {
+    if (bounty.status !== "released" || !bounty.contributor) {
+      continue;
+    }
+
+    const entry = entriesByContributor.get(bounty.contributor) ?? {
+      address: bounty.contributor,
+      totalXlm: 0,
+      bountiesCompleted: 0,
+    };
+
+    entry.totalXlm += bounty.amount;
+    entry.bountiesCompleted += 1;
+    entriesByContributor.set(bounty.contributor, entry);
+  }
+
+  return [...entriesByContributor.values()]
+    .sort((left, right) => right.totalXlm - left.totalXlm || right.bountiesCompleted - left.bountiesCompleted)
+    .slice(0, limit);
 }

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -2,6 +2,12 @@ import type { RequestHandler } from "express";
 import { rateLimit } from "express-rate-limit";
 import { StrKey } from "@stellar/stellar-sdk";
 
+export const SOROBAN_ADDRESS_REGEX = /^C[A-Z2-7]{55}$/;
+
+export function isValidStellarAddress(address: string): boolean {
+  return StrKey.isValidEd25519PublicKey(address);
+}
+
 /** Bypass strict limits in automated tests so suites can hit POST routes freely. */
 export const limiter: RequestHandler =
   process.env.NODE_ENV === "test"
@@ -13,7 +19,3 @@ export const limiter: RequestHandler =
         legacyHeaders: false,
         ipv6Subnet: 56,
       });
-
-/**
-
-}

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -2,6 +2,7 @@ import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 
 import { githubPrUrlSchema } from "./prUrl";
+import { isValidStellarAddress, SOROBAN_ADDRESS_REGEX } from "../utils";
 
 extendZodWithOpenApi(z);
 
@@ -74,7 +75,7 @@ export const createBountySchema = z
       .openapi({ example: "XLM", description: "Stellar token symbol for payout (1–12 alphanumeric chars)." }),
     amount: z.coerce
       .number()
-      .min(1, "Amount must be at least 1 XLM.")
+      .min(1, "Amount must be at least 1 XLM."),
 
     deadlineDays: z.coerce
       .number()
@@ -122,6 +123,14 @@ export const submitBountySchema = z
     contributor: stellarAccountSchema.openapi({
       description: "Must match the contributor who reserved the bounty.",
     }),
+    submissionUrl: z
+      .string()
+      .trim()
+      .url()
+      .openapi({
+        example: "https://github.com/owner/repo/pull/99",
+        description: "GitHub pull request URL submitted for this bounty.",
+      }),
 
     notes: z
       .string()

--- a/backend/test/logger.test.ts
+++ b/backend/test/logger.test.ts
@@ -1,0 +1,49 @@
+import { Writable } from "node:stream";
+import { describe, expect, it } from "vitest";
+
+import { createLogger } from "../src/logger";
+
+const STELLAR_SECRET_KEY = `S${"A".repeat(55)}`;
+
+function createCapturedLogger() {
+  const chunks: string[] = [];
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk.toString());
+      callback();
+    },
+  });
+
+  return {
+    logger: createLogger(stream),
+    output: () => chunks.join(""),
+  };
+}
+
+describe("logger redaction", () => {
+  it("redacts Stellar secret keys from structured fields and text messages", () => {
+    const { logger, output } = createCapturedLogger();
+
+    logger.error(
+      {
+        secretKey: STELLAR_SECRET_KEY,
+        privateKey: STELLAR_SECRET_KEY,
+        seed: STELLAR_SECRET_KEY,
+        nested: { error: `Transaction failed for ${STELLAR_SECRET_KEY}` },
+      },
+      `failed to process ${STELLAR_SECRET_KEY}`,
+    );
+
+    expect(output()).not.toContain(STELLAR_SECRET_KEY);
+    expect(output()).toContain("[redacted]");
+  });
+
+  it("does not redact Stellar public keys", () => {
+    const publicKey = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+    const { logger, output } = createCapturedLogger();
+
+    logger.info({ publicKey }, "public account is safe to log");
+
+    expect(output()).toContain(publicKey);
+  });
+});

--- a/backend/test/utils.test.ts
+++ b/backend/test/utils.test.ts
@@ -1,1 +1,10 @@
 
+import { describe, expect, it } from "vitest";
+
+import { limiter } from "../src/utils";
+
+describe("utils", () => {
+  it("exports the rate limiter middleware", () => {
+    expect(typeof limiter).toBe("function");
+  });
+});


### PR DESCRIPTION
Replaces #399 after branch naming cleanup.

Closes #381

## Root cause
The logger redacted generic secret-like fields, but Stellar secret-key shaped values (`S...`) could still leak when they appeared in error messages, nested log payloads, or fields such as `secretKey`, `privateKey`, and `seed`.

## Approach
- Added a small logger sanitization layer before pino writes log arguments.
- Redacted Stellar secret-key shaped strings wherever they appear in structured payloads, arrays, error objects, or message text.
- Extended pino field redaction for `secretKey`, `privateKey`, and `seed`.
- Added focused logger tests and documented secret logging expectations in `SECURITY.md`.
- Repaired minimal backend compile/test blockers encountered while validating this change: malformed utility/schema syntax, missing `submissionUrl` typing, empty `utils.test.ts`, and missing leaderboard export used by existing routes/tests.

## Security
- Prevents accidental plaintext Stellar private key exposure in backend logs.
- Keeps public Stellar account IDs visible for debugging.
- Does not change wallet signing, transaction creation, custody, or payout behavior.
- The redaction is defensive and applies before log output, so both structured and text logs are covered.

## Validation
- `npm --prefix backend test -- logger.test.ts utils.test.ts leaderboard.test.ts`
- `npm --prefix backend run build`

Full `npm --prefix backend test` still has unrelated pre-existing failures in auth middleware, expiry, and amount validation tests. I left those outside this PR so the redaction change stays reviewable.

Disclosure: this PR was prepared with AI assistance. I reviewed the diff and am submitting it under my GitHub account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Application logs now automatically redact sensitive credentials to prevent accidental exposure.

* **New Features**
  * Added leaderboard feature displaying top contributors ranked by total earnings and bounties completed.
  * Bounty submissions now support URL submission tracking.

* **Documentation**
  * Updated security guidelines with logging best practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->