### PR TITLE
Add configurable multi-token bounty release support

### DIFF
--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -42,6 +42,7 @@ export interface BountyRecord {
   maintainer: string;
   contributor?: string;
   tokenSymbol: string;
+  tokenAddress?: string;
   amount: number;
   labels: string[];
   status: BountyStatus;
@@ -113,6 +114,7 @@ const sampleBounties: BountyRecord[] = [
     maintainer: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
     contributor: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
     tokenSymbol: "XLM",
+    tokenAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
     amount: 150,
     labels: ["help wanted", "realtime"],
     status: "reserved",
@@ -135,6 +137,7 @@ const sampleBounties: BountyRecord[] = [
       "Create a contributor-facing export view for released payouts with CSV download and per-asset grouping.",
     maintainer: "GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
     tokenSymbol: "USDC",
+    tokenAddress: "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
     amount: 220,
     labels: ["frontend", "analytics"],
     status: "open",
@@ -148,6 +151,35 @@ const sampleBounties: BountyRecord[] = [
 
 function nowInSeconds(): number {
   return Math.floor(Date.now() / 1000);
+}
+
+const DEFAULT_TOKEN_ADDRESS_MAP: Record<string, string> = {
+  XLM: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  USDC: "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+};
+
+function getTokenAddressMap(): Record<string, string> {
+  const configured = process.env.TOKEN_ADDRESS_MAP?.trim();
+  if (!configured) {
+    return DEFAULT_TOKEN_ADDRESS_MAP;
+  }
+
+  const parsed = JSON.parse(configured) as Record<string, string>;
+  return {
+    ...DEFAULT_TOKEN_ADDRESS_MAP,
+    ...Object.fromEntries(Object.entries(parsed).map(([symbol, address]) => [symbol.toUpperCase(), address])),
+  };
+}
+
+export function resolveTokenAddress(tokenSymbol: string): { tokenSymbol: string; tokenAddress: string } {
+  const normalizedSymbol = tokenSymbol.trim().toUpperCase();
+  const tokenAddress = getTokenAddressMap()[normalizedSymbol];
+
+  if (!tokenAddress) {
+    throw new Error(`Unsupported token symbol "${normalizedSymbol}". Configure TOKEN_ADDRESS_MAP to add it.`);
+  }
+
+  return { tokenSymbol: normalizedSymbol, tokenAddress };
 }
 
 function ensureStore(): void {
@@ -301,13 +333,17 @@ function normalizeRecords(records: BountyRecord[]): BountyRecord[] {
       };
     }
 
-    // Ensure version and events exist for backward compatibility
-    if (!record.version || !record.events) {
+    // Ensure version, events, and token address exist for backward compatibility
+    if (!record.version || !record.events || !record.tokenAddress) {
+      const resolvedToken = record.tokenAddress
+        ? { tokenAddress: record.tokenAddress }
+        : resolveTokenAddress(record.tokenSymbol);
       changed = true;
       return {
         ...record,
         version: record.version || 1,
         events,
+        tokenAddress: resolvedToken.tokenAddress,
         reservationTimeoutSeconds: record.reservationTimeoutSeconds || 604800,
       };
     }
@@ -386,6 +422,7 @@ export async function createBounty(input: CreateBountyInput): Promise<BountyReco
   return withGlobalLock(() => {
     const records = listBounties();
     const createdAt = nowInSeconds();
+    const token = resolveTokenAddress(input.tokenSymbol);
     const bounty: BountyRecord = {
       id: nextId(records),
       repo: input.repo,
@@ -393,7 +430,8 @@ export async function createBounty(input: CreateBountyInput): Promise<BountyReco
       title: input.title,
       summary: input.summary,
       maintainer: input.maintainer,
-      tokenSymbol: input.tokenSymbol.toUpperCase(),
+      tokenSymbol: token.tokenSymbol,
+      tokenAddress: token.tokenAddress,
       amount: Number(input.amount.toFixed(2)),
       labels: input.labels,
       status: "open",
@@ -716,5 +754,26 @@ export interface LeaderboardEntry {
   bountiesCompleted: number;
 }
 
+export function getLeaderboard(limit = 10): LeaderboardEntry[] {
+  const entriesByContributor = new Map<string, LeaderboardEntry>();
 
+  for (const bounty of listBounties()) {
+    if (bounty.status !== "released" || !bounty.contributor) {
+      continue;
+    }
+
+    const entry = entriesByContributor.get(bounty.contributor) ?? {
+      address: bounty.contributor,
+      totalXlm: 0,
+      bountiesCompleted: 0,
+    };
+
+    entry.totalXlm += bounty.amount;
+    entry.bountiesCompleted += 1;
+    entriesByContributor.set(bounty.contributor, entry);
+  }
+
+  return [...entriesByContributor.values()]
+    .sort((left, right) => right.totalXlm - left.totalXlm || right.bountiesCompleted - left.bountiesCompleted)
+    .slice(0, limit);
 }

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -2,6 +2,12 @@ import type { RequestHandler } from "express";
 import { rateLimit } from "express-rate-limit";
 import { StrKey } from "@stellar/stellar-sdk";
 
+export const SOROBAN_ADDRESS_REGEX = /^C[A-Z2-7]{55}$/;
+
+export function isValidStellarAddress(address: string): boolean {
+  return StrKey.isValidEd25519PublicKey(address);
+}
+
 /** Bypass strict limits in automated tests so suites can hit POST routes freely. */
 export const limiter: RequestHandler =
   process.env.NODE_ENV === "test"
@@ -13,7 +19,3 @@ export const limiter: RequestHandler =
         legacyHeaders: false,
         ipv6Subnet: 56,
       });
-
-/**
-
-}

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -2,6 +2,7 @@ import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 
 import { githubPrUrlSchema } from "./prUrl";
+import { isValidStellarAddress, SOROBAN_ADDRESS_REGEX } from "../utils";
 
 extendZodWithOpenApi(z);
 
@@ -71,10 +72,13 @@ export const createBountySchema = z
       .string()
       .trim()
       .regex(TOKEN_REGEX, "Token symbol must be 1-12 letters or numbers.")
-      .openapi({ example: "XLM", description: "Stellar token symbol for payout (1–12 alphanumeric chars)." }),
+      .openapi({
+        example: "XLM",
+        description: "Stellar token symbol for payout. The backend resolves it through TOKEN_ADDRESS_MAP.",
+      }),
     amount: z.coerce
       .number()
-      .min(1, "Amount must be at least 1 XLM.")
+      .min(1, "Amount must be at least 1 XLM."),
 
     deadlineDays: z.coerce
       .number()
@@ -122,6 +126,14 @@ export const submitBountySchema = z
     contributor: stellarAccountSchema.openapi({
       description: "Must match the contributor who reserved the bounty.",
     }),
+    submissionUrl: z
+      .string()
+      .trim()
+      .url()
+      .openapi({
+        example: "https://github.com/owner/repo/pull/99",
+        description: "Pull request URL submitted for this bounty.",
+      }),
 
     notes: z
       .string()
@@ -169,6 +181,7 @@ export const bountyRecordSchema = z
     maintainer: z.string().openapi({ example: STELLAR_EXAMPLE }),
     contributor: z.string().optional().openapi({ example: STELLAR_EXAMPLE }),
     tokenSymbol: z.string().openapi({ example: "XLM" }),
+    tokenAddress: z.string().optional().openapi({ example: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" }),
     amount: z.number().openapi({ example: 100 }),
     labels: z.array(z.string()).openapi({ example: ["bug", "help wanted"] }),
     status: z

--- a/backend/test/multiTokenRelease.test.ts
+++ b/backend/test/multiTokenRelease.test.ts
@@ -1,0 +1,67 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CONTRIBUTOR, MAINTAINER } from "./fixtures";
+
+let storeFile: string;
+
+beforeEach(() => {
+  storeFile = path.join(os.tmpdir(), `multi-token-release-${randomUUID()}.json`);
+  fs.writeFileSync(storeFile, "[]", "utf8");
+  process.env.BOUNTY_STORE_PATH = storeFile;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete process.env.BOUNTY_STORE_PATH;
+  delete process.env.TOKEN_ADDRESS_MAP;
+
+  try {
+    fs.unlinkSync(storeFile);
+  } catch {
+    /* temp cleanup best-effort */
+  }
+
+  try {
+    fs.unlinkSync(storeFile.replace(/\.json$/i, ".audit.json"));
+  } catch {
+    /* temp cleanup best-effort */
+  }
+});
+
+describe("multi-token release support", () => {
+  it("creates, reserves, submits, and releases a USDC bounty with a configured token address", async () => {
+    const usdcAddress = "CDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD";
+    process.env.TOKEN_ADDRESS_MAP = JSON.stringify({ USDC: usdcAddress });
+
+    const { createBounty, reserveBounty, submitBounty, releaseBounty } = await import(
+      "../src/services/bountyStore"
+    );
+
+    const created = await createBounty({
+      repo: "acme/widget",
+      issueNumber: 99,
+      title: "Pay this bounty in USDC",
+      summary: "Verify that USDC bounties keep their configured token address through release.",
+      maintainer: MAINTAINER,
+      tokenSymbol: "usdc",
+      amount: 75,
+      deadlineDays: 14,
+      labels: [],
+    });
+
+    expect(created.tokenSymbol).toBe("USDC");
+    expect(created.tokenAddress).toBe(usdcAddress);
+
+    await reserveBounty(created.id, CONTRIBUTOR);
+    await submitBounty(created.id, CONTRIBUTOR, "https://github.com/acme/widget/pull/99");
+    const released = await releaseBounty(created.id, MAINTAINER, "e".repeat(64));
+
+    expect(released.status).toBe("released");
+    expect(released.tokenSymbol).toBe("USDC");
+    expect(released.tokenAddress).toBe(usdcAddress);
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,6 +51,7 @@ const STELLAR_PUBLIC_KEY_HINT = "Expected Stellar public key (starts with G and 
 const STELLAR_PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
 
 const DARK_MODE_KEY = "stellar-bounty-board:theme";
+const TOKEN_OPTIONS = ["XLM", "USDC"];
 
 function useDarkMode() {
   const [dark, setDark] = useState<boolean>(() => {
@@ -809,10 +810,16 @@ function App() {
 
               <label>
                 Token
-                <input
+                <select
                   value={form.tokenSymbol}
                   onChange={(event) => setForm({ ...form, tokenSymbol: event.target.value })}
-                />
+                >
+                  {TOKEN_OPTIONS.map((token) => (
+                    <option key={token} value={token}>
+                      {token}
+                    </option>
+                  ))}
+                </select>
               </label>
             </div>
 


### PR DESCRIPTION
Replaces #402 after branch naming cleanup.

Closes #223

## Root cause
The contract already stores a token address per bounty, but the app/backend flow only exposed a loose `tokenSymbol` string. There was no backend token-address resolution path or UI picker that made XLM vs USDC explicit during bounty creation.

## Approach
- Added backend `TOKEN_ADDRESS_MAP` resolution so `tokenSymbol` is normalized and stored with its configured Soroban token address.
- Persisted `tokenAddress` on newly created bounties and backfilled sample/default records where the symbol is known.
- Added a frontend token picker with XLM and USDC options instead of a free-text token input.
- Added a backend lifecycle test that creates, reserves, submits, and releases a USDC bounty while asserting the configured USDC token address remains attached through release.
- Included minimal backend compile blockers already present on main so `tsc` can validate the touched backend path.

## Contract check
`release_bounty` already reads `bounty.token` and constructs `TokenClient::new(&env, &bounty.token)`, so the contract release path uses the per-bounty token address rather than a global token. I did not change contract code.

## Security
- Unsupported token symbols are rejected unless explicitly configured in `TOKEN_ADDRESS_MAP`, reducing accidental payouts against unknown assets.
- The frontend picker limits the common path to XLM/USDC and avoids typo-prone free text for those assets.
- No private keys, wallet signing, custody logic, or transfer semantics changed.

## Validation
- `npm --prefix backend test -- multiTokenRelease.test.ts leaderboard.test.ts`
- `npm --prefix backend run build`

Could not run contract tests locally because `cargo` is not installed in this environment. `npm --prefix frontend run build` is still blocked by the existing `frontend/src/api.ts:158` syntax error on main.

Disclosure: this PR was prepared with AI assistance. I reviewed the diff and am submitting it under my GitHub account.