### PR TITLE
feat: add minAmount/maxAmount query params to GET /api/bounties (#262)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -155,8 +155,33 @@ app.get("/worker/health", (_req: Request, res: Response) => {
 });
 
 app.get("/api/bounties", (req: Request, res: Response) => {
-  const q = typeof req.query.q === "string" ? req.query.q : undefined;
-  res.json({ data: listBounties({ q }) });
+  try {
+    const q = typeof req.query.q === "string" ? req.query.q : undefined;
+
+    let minAmount: number | undefined;
+    if (req.query.minAmount !== undefined) {
+      minAmount = parsePaginationValue(
+        req.query.minAmount,
+        "minAmount",
+        0,
+        0,
+      );
+    }
+
+    let maxAmount: number | undefined;
+    if (req.query.maxAmount !== undefined) {
+      maxAmount = parsePaginationValue(
+        req.query.maxAmount,
+        "maxAmount",
+        0,
+        0,
+      );
+    }
+
+    res.json({ data: listBounties({ q, minAmount, maxAmount }) });
+  } catch (error) {
+    sendError(res, req, error);
+  }
 });
 
 app.get("/api/leaderboard", (_req: Request, res: Response) => {

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -347,6 +347,10 @@ function persistUpdated(records: BountyRecord[], updated: BountyRecord): BountyR
 export interface ListBountiesOptions {
   /** Case-insensitive substring filter applied to title, summary, and labels. */
   q?: string;
+  /** Only return bounties with amount >= this value. */
+  minAmount?: number;
+  /** Only return bounties with amount <= this value. */
+  maxAmount?: number;
 }
 
 export function listBounties(options: ListBountiesOptions = {}): BountyRecord[] {
@@ -361,6 +365,13 @@ export function listBounties(options: ListBountiesOptions = {}): BountyRecord[] 
         b.summary.toLowerCase().includes(q) ||
         b.labels.some((l) => l.toLowerCase().includes(q)),
     );
+  }
+
+  if (options.minAmount !== undefined) {
+    sorted = sorted.filter((b) => b.amount >= options.minAmount!);
+  }
+  if (options.maxAmount !== undefined) {
+    sorted = sorted.filter((b) => b.amount <= options.maxAmount!);
   }
 
   return sorted;

--- a/backend/test/bountyStore.test.ts
+++ b/backend/test/bountyStore.test.ts
@@ -524,3 +524,81 @@ describe("bountyStore — event history and metrics", () => {
     expect(reserved.events.some((e) => e.type === "reserved")).toBe(true);
   });
 });
+
+describe("listBounties — amount range filter", () => {
+  it("minAmount filters bounties with amount >= threshold", async () => {
+    const { createBounty, listBounties } = await loadStore();
+
+    await createBounty({
+      repo: "acme/widget", issueNumber: 101,
+      title: "Cheap fix bounty title long enough",
+      summary: "Summary with twenty or more characters here.",
+      maintainer: MAINTAINER, tokenSymbol: "XLM", amount: 50,
+      deadlineDays: 14, labels: [],
+    });
+    await createBounty({
+      repo: "acme/widget", issueNumber: 102,
+      title: "Expensive fix bounty title long",
+      summary: "Summary with twenty or more characters here.",
+      maintainer: MAINTAINER, tokenSymbol: "XLM", amount: 500,
+      deadlineDays: 14, labels: [],
+    });
+
+    const result = listBounties({ minAmount: 100 });
+    expect(result.every((b) => b.amount >= 100)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("maxAmount filters bounties with amount <= threshold", async () => {
+    const { createBounty, listBounties } = await loadStore();
+
+    await createBounty({
+      repo: "acme/widget", issueNumber: 201,
+      title: "Low value fix bounty title long enough",
+      summary: "Summary with twenty or more characters here.",
+      maintainer: MAINTAINER, tokenSymbol: "XLM", amount: 30,
+      deadlineDays: 14, labels: [],
+    });
+    await createBounty({
+      repo: "acme/widget", issueNumber: 202,
+      title: "High value fix bounty title long enough",
+      summary: "Summary with twenty or more characters here.",
+      maintainer: MAINTAINER, tokenSymbol: "XLM", amount: 1000,
+      deadlineDays: 14, labels: [],
+    });
+
+    const result = listBounties({ maxAmount: 100 });
+    expect(result.every((b) => b.amount <= 100)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("combined minAmount + maxAmount filter", async () => {
+    const { createBounty, listBounties } = await loadStore();
+
+    await createBounty({
+      repo: "acme/widget", issueNumber: 301,
+      title: "Low range fix bounty title long enough",
+      summary: "Summary with twenty or more characters here.",
+      maintainer: MAINTAINER, tokenSymbol: "XLM", amount: 20,
+      deadlineDays: 14, labels: [],
+    });
+    await createBounty({
+      repo: "acme/widget", issueNumber: 302,
+      title: "Mid range fix bounty title long enough",
+      summary: "Summary with twenty or more characters here.",
+      maintainer: MAINTAINER, tokenSymbol: "XLM", amount: 150,
+      deadlineDays: 14, labels: [],
+    });
+    await createBounty({
+      repo: "acme/widget", issueNumber: 303,
+      title: "High range fix bounty title long enough",
+      summary: "Summary with twenty or more characters here.",
+      maintainer: MAINTAINER, tokenSymbol: "XLM", amount: 800,
+      deadlineDays: 14, labels: [],
+    });
+
+    const result = listBounties({ minAmount: 100, maxAmount: 500 });
+    expect(result.every((b) => b.amount >= 100 && b.amount <= 500)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Add optional `?minAmount=N&maxAmount=N` query parameters to `GET /api/bounties` so contributors can filter bounties by reward range server-side instead of fetching all and filtering client-side.

## Changes

- **`bountyStore.ts`**: Add `minAmount` and `maxAmount` to `ListBountiesOptions` interface with amount-range filter logic
- **`app.ts`**: Parse `minAmount`/`maxAmount` query params in route handler, reusing existing `parsePaginationValue` for integer validation (non-numeric → 400)
- **`bountyStore.test.ts`**: Add 3 integration tests covering min-only, max-only, and combined range filtering

## Test Plan

- [x] `?minAmount=100` returns only bounties with amount >= 100
- [x] `?maxAmount=100` returns only bounties with amount <= 100
- [x] `?minAmount=100&maxAmount=500` returns only bounties in [100, 500]
- [x] Non-numeric values return 400 (via existing `parsePaginationValue`)
- [x] Combined with existing `?q=` filter via AND logic

## Related

Closes #262

## Bounty

Stellar Wave: 75 points

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bounties API now supports filtering by amount range using optional minimum and maximum amount parameters.

* **Bug Fixes**
  * Improved error handling for the bounties endpoint.

* **Tests**
  * Added comprehensive test coverage for amount range filtering functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->