### PR TITLE
Add max bounty amount validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Routes:
 - `POST /api/bounties/:id/refund`
 - `GET /api/open-issues`
 
+Create bounty requests require `amount` to be between `1` and `1_000_000` tokens, with at most 7 decimal places.
+
 ## Run Locally
 
 ```bash

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -10,9 +10,15 @@ extendZodWithOpenApi(z);
 const REPO_REGEX = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
 const TOKEN_REGEX = /^[A-Za-z0-9]{1,12}$/;
 const SOROBAN_ADDRESS_REGEX = /^C[A-Z2-7]{55}$/;
+export const MAX_BOUNTY_AMOUNT = 1_000_000;
 
 const STELLAR_EXAMPLE = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 const TX_HASH_REGEX = /^[0-9a-fA-F]{64}$/;
+
+function hasAtMostSevenDecimals(value: number): boolean {
+  const scaled = value * 10_000_000;
+  return Math.abs(scaled - Math.round(scaled)) < Number.EPSILON * 10_000_000;
+}
 
 export const bountyIdSchema = z
   .string()
@@ -76,7 +82,13 @@ export const createBountySchema = z
       .openapi({ example: "XLM", description: "Stellar token symbol for payout (1–12 alphanumeric chars)." }),
     amount: z.coerce
       .number()
-      .min(1, "Amount must be at least 1 XLM."),
+      .min(1, "Amount must be at least 1 XLM.")
+      .max(MAX_BOUNTY_AMOUNT, `Amount must not exceed ${MAX_BOUNTY_AMOUNT} XLM.`)
+      .refine(hasAtMostSevenDecimals, "Amount can have at most 7 decimal places.")
+      .openapi({
+        example: 100,
+        description: `Bounty amount, from 1 to ${MAX_BOUNTY_AMOUNT} tokens, with at most 7 decimal places.`,
+      }),
 
     deadlineDays: z.coerce
       .number()
@@ -171,7 +183,10 @@ export const bountyRecordSchema = z
     maintainer: z.string().openapi({ example: STELLAR_EXAMPLE }),
     contributor: z.string().optional().openapi({ example: STELLAR_EXAMPLE }),
     tokenSymbol: z.string().openapi({ example: "XLM" }),
-    amount: z.number().openapi({ example: 100 }),
+    amount: z.number().max(MAX_BOUNTY_AMOUNT).openapi({
+      example: 100,
+      description: `Bounty amount, capped at ${MAX_BOUNTY_AMOUNT} tokens.`,
+    }),
     labels: z.array(z.string()).openapi({ example: ["bug", "help wanted"] }),
     status: z
       .enum(["open", "reserved", "submitted", "released", "refunded", "expired"])

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -82,8 +82,8 @@ export const createBountySchema = z
       .openapi({ example: "XLM", description: "Stellar token symbol for payout (1–12 alphanumeric chars)." }),
     amount: z.coerce
       .number()
-      .min(1, "Amount must be at least 1 XLM.")
-      .max(MAX_BOUNTY_AMOUNT, `Amount must not exceed ${MAX_BOUNTY_AMOUNT} XLM.`)
+      .min(1, "Amount must be at least 1 token.")
+      .max(MAX_BOUNTY_AMOUNT, `Amount must not exceed ${MAX_BOUNTY_AMOUNT} tokens.`)
       .refine(hasAtMostSevenDecimals, "Amount can have at most 7 decimal places.")
       .openapi({
         example: 100,

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -85,13 +85,13 @@ describe("API — bounty lifecycle routes", () => {
     expect(res.body.error).toMatch(/at least 1 XLM/i);
   });
 
-  it("POST create with amount above 10000 XLM returns 400", async () => {
+  it("POST create with amount above 1M tokens returns 400", async () => {
     const app = await getApp();
     const res = await request(app)
       .post("/api/bounties")
-      .send({ ...validCreateBody, amount: 10001 })
+      .send({ ...validCreateBody, amount: 1_000_001 })
       .expect(400);
-    expect(res.body.error).toMatch(/exceed 10000 XLM/i);
+    expect(res.body.error).toMatch(/exceed 1000000 XLM/i);
   });
 
   it("POST create with more than 7 decimal places returns 400", async () => {
@@ -121,13 +121,13 @@ describe("API — bounty lifecycle routes", () => {
     expect(res.body.data.amount).toBe(1);
   });
 
-  it("POST create with 10000 XLM succeeds", async () => {
+  it("POST create with exactly 1M tokens succeeds", async () => {
     const app = await getApp();
     const res = await request(app)
       .post("/api/bounties")
-      .send({ ...validCreateBody, amount: 10000 })
+      .send({ ...validCreateBody, amount: 1_000_000 })
       .expect(201);
-    expect(res.body.data.amount).toBe(10000);
+    expect(res.body.data.amount).toBe(1_000_000);
   });
 
   it("reserve → submit → release flow via HTTP", async () => {

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -76,13 +76,13 @@ describe("API — bounty lifecycle routes", () => {
     expect(res.body.error).toBeDefined();
   });
 
-  it("POST create with amount below 1 XLM returns 400", async () => {
+  it("POST create with amount below 1 token returns 400", async () => {
     const app = await getApp();
     const res = await request(app)
       .post("/api/bounties")
       .send({ ...validCreateBody, amount: 0.5 })
       .expect(400);
-    expect(res.body.error).toMatch(/at least 1 XLM/i);
+    expect(res.body.error).toMatch(/at least 1 token/i);
   });
 
   it("POST create with amount above 1M tokens returns 400", async () => {
@@ -91,7 +91,7 @@ describe("API — bounty lifecycle routes", () => {
       .post("/api/bounties")
       .send({ ...validCreateBody, amount: 1_000_001 })
       .expect(400);
-    expect(res.body.error).toMatch(/exceed 1000000 XLM/i);
+    expect(res.body.error).toMatch(/exceed 1000000 tokens/i);
   });
 
   it("POST create with more than 7 decimal places returns 400", async () => {
@@ -112,7 +112,7 @@ describe("API — bounty lifecycle routes", () => {
     expect(res.body.data.id).toMatch(/^BNT-\d{4}$/);
   });
 
-  it("POST create with 1 XLM succeeds", async () => {
+  it("POST create with 1 token succeeds", async () => {
     const app = await getApp();
     const res = await request(app)
       .post("/api/bounties")


### PR DESCRIPTION
## Summary
- caps bounty creation amounts at `1_000_000` tokens in the Zod schema
- documents the maximum in the generated OpenAPI schema and README
- updates API coverage so exactly `1_000_000` succeeds and `1_000_001` returns 400

Closes #347

## Validation
- `git diff --check`
- `npm --prefix backend test -- api.test.ts` (26 passed)

## Existing baseline failures observed
- `npm --prefix backend run build` currently fails on missing `swagger-ui-express` typings and an existing `submissionUrl` submit-schema type mismatch in `src/app.ts`.
- `npm --prefix backend test` currently has unrelated baseline failures in `test/utils.test.ts`, `authMiddleware.test.ts`, `expiry.test.ts`, and `reservationExpirationJob.test.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification to the API overview on bounty creation amount requirements.

* **Bug Fixes**
  * Improved validation for bounty amounts to strictly enforce constraints: 1 to 1,000,000 tokens with maximum 7 decimal places.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->