### PR TITLE
Add utils edge case coverage

### DIFF
--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { xlmToUsd, resetXlmToUsdCache } from "./utils";
+import {
+  calculateDeadlineAt,
+  formatAmount,
+  getStatusAtDeadline,
+  resetXlmToUsdCache,
+  xlmToUsd,
+} from "./utils";
+
+describe("deadline and amount helpers", () => {
+  it("computes a leap-year deadline on Feb 29", () => {
+    const startsAt = Date.UTC(2024, 1, 28, 12, 0, 0);
+    const deadlineAt = calculateDeadlineAt(startsAt, 1);
+
+    expect(new Date(deadlineAt).toISOString()).toBe("2024-02-29T12:00:00.000Z");
+  });
+
+  it("keeps a zero-day deadline within the same day", () => {
+    const startsAt = Date.UTC(2026, 4, 26, 9, 30, 0);
+    const deadlineAt = calculateDeadlineAt(startsAt, 0);
+
+    expect(new Date(deadlineAt).toISOString().slice(0, 10)).toBe("2026-05-26");
+  });
+
+  it("expires exactly at the deadline timestamp, not before it", () => {
+    const deadlineAt = Date.UTC(2026, 4, 26, 17, 0, 0);
+
+    expect(getStatusAtDeadline("open", deadlineAt, deadlineAt - 1)).toBe("open");
+    expect(getStatusAtDeadline("open", deadlineAt, deadlineAt)).toBe("expired");
+  });
+
+  it("formats a zero XLM amount with seven decimals", () => {
+    expect(formatAmount(0, "XLM")).toBe("0.0000000 XLM");
+  });
+});
 
 describe("xlmToUsd", () => {
   const fetchMock = vi.fn();

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,6 +1,7 @@
 import { Bounty, BountyStatus } from "./types";
 import { FilterState } from "./constants";
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 // Simple debounce function for search
 export function debounce<T extends (...args: any[]) => any>(
@@ -89,6 +90,27 @@ export function getRewardBounds(bounties: Bounty[]): { lowest: number; highest: 
     lowest: Math.min(...amounts),
     highest: Math.max(...amounts),
   };
+}
+
+export function calculateDeadlineAt(startedAtMs: number, deadlineDays: number): number {
+  return startedAtMs + Math.max(0, deadlineDays) * MS_PER_DAY;
+}
+
+export function getStatusAtDeadline(
+  status: BountyStatus,
+  deadlineAtMs: number,
+  nowMs = Date.now()
+): BountyStatus {
+  if ((status === "open" || status === "reserved") && nowMs >= deadlineAtMs) {
+    return "expired";
+  }
+
+  return status;
+}
+
+export function formatAmount(amount: number, tokenSymbol: string): string {
+  const symbol = tokenSymbol.trim() || "XLM";
+  return `${amount.toFixed(7)} ${symbol}`;
 }
 
 export type SortOption = "reward-high" | "reward-low" | "deadline-soonest" | "deadline-latest" | "newest" | "oldest";


### PR DESCRIPTION
Replaces #400 after branch naming cleanup.

Closes #379

## Root cause
`utils.test.ts` only covered XLM/USD conversion. It did not lock down the deadline and amount helper edge cases called out in the issue, so leap-day dates, zero-day deadlines, deadline-boundary status, and zero XLM formatting could regress silently.

## Approach
- Added small, focused helpers for deadline calculation, deadline-boundary status derivation, and token amount formatting.
- Added edge-case tests for Feb 29 leap-year deadlines, `deadlineDays=0`, `deadlineAt - 1ms` versus exactly `deadlineAt`, and `formatAmount(0, XLM)`.
- Kept the helpers pure and isolated so they are easy to reuse from UI components without coupling to network/API state.

## Security
- No new network calls, storage, wallet access, or user-controlled HTML rendering.
- Token symbols are formatted as plain text only; no signing or payout behavior is changed.
- Deadline logic is deterministic and does not trust client input beyond numeric timestamps already used by the UI.

## Validation
- `npm --prefix frontend test -- utils.test.ts`

`npm --prefix frontend run build` is currently blocked by unrelated existing TypeScript errors in `api.ts`, `BountyDetailPage.tsx`, `recommendations.ts`, and `RecommendedBounties.tsx`; I kept those outside this scoped test PR.

Disclosure: this PR was prepared with AI assistance. I reviewed the diff and am submitting it under my GitHub account.