### PR TITLE
feat: CodeQL, compose health checks, bounty list memoization, CopyIcon polish

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly Monday 09:00 UTC scan
+    - cron: "0 9 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # `javascript` covers both JS and TS sources.
+          queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,4 +16,8 @@ If you discover a potential security issue, please report it privately by emaili
 * **Acknowledge:** We will acknowledge receipt of your report within **48 hours** (SLA).
 * **Triage:** We will provide a status update after initial triage.
 * **Disclosure:** We follow a responsible disclosure timeline of **90 days** before public release, though we aim to fix critical issues much faster.
+
+## Automated Security Analysis
+
+This repository runs [GitHub CodeQL](https://codeql.github.com/) on the `javascript` language (which covers both JavaScript and TypeScript) for every push and pull request to `main`, plus a weekly scheduled scan. The workflow is defined at [.github/workflows/codeql.yml](.github/workflows/codeql.yml) and uses the `security-extended` and `security-and-quality` query suites. Alerts surface in the **Security** tab of the repository.
 ￼Enter

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,1 +1,49 @@
+# Stellar Bounty Board — local dev stack
+#
+# Health checks ensure `docker compose up` only reports services healthy once
+# they actually respond. The frontend uses `depends_on: condition: service_healthy`
+# so it waits for the backend to be ready before starting.
+#
+# - interval: how often to run the check (10s gives quick feedback during boot)
+# - timeout:  fail the probe if it takes longer than 5s
+# - retries:  N consecutive failures before marking unhealthy
+# - start_period: grace period at startup before failures count
 
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: stellar-bounty-backend
+    ports:
+      - "3001:3001"
+    environment:
+      - NODE_ENV=development
+      - PORT=3001
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3001/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    container_name: stellar-bounty-frontend
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=development
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3000 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { FormEvent, ReactNode, memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowUpRight,
   Coins,
@@ -140,7 +140,7 @@ function formatTimestamp(value?: number): string {
   return new Date(value * 1000).toLocaleString();
 }
 
-function BountyAmount({ bounty }: { bounty: Bounty }) {
+const BountyAmount = memo(function BountyAmount({ bounty }: { bounty: Bounty }) {
   const [usdAmount, setUsdAmount] = useState<string | null>(null);
 
   useEffect(() => {
@@ -171,7 +171,131 @@ function BountyAmount({ bounty }: { bounty: Bounty }) {
       {usdAmount && <span>{usdAmount}</span>}
     </div>
   );
+});
+
+type BountyCardProps = {
+  bounty: Bounty;
+  onOpen: (id: string) => void;
+  renderActionButton: (
+    bounty: Bounty,
+    action: { action: "reserve" | "submit" | "release" | "refund"; label: string; title: string },
+  ) => ReactNode;
+};
+
+// Custom comparator: skip re-renders when the underlying bounty data is
+// unchanged, even if parent recreated callback identities. `statusCopy` and
+// `actionCopy` come from a stable module-scope import.
+function bountyCardPropsEqual(prev: BountyCardProps, next: BountyCardProps): boolean {
+  const a = prev.bounty;
+  const b = next.bounty;
+  return (
+    a.id === b.id &&
+    a.status === b.status &&
+    a.amount === b.amount &&
+    a.tokenSymbol === b.tokenSymbol &&
+    a.contributor === b.contributor &&
+    a.maintainer === b.maintainer &&
+    a.title === b.title &&
+    a.summary === b.summary &&
+    a.deadlineAt === b.deadlineAt &&
+    a.submissionUrl === b.submissionUrl &&
+    a.releasedTxHash === b.releasedTxHash &&
+    a.refundedTxHash === b.refundedTxHash &&
+    a.labels === b.labels
+  );
 }
+
+const BountyCard = memo(function BountyCard({ bounty, onOpen, renderActionButton }: BountyCardProps) {
+  return (
+    <article
+      className="bounty-card"
+      role="link"
+      tabIndex={0}
+      onClick={() => onOpen(bounty.id)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onOpen(bounty.id);
+        }
+      }}
+    >
+      <div className="bounty-card__top">
+        <div>
+          <span
+            className={`status-pill status-pill--${bounty.status}`}
+            title={statusCopy[bounty.status].description}
+            aria-label={`${statusCopy[bounty.status].label}: ${statusCopy[bounty.status].description}`}
+          >
+            {statusCopy[bounty.status].label}
+          </span>
+          <h3>{bounty.title}</h3>
+        </div>
+      </div>
+
+      <p className="bounty-summary">{bounty.summary}</p>
+
+      <div className="meta-grid">
+        <div>
+          <span className="meta-label">Issue</span>
+          <strong>
+            <a
+              className="inline-link"
+              href={`https://github.com/${bounty.repo}/issues/${bounty.issueNumber}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {bounty.repo} #{bounty.issueNumber}
+            </a>
+          </strong>
+        </div>
+        <div>
+          <span className="meta-label">Deadline</span>
+          <strong>{formatRelativeDeadline(bounty.deadlineAt)}</strong>
+        </div>
+        <div>
+          <span className="meta-label">Maintainer</span>
+          <strong>{shortAddress(bounty.maintainer)}</strong>
+        </div>
+        <div>
+          <span className="meta-label">Contributor</span>
+          <strong>{bounty.contributor ? shortAddress(bounty.contributor) : "Open"}</strong>
+        </div>
+        {bounty.status === "released" && bounty.releasedTxHash && (
+          <div>
+            <span className="meta-label">Release tx</span>
+            <strong>{`${bounty.releasedTxHash.slice(0, 10)}...`}</strong>
+          </div>
+        )}
+        {bounty.status === "refunded" && bounty.refundedTxHash && (
+          <div>
+            <span className="meta-label">Refund tx</span>
+            <strong>{`${bounty.refundedTxHash.slice(0, 10)}...`}</strong>
+          </div>
+        )}
+      </div>
+
+      <div className="chip-row">
+        {bounty.labels.map((label) => (
+          <span className="chip" key={label.name}>{label.name}</span>
+        ))}
+      </div>
+
+      <p className="status-helper">
+        <strong>{statusCopy[bounty.status].label}:</strong> {statusCopy[bounty.status].description}
+      </p>
+
+      {bounty.submissionUrl && (
+        <a className="submission-link" href={bounty.submissionUrl} target="_blank" rel="noreferrer">
+          Review submission <ArrowUpRight size={16} />
+        </a>
+      )}
+
+      <div className="action-row">
+        {(actionCopy[bounty.status] ?? []).map((action) => renderActionButton(bounty, action))}
+      </div>
+    </article>
+  );
+}, bountyCardPropsEqual);
 
 function App() {
   const { dark, toggle: toggleDark } = useDarkMode();
@@ -418,6 +542,13 @@ function App() {
       setSubmitting(false);
     }
   }
+
+  const handleOpenBounty = useCallback(
+    (id: string) => {
+      navigate(`/bounties/${encodeURIComponent(id)}`);
+    },
+    [navigate],
+  );
 
   function renderActionButton(
     bounty: Bounty,
@@ -1104,99 +1235,14 @@ placeholder="help wanted, backend"
                   </div>
                   <div className="repo-group__bounties">
                     {repoBounties.map((bounty) => (
-                <article
-                  className="bounty-card"
-                  key={bounty.id}
-                  role="link"
-                  tabIndex={0}
-                  onClick={() => navigate(`/bounties/${encodeURIComponent(bounty.id)}`)}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" || event.key === " ") {
-                      event.preventDefault();
-                      navigate(`/bounties/${encodeURIComponent(bounty.id)}`);
-                    }
-                  }}
-                >
-                  <div className="bounty-card__top">
-                    <div>
-                      <span
-                        className={`status-pill status-pill--${bounty.status}`}
-                        title={statusCopy[bounty.status].description}
-                        aria-label={`${statusCopy[bounty.status].label}: ${statusCopy[bounty.status].description}`}
-                      >
-                        {statusCopy[bounty.status].label}
-                      </span>
-                      <h3>{bounty.title}</h3>
-                    </div>
-
-                  </div>
-
-                  <p className="bounty-summary">{bounty.summary}</p>
-
-                  <div className="meta-grid">
-                    <div>
-                      <span className="meta-label">Issue</span>
-                      <strong>
-                        <a
-                          className="inline-link"
-                          href={`https://github.com/${bounty.repo}/issues/${bounty.issueNumber}`}
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          {bounty.repo} #{bounty.issueNumber}
-                        </a>
-                      </strong>
-                    </div>
-                    <div>
-                      <span className="meta-label">Deadline</span>
-                      <strong>{formatRelativeDeadline(bounty.deadlineAt)}</strong>
-                    </div>
-                    <div>
-                      <span className="meta-label">Maintainer</span>
-                      <strong>{shortAddress(bounty.maintainer)}</strong>
-                    </div>
-                    <div>
-                      <span className="meta-label">Contributor</span>
-                      <strong>{bounty.contributor ? shortAddress(bounty.contributor) : "Open"}</strong>
-                    </div>
-                    {bounty.status === "released" && bounty.releasedTxHash && (
-                      <div>
-                        <span className="meta-label">Release tx</span>
-                        <strong>{`${bounty.releasedTxHash.slice(0, 10)}...`}</strong>
-                      </div>
-                    )}
-                    {bounty.status === "refunded" && bounty.refundedTxHash && (
-                      <div>
-                        <span className="meta-label">Refund tx</span>
-                        <strong>{`${bounty.refundedTxHash.slice(0, 10)}...`}</strong>
-                      </div>
-                    )}
-                  </div>
-
-                  <div className="chip-row">
-                    {bounty.labels.map((label) => (
-                      <span className="chip" key={label.name}>
-  {label.name}
-</span>
+                      <BountyCard
+                        key={bounty.id}
+                        bounty={bounty}
+                        onOpen={handleOpenBounty}
+                        renderActionButton={renderActionButton}
+                      />
                     ))}
                   </div>
-
-                  <p className="status-helper">
-                    <strong>{statusCopy[bounty.status].label}:</strong> {statusCopy[bounty.status].description}
-                  </p>
-
-                  {bounty.submissionUrl && (
-                    <a className="submission-link" href={bounty.submissionUrl} target="_blank" rel="noreferrer">
-                      Review submission <ArrowUpRight size={16} />
-                    </a>
-                  )}
-
-                  <div className="action-row">
-                    {(actionCopy[bounty.status] ?? []).map((action) => renderActionButton(bounty, action))}
-                  </div>
-                </article>
-              ))}
-              </div>
             </div>
           ))}
             </div>

--- a/frontend/src/BountyDetailPage.tsx
+++ b/frontend/src/BountyDetailPage.tsx
@@ -1,7 +1,8 @@
 
-import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
-import { ArrowUpRight, Check, Clock, Copy, Printer } from "lucide-react";
+import { ReactNode, useEffect, useRef, useState } from "react";
+import { ArrowUpRight, Clock, Printer } from "lucide-react";
 
+import CopyIcon from "./CopyIcons";
 import UsdAmount from "./UsdAmount";
 import type { Bounty, BountyEvent, BountyStatus } from "./types";
 
@@ -24,42 +25,6 @@ type Props = {
   ) => ReactNode;
   formatTimestamp: (value?: number) => string;
 };
-
-function useCopyToClipboard(timeout = 2000) {
-  const [copiedKey, setCopiedKey] = useState<string | null>(null);
-
-  const copy = useCallback(
-    (text: string, key: string) => {
-      void navigator.clipboard.writeText(text).then(() => {
-        setCopiedKey(key);
-        setTimeout(() => setCopiedKey(null), timeout);
-      });
-    },
-    [timeout],
-  );
-
-  return { copiedKey, copy };
-}
-
-function CopyButton({ text, label }: { text: string; label: string }) {
-  const { copiedKey, copy } = useCopyToClipboard();
-  const copied = copiedKey !== null;
-
-  return (
-    <span className="copy-button-wrapper">
-      <button
-        type="button"
-        className="copy-button"
-        aria-label={copied ? "Copied!" : `Copy ${label}`}
-        title={copied ? "Copied!" : `Copy ${label}`}
-        onClick={() => copy(text, label)}
-      >
-        {copied ? <Check size={14} /> : <Copy size={14} />}
-      </button>
-      {copied && <span className="copy-tooltip">Copied!</span>}
-    </span>
-  );
-}
 
 function useBountyStatusAnnouncement(
   bounty: Bounty | null,
@@ -232,7 +197,7 @@ export default function BountyDetailPage({
                 <span className="meta-label">Bounty ID</span>
                 <strong className="copy-row">
                   {bounty.id}
-                  <CopyButton text={bounty.id} label="bounty ID" />
+                  <CopyIcon text={bounty.id} label="bounty ID" />
                 </strong>
               </div>
               <div>
@@ -260,7 +225,7 @@ export default function BountyDetailPage({
                 <span className="meta-label">Maintainer</span>
                 <strong className="copy-row">
                   {bounty.maintainer}
-                  <CopyButton text={bounty.maintainer} label="maintainer wallet address" />
+                  <CopyIcon text={bounty.maintainer} label="maintainer wallet address" />
                 </strong>
               </div>
               <div>
@@ -268,7 +233,7 @@ export default function BountyDetailPage({
                 <strong className="copy-row">
                   {bounty.contributor ?? "Open"}
                   {bounty.contributor && (
-                    <CopyButton text={bounty.contributor} label="contributor address" />
+                    <CopyIcon text={bounty.contributor} label="contributor address" />
                   )}
                 </strong>
               </div>
@@ -301,7 +266,7 @@ export default function BountyDetailPage({
                   <span className="meta-label">Release tx</span>
                   <strong className="copy-row">
                     {bounty.releasedTxHash}
-                    <CopyButton text={bounty.releasedTxHash} label="release transaction hash" />
+                    <CopyIcon text={bounty.releasedTxHash} label="release transaction hash" />
                   </strong>
                 </div>
               )}
@@ -310,7 +275,7 @@ export default function BountyDetailPage({
                   <span className="meta-label">Refund tx</span>
                   <strong className="copy-row">
                     {bounty.refundedTxHash}
-                    <CopyButton text={bounty.refundedTxHash} label="refund transaction hash" />
+                    <CopyIcon text={bounty.refundedTxHash} label="refund transaction hash" />
                   </strong>
                 </div>
               )}

--- a/frontend/src/CopyIcons.tsx
+++ b/frontend/src/CopyIcons.tsx
@@ -1,41 +1,86 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
-interface CopyIconProp {
+interface CopyIconProps {
   text: string;
+  /** Used in `aria-label` and tooltip, e.g. `"bounty ID"` → "Copy bounty ID". */
+  label?: string;
 }
 
-export default function CopyIcon({ text }: CopyIconProp) {
-  const [isCopied, setIsCopied] = useState(false);
-  useEffect(() => {
-    if (isCopied) {
-      const timerRef = setTimeout(() => {
-        setIsCopied(false);
-        clearTimeout(timerRef);
-      }, 2000);
+async function copyToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // fall through to legacy path
     }
+  }
+  if (typeof document === "undefined") return false;
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.setAttribute("readonly", "");
+  ta.style.position = "fixed";
+  ta.style.top = "-1000px";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.select();
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+  document.body.removeChild(ta);
+  return ok;
+}
+
+export default function CopyIcon({ text, label }: CopyIconProps) {
+  const [isCopied, setIsCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!isCopied) return;
+    timerRef.current = setTimeout(() => setIsCopied(false), 2000);
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
   }, [isCopied]);
 
   const handleCopyText = async () => {
-    await navigator.clipboard.writeText(text);
-    console.log(text);
-    setIsCopied(true);
+    const ok = await copyToClipboard(text);
+    if (ok) setIsCopied(true);
   };
 
+  const ariaLabel = isCopied
+    ? "Copied!"
+    : label
+      ? `Copy ${label}`
+      : "Copy to clipboard";
+
   return (
-    <>
-      <div>
+    <span className="copy-button-wrapper">
+      <button
+        type="button"
+        className="copy-button"
+        aria-label={ariaLabel}
+        title={ariaLabel}
+        onClick={handleCopyText}
+      >
         {!isCopied && (
           <svg
-            onClick={handleCopyText}
             xmlns="http://www.w3.org/2000/svg"
             width="16"
             height="16"
             fill="currentColor"
             className="bi bi-copy"
             viewBox="0 0 16 16"
+            aria-hidden="true"
           >
             <path
-              fill-rule="evenodd"
+              fillRule="evenodd"
               d="M4 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2zm2-1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM2 5a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-1h1v1a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1v1z"
             />
           </svg>
@@ -48,16 +93,18 @@ export default function CopyIcon({ text }: CopyIconProp) {
             fill="currentColor"
             className="bi bi-clipboard-check"
             viewBox="0 0 16 16"
+            aria-hidden="true"
           >
             <path
-              fill-rule="evenodd"
+              fillRule="evenodd"
               d="M10.854 7.146a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708 0l-1.5-1.5a.5.5 0 1 1 .708-.708L7.5 9.793l2.646-2.647a.5.5 0 0 1 .708 0"
             />
             <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1z" />
             <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0z" />
           </svg>
         )}
-      </div>
-    </>
+      </button>
+      {isCopied && <span className="copy-tooltip">Copied!</span>}
+    </span>
   );
 }

--- a/frontend/src/SkeletonBountyCard.tsx
+++ b/frontend/src/SkeletonBountyCard.tsx
@@ -1,9 +1,11 @@
+import { memo } from "react";
+
 /**
  * Skeleton placeholder that mirrors the dimensions of a real bounty-card.
  * Rendered while the initial bounty list is loading to prevent layout shift
  * and provide a smoother first render.
  */
-function SkeletonBountyCard() {
+function SkeletonBountyCardBase() {
   return (
     <article className="bounty-card skeleton-card" aria-hidden="true">
       <div className="bounty-card__top">
@@ -48,5 +50,7 @@ function SkeletonBountyCard() {
     </article>
   );
 }
+
+const SkeletonBountyCard = memo(SkeletonBountyCardBase);
 
 export default SkeletonBountyCard;


### PR DESCRIPTION
## Summary

- Closes #295 — Polish `frontend/src/CopyIcons.tsx`: fix effect cleanup (timer cancel moved to effect return), remove stray `console.log`, add visible `Copied!` tooltip + `aria-label`, fall back to `document.execCommand('copy')` when the Clipboard API is unavailable, accept an optional `label` prop. Replace the inline `CopyButton` in `BountyDetailPage.tsx` with the shared `CopyIcon` next to bounty ID, maintainer address, contributor address, and release/refund transaction hashes — all existing tests (`BountyDetailPage.test.tsx`) continue to assert the `Copied!` tooltip
- Closes #312 — Extract the bounty card from the inline `.map()` in `App.tsx` (was ~90 lines of JSX) into a module-scope `BountyCard` wrapped in `React.memo` with a custom comparator that compares only the underlying bounty fields, so function-prop identity churn from the parent does not re-render unchanged cards; wrap `BountyAmount` and `SkeletonBountyCard` in `React.memo`; `useCallback` for `handleOpenBounty`; filter/sort already lives in a `useMemo`
- Closes #319 — Write `docker-compose.yml` (was empty): `backend` and `frontend` services with `curl`-based `healthcheck` blocks (interval 10s, timeout 5s, retries 5, documented `start_period`), frontend `depends_on: backend: condition: service_healthy`. Backend probes `/api/health` (verified at `backend/src/app.ts`)
- Closes #322 — Add `.github/workflows/codeql.yml`: `javascript` language (covers JS + TS), triggers on push/PR to `main` plus weekly Monday cron, `security-extended,security-and-quality` query suites, scoped `security-events: write` permissions. `SECURITY.md` updated with a paragraph linking to the workflow

## Test plan

- [ ] `cd frontend && npm run build` passes
- [ ] `cd frontend && npm test` — `BountyDetailPage.test.tsx` still green (copy button + accessibility tests)
- [ ] `docker compose up` shows backend healthy before frontend starts; both services hit a `(healthy)` state on `docker compose ps`
- [ ] CodeQL workflow runs on this PR and uploads results to the Security tab
- [ ] React DevTools Profiler: typing in the filter does not re-render bounty cards whose data is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced copy-to-clipboard functionality with visual feedback (displays "Copied!" confirmation when copying text)

* **Chores**
  * Configured automated security analysis on code pushes and pull requests
  * Set up local development environment with containerized backend and frontend services

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->