### PR TITLE
docs: document reservation expiration job settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,15 @@ CORS_ORIGINS=http://localhost:5173
 # [OPTIONAL] Logging level (debug, info, warn, error). Default: info
 LOG_LEVEL=info
 
+# [OPTIONAL] Number of days a reservation may stay open before the
+# reservation expiration job returns it to the open bounty pool.
+# Default: 7
+RESERVATION_TTL_DAYS=7
+
+# [OPTIONAL] How often the reservation expiration job checks for stale
+# reservations, in milliseconds. Default: 3600000 (1 hour)
+EXPIRATION_CRON_INTERVAL_MS=3600000
+
 
 # ------------------------------------------------------------------------------
 # WORKER CONFIGURATION (SOROBAN)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,27 @@ Routes:
 - `POST /api/bounties/:id/refund`
 - `GET /api/open-issues`
 
+## Reservation Expiration
+
+Reserved bounties can be returned to the open pool when the contributor does not submit work before the reservation timeout.
+
+New bounties support an optional `reservationTimeoutSeconds` field. When omitted, the backend stores a default value of `604800` seconds, which is 7 days. This per-bounty value is used when bounty records are normalized during normal store reads.
+
+The backend also includes a scheduled expiration job in `backend/src/services/reservationExpirationJob.ts`. When started, it:
+
+- checks reserved bounties immediately and then on a timer
+- returns stale reserved bounties to `open`
+- clears `contributor` and `reservedAt`
+- increments the bounty `version`
+- appends an `expired` event with the reason `reservation_ttl_exceeded`
+
+The scheduled job can be tuned with these environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RESERVATION_TTL_DAYS` | `7` | Number of days a reservation may remain stale before the scheduled job expires it. Invalid or non-positive values fall back to 7 days. |
+| `EXPIRATION_CRON_INTERVAL_MS` | `3600000` | How often the scheduled job checks for stale reservations, in milliseconds. Invalid or non-positive values fall back to 1 hour. |
+
 ## Run Locally
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The backend also includes a scheduled expiration job in `backend/src/services/re
 - increments the bounty `version`
 - appends an `expired` event with the reason `reservation_ttl_exceeded`
 
+`reservationTimeoutSeconds` and `RESERVATION_TTL_DAYS` are evaluated separately. The per-bounty `reservationTimeoutSeconds` value is applied during bounty store normalization, while `RESERVATION_TTL_DAYS` controls the scheduled job in `backend/src/services/reservationExpirationJob.ts`. Keep them aligned when you want one consistent reservation window; if they differ, the shorter effective timeout can return the reservation to `open` first.
+
 The scheduled job can be tuned with these environment variables:
 
 | Variable | Default | Description |


### PR DESCRIPTION
Closes #342

## Summary
- add `RESERVATION_TTL_DAYS` and `EXPIRATION_CRON_INTERVAL_MS` to `.env.example`
- document how the reservation expiration job returns stale reservations to the open bounty pool
- describe the per-bounty `reservationTimeoutSeconds` override and default value

## Validation
- `git diff --check HEAD~1 HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic reservation expiration: reserved bounties return to the open pool if not claimed within the configured timeout (default 7 days). Job runs immediately and then periodically; check interval is configurable.

* **Documentation**
  * Updated docs explaining reservation expiration behavior, configuration options (including RESERVATION_TTL_DAYS and EXPIRATION_CRON_INTERVAL_MS), and how per-bounty and global timeouts interact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->