### PR TITLE
Deduplicate XLM/USD conversion helper

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,7 +38,19 @@ import SubmissionChecklistModal, { type SubmissionFormData } from "./SubmissionC
 import { BountyRecommendation, ContributorProfile, createDefaultProfile, generateRecommendations, updateProfileFromBounties } from "./recommendations";
 import RecommendedBounties from "./RecommendedBounties";
 import { statusCopy, actionCopy, readInitialFilters, FilterState, statusOptions, statusGlossary, sortOptions } from "./constants";
-import { filterBounties, getRewardBounds, getActiveRewardLabel, getContributorMetrics, getUniqueRepos, getRepoMetrics, sortBounties, debounce, SortOption, SortState, xlmToUsd } from "./utils";
+import {
+  filterBounties,
+  getRewardBounds,
+  getActiveRewardLabel,
+  getContributorMetrics,
+  getUniqueRepos,
+  getRepoMetrics,
+  sortBounties,
+  debounce,
+  SortOption,
+  SortState,
+} from "./utils";
+import { xlmToUsd } from "./xlmUsd";
 import { Bounty, CreateBountyPayload, OpenIssue, BountyStatus } from "./types";
 
 import GitHubIssuePreviewCard from "./GitHubIssuePreviewCard";

--- a/frontend/src/UsdAmount.tsx
+++ b/frontend/src/UsdAmount.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { xlmToUsd } from "./utils";
+import { xlmToUsd } from "./xlmUsd";
 
 interface UsdAmountProps {
   amount: number;

--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { xlmToUsd, resetXlmToUsdCache } from "./utils";
+import { xlmToUsd, resetXlmToUsdCache } from "./xlmUsd";
 
 describe("xlmToUsd", () => {
   const fetchMock = vi.fn();

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -153,57 +153,7 @@ export function getActiveRewardLabel(
   return `${min} - ${max} XLM`;
 }
 
-const XLM_USD_PRICE_URL =
-  "https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd";
-const XLM_USD_CACHE_MS = 5 * 60 * 1000;
-
-let cachedXlmUsdRate: { rate: number; fetchedAt: number } | null = null;
-
-async function fetchXlmUsdRate(): Promise<number> {
-  if (cachedXlmUsdRate && Date.now() - cachedXlmUsdRate.fetchedAt < XLM_USD_CACHE_MS) {
-    return cachedXlmUsdRate.rate;
-  }
-
-  const controller = new AbortController();
-  const timeoutId = window.setTimeout(() => controller.abort(), 5000);
-
-  try {
-    const response = await fetch(XLM_USD_PRICE_URL, { signal: controller.signal });
-    if (!response.ok) {
-      throw new Error(`Failed to fetch XLM/USD rate: ${response.status}`);
-    }
-
-    const data = (await response.json()) as { stellar?: { usd?: number } };
-    const rate = data.stellar?.usd;
-
-    if (typeof rate !== "number" || !Number.isFinite(rate)) {
-      throw new Error("CoinGecko response did not include a numeric XLM/USD rate");
-    }
-
-    cachedXlmUsdRate = { rate, fetchedAt: Date.now() };
-    return rate;
-  } finally {
-    window.clearTimeout(timeoutId);
-  }
-}
-
-export async function xlmToUsd(amount: number): Promise<string> {
-  try {
-    const rate = await fetchXlmUsdRate();
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(amount * rate);
-  } catch {
-    return "USD unavailable";
-  }
-}
-
-export function resetXlmToUsdCache(): void {
-  cachedXlmUsdRate = null;
-}
+export { xlmToUsd, resetXlmToUsdCache } from "./xlmUsd";
 
 export function getContributorMetrics(bounties: Bounty[], contributorAddress?: string) {
   if (!contributorAddress) {

--- a/frontend/src/xlmUsd.ts
+++ b/frontend/src/xlmUsd.ts
@@ -1,0 +1,61 @@
+const XLM_USD_PRICE_URL =
+  "https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd";
+const XLM_USD_CACHE_MS = 5 * 60 * 1000;
+const XLM_USD_TIMEOUT_MS = 5000;
+
+let cachedXlmUsdRate: { rate: number; fetchedAt: number } | null = null;
+let pendingXlmUsdRate: Promise<number> | null = null;
+
+async function fetchXlmUsdRate(): Promise<number> {
+  if (cachedXlmUsdRate && Date.now() - cachedXlmUsdRate.fetchedAt < XLM_USD_CACHE_MS) {
+    return cachedXlmUsdRate.rate;
+  }
+
+  if (pendingXlmUsdRate) return pendingXlmUsdRate;
+
+  pendingXlmUsdRate = (async () => {
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => controller.abort(), XLM_USD_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(XLM_USD_PRICE_URL, { signal: controller.signal });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch XLM/USD rate: ${response.status}`);
+      }
+
+      const data = (await response.json()) as { stellar?: { usd?: number } };
+      const rate = data.stellar?.usd;
+
+      if (typeof rate !== "number" || !Number.isFinite(rate)) {
+        throw new Error("CoinGecko response did not include a numeric XLM/USD rate");
+      }
+
+      cachedXlmUsdRate = { rate, fetchedAt: Date.now() };
+      return rate;
+    } finally {
+      window.clearTimeout(timeoutId);
+      pendingXlmUsdRate = null;
+    }
+  })();
+
+  return pendingXlmUsdRate;
+}
+
+export async function xlmToUsd(amount: number): Promise<string> {
+  try {
+    const rate = await fetchXlmUsdRate();
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount * rate);
+  } catch {
+    return "USD unavailable";
+  }
+}
+
+export function resetXlmToUsdCache(): void {
+  cachedXlmUsdRate = null;
+  pendingXlmUsdRate = null;
+}


### PR DESCRIPTION
Fixes #288.

Changes:
- Moves the CoinGecko XLM/USD conversion into a dedicated `xlmUsd` helper.
- Reuses the same cached + timeout-protected conversion in cards, detail, and recommended bounty displays.
- Adds in-flight request de-duping so many rendered bounty cards do not trigger duplicate price fetches.
- Keeps the existing graceful `USD unavailable` fallback.

Verification:
- `npm --prefix frontend test -- --run src/utils.test.ts` ✅
- `git diff --check` ✅
- `npm --prefix frontend run build` still blocked by existing upstream `src/api.ts(158,1): error TS1128: Declaration or statement expected.` (present before this PR)