### PR TITLE
Update security disclosure timeline

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,19 +1,34 @@
 # Security Policy
 
 ## Supported Versions
-Only the latest version of the Stellar Bounty Board is currently supported with security updates.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| Active  | :white_check_mark: |
+Only the latest version of Stellar Bounty Board is currently supported with security updates.
+
+| Version | Supported |
+| ------- | --------- |
+| Active  | Yes       |
 
 ## Reporting a Vulnerability
-**Please do not open a public GitHub issue for security vulnerabilities.**
 
-If you discover a potential security issue, please report it privately by emailing [Insert Email or Use GitHub Private Reporting]. We appreciate your help in keeping the Stellar ecosystem safe.
+Please do not open a public GitHub issue for suspected security vulnerabilities.
 
-### Our Commitment
-* **Acknowledge:** We will acknowledge receipt of your report within **48 hours** (SLA).
-* **Triage:** We will provide a status update after initial triage.
-* **Disclosure:** We follow a responsible disclosure timeline of **90 days** before public release, though we aim to fix critical issues much faster.
-￼Enter
+Use the repository's GitHub Security Advisory form whenever possible. If private reporting is unavailable, contact the maintainers privately and include:
+
+- a concise description of the vulnerability;
+- affected components, endpoints, or contracts;
+- reproduction steps or proof-of-concept details;
+- expected impact and any suggested mitigation.
+
+## Responsible Disclosure Timeline
+
+We follow a coordinated disclosure process:
+
+- **Acknowledgement:** we aim to acknowledge receipt within **48 hours**.
+- **Initial assessment:** we aim to complete triage and share an initial severity assessment within **7 days**.
+- **Fix target:** we aim to remediate accepted vulnerabilities within **30 days**, depending on severity and complexity.
+
+Please keep vulnerability details private until the maintainers confirm a fix is available or agree on a disclosure date.
+
+## Bug Bounty Policy
+
+There is no formal bug bounty program at this time. Reports are still appreciated and will be reviewed under the responsible disclosure process above.


### PR DESCRIPTION
## Summary
- update SECURITY.md to prefer GitHub Security Advisory reporting
- document coordinated disclosure expectations: 48h acknowledgement, 7d initial assessment, 30d fix target
- clarify that there is no formal bug bounty program yet

Fixes #388

## Verification
- git diff --check