### PR TITLE
feat: add Stellar Expert deep links for transaction hashes (closes #382)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,7 +38,7 @@ import SubmissionChecklistModal, { type SubmissionFormData } from "./SubmissionC
 import { BountyRecommendation, ContributorProfile, createDefaultProfile, generateRecommendations, updateProfileFromBounties } from "./recommendations";
 import RecommendedBounties from "./RecommendedBounties";
 import { statusCopy, actionCopy, readInitialFilters, FilterState, statusOptions, statusGlossary, sortOptions } from "./constants";
-import { filterBounties, getRewardBounds, getActiveRewardLabel, getContributorMetrics, getUniqueRepos, getRepoMetrics, sortBounties, debounce, SortOption, SortState, xlmToUsd } from "./utils";
+import { filterBounties, getRewardBounds, getActiveRewardLabel, getContributorMetrics, getUniqueRepos, getRepoMetrics, sortBounties, debounce, SortOption, SortState, xlmToUsd, txHashLink } from "./utils";
 import { Bounty, CreateBountyPayload, OpenIssue, BountyStatus } from "./types";
 
 import GitHubIssuePreviewCard from "./GitHubIssuePreviewCard";
@@ -1148,18 +1148,32 @@ placeholder="help wanted, backend"
                       <span className="meta-label">Contributor</span>
                       <strong>{bounty.contributor ? shortAddress(bounty.contributor) : "Open"}</strong>
                     </div>
-                    {bounty.status === "released" && bounty.releasedTxHash && (
+                    {bounty.status === "released" && bounty.releasedTxHash && (() => {
+                      const { href, display } = txHashLink(bounty.releasedTxHash!);
+                      return (
                       <div>
                         <span className="meta-label">Release tx</span>
-                        <strong>{`${bounty.releasedTxHash.slice(0, 10)}...`}</strong>
+                        <strong>
+                          <a className="inline-link" href={href} target="_blank" rel="noopener noreferrer" title={bounty.releasedTxHash}>
+                            {display}
+                          </a>
+                        </strong>
                       </div>
-                    )}
-                    {bounty.status === "refunded" && bounty.refundedTxHash && (
+                      );
+                    })()}
+                    {bounty.status === "refunded" && bounty.refundedTxHash && (() => {
+                      const { href, display } = txHashLink(bounty.refundedTxHash!);
+                      return (
                       <div>
                         <span className="meta-label">Refund tx</span>
-                        <strong>{`${bounty.refundedTxHash.slice(0, 10)}...`}</strong>
+                        <strong>
+                          <a className="inline-link" href={href} target="_blank" rel="noopener noreferrer" title={bounty.refundedTxHash}>
+                            {display}
+                          </a>
+                        </strong>
                       </div>
-                    )}
+                      );
+                    })()}
                   </div>
 
                   <div className="chip-row">
@@ -1383,18 +1397,32 @@ placeholder="help wanted, backend"
                         </strong>
                       </div>
                     )}
-                    {bounty.status === "released" && bounty.releasedTxHash && (
+                    {bounty.status === "released" && bounty.releasedTxHash && (() => {
+                      const { href, display } = txHashLink(bounty.releasedTxHash!);
+                      return (
                       <div>
                         <span className="meta-label">Release tx</span>
-                        <strong>{`${bounty.releasedTxHash.slice(0, 10)}...`}</strong>
+                        <strong>
+                          <a className="inline-link" href={href} target="_blank" rel="noopener noreferrer" title={bounty.releasedTxHash}>
+                            {display}
+                          </a>
+                        </strong>
                       </div>
-                    )}
-                    {bounty.status === "refunded" && bounty.refundedTxHash && (
+                      );
+                    })()}
+                    {bounty.status === "refunded" && bounty.refundedTxHash && (() => {
+                      const { href, display } = txHashLink(bounty.refundedTxHash!);
+                      return (
                       <div>
                         <span className="meta-label">Refund tx</span>
-                        <strong>{`${bounty.refundedTxHash.slice(0, 10)}...`}</strong>
+                        <strong>
+                          <a className="inline-link" href={href} target="_blank" rel="noopener noreferrer" title={bounty.refundedTxHash}>
+                            {display}
+                          </a>
+                        </strong>
                       </div>
-                    )}
+                      );
+                    })()}
                   </div>
                 </article>
               ))}

--- a/frontend/src/BountyDetailPage.tsx
+++ b/frontend/src/BountyDetailPage.tsx
@@ -1,4 +1,6 @@
 
+import { txHashLink } from "./utils";
+
 type BountyAction = "reserve" | "submit" | "release" | "refund";
 
 type Props = {
@@ -225,24 +227,34 @@ export default function BountyDetailPage({
                   <strong>{formatTimestamp(bounty.refundedAt)}</strong>
                 </div>
               )}
-              {bounty.releasedTxHash && (
+              {bounty.releasedTxHash && (() => {
+                const { href, display } = txHashLink(bounty.releasedTxHash!);
+                return (
                 <div>
                   <span className="meta-label">Release tx</span>
                   <strong className="copy-row">
-                    {bounty.releasedTxHash}
-                    <CopyButton text={bounty.releasedTxHash} label="release transaction hash" />
+                    <a className="inline-link" href={href} target="_blank" rel="noopener noreferrer" title={bounty.releasedTxHash}>
+                      {display}
+                    </a>
+                    <CopyButton text={bounty.releasedTxHash!} label="release transaction hash" />
                   </strong>
                 </div>
-              )}
-              {bounty.refundedTxHash && (
+                );
+              })()}
+              {bounty.refundedTxHash && (() => {
+                const { href, display } = txHashLink(bounty.refundedTxHash!);
+                return (
                 <div>
                   <span className="meta-label">Refund tx</span>
                   <strong className="copy-row">
-                    {bounty.refundedTxHash}
-                    <CopyButton text={bounty.refundedTxHash} label="refund transaction hash" />
+                    <a className="inline-link" href={href} target="_blank" rel="noopener noreferrer" title={bounty.refundedTxHash}>
+                      {display}
+                    </a>
+                    <CopyButton text={bounty.refundedTxHash!} label="refund transaction hash" />
                   </strong>
                 </div>
-              )}
+                );
+              })()}
             </div>
 
             {bounty.labels.length > 0 && (

--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -15,6 +15,18 @@ describe("txHashLink", () => {
     expect(result.display).toBe("abcdef01...23456789");
     expect(result.display.length).toBe(19); // 8 + 3 dots + 8
   });
+
+  it("returns full hash when 16 chars or shorter and trims whitespace", () => {
+    const result = txHashLink("  abcd1234  ");
+    expect(result.display).toBe("abcd1234");
+    expect(result.href).toBe("https://stellar.expert/explorer/testnet/tx/abcd1234");
+  });
+
+  it("URL-encodes special characters in the hash", () => {
+    const result = txHashLink("hash with spaces");
+    expect(result.href).toBe("https://stellar.expert/explorer/testnet/tx/hash%20with%20spaces");
+    expect(result.display).toBe("hash with spaces");
+  });
 });
 
 describe("xlmToUsd", () => {

--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { xlmToUsd, resetXlmToUsdCache } from "./utils";
+import { xlmToUsd, resetXlmToUsdCache, txHashLink } from "./utils";
+
+describe("txHashLink", () => {
+  it("builds a Stellar Expert testnet link and truncated display", () => {
+    const hash = "a".repeat(64);
+    const result = txHashLink(hash);
+    expect(result.href).toBe(`https://stellar.expert/explorer/testnet/tx/${hash}`);
+    expect(result.display).toBe(`${hash.slice(0, 8)}...${hash.slice(-8)}`);
+  });
+
+  it("truncates a real Stellar tx hash to first 8 + last 8 chars", () => {
+    const hash = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    const result = txHashLink(hash);
+    expect(result.display).toBe("abcdef01...23456789");
+    expect(result.display.length).toBe(19); // 8 + 3 dots + 8
+  });
+});
 
 describe("xlmToUsd", () => {
   const fetchMock = vi.fn();

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -207,9 +207,13 @@ export function resetXlmToUsdCache(): void {
 
 /** Build a Stellar Expert testnet link and truncated display for a transaction hash. */
 export function txHashLink(hash: string): { href: string; display: string } {
+  const normalizedHash = hash.trim();
+  const display = normalizedHash.length > 16
+    ? `${normalizedHash.slice(0, 8)}...${normalizedHash.slice(-8)}`
+    : normalizedHash;
   return {
-    href: `https://stellar.expert/explorer/testnet/tx/${hash}`,
-    display: `${hash.slice(0, 8)}...${hash.slice(-8)}`,
+    href: `https://stellar.expert/explorer/testnet/tx/${encodeURIComponent(normalizedHash)}`,
+    display,
   };
 }
 

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -205,6 +205,14 @@ export function resetXlmToUsdCache(): void {
   cachedXlmUsdRate = null;
 }
 
+/** Build a Stellar Expert testnet link and truncated display for a transaction hash. */
+export function txHashLink(hash: string): { href: string; display: string } {
+  return {
+    href: `https://stellar.expert/explorer/testnet/tx/${hash}`,
+    display: `${hash.slice(0, 8)}...${hash.slice(-8)}`,
+  };
+}
+
 export function getContributorMetrics(bounties: Bounty[], contributorAddress?: string) {
   if (!contributorAddress) {
     return {


### PR DESCRIPTION
## Summary

Renders `releasedTxHash` and `refundedTxHash` as clickable links to Stellar Expert testnet explorer, with truncated display (first 8 + last 8 characters) and a tooltip showing the full hash.

## Changes

- Added `txHashLink()` utility to `utils.ts` that builds the Stellar Expert URL and truncates the hash
- Updated `BountyDetailPage.tsx` — release/refund tx hashes are now links alongside the existing copy button
- Updated `App.tsx` — both the list view card and the detail expanded card now show clickable hash links
- Added vitest unit tests for `txHashLink()`

## Test Plan

- [x] `npm run test -- utils.test.ts` passes (5/5 tests including 2 new txHashLink tests)
- Verified hash truncation: displays `first8...last8` (19 chars total)
- Verified link: `https://stellar.expert/explorer/testnet/tx/<hash>`
- Verified `target="_blank"` and `rel="noopener noreferrer"` on link
- Verified full hash in `title` attribute for tooltip
- Copy button still present alongside the link

## Related

Closes #382

**Complexity:** Easy · 50 points

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Release tx" and "Refund tx" now link to the Stellar Expert testnet explorer and show a shortened, more readable transaction string; full-hash copy-to-clipboard remains available.
  * Added a utility to generate stable explorer links and shortened display text for transaction hashes.

* **Tests**
  * Added tests to validate link generation, URL encoding, and display truncation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/419?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->