### PR TITLE
Add social share metadata to bounty detail page

### DIFF
--- a/frontend/src/BountyDetailPage.test.tsx
+++ b/frontend/src/BountyDetailPage.test.tsx
@@ -106,6 +106,29 @@ describe("BountyDetailPage social metadata", () => {
       "Patch a critical edge case. - 250 USDC bounty",
     );
   });
+
+  it("restores previous title and social tags when unmounted", () => {
+    document.title = "Original title";
+    const previousOgTitle = document.createElement("meta");
+    previousOgTitle.setAttribute("property", "og:title");
+    previousOgTitle.setAttribute("content", "Original OG title");
+    document.head.appendChild(previousOgTitle);
+
+    const { unmount } = renderDetail();
+
+    expect(document.title).toBe("Copy button test bounty | Stellar Bounty Board");
+    expect(document.head.querySelector('meta[property="og:title"]')).toHaveAttribute("content", bounty.title);
+    expect(document.head.querySelector('meta[property="og:description"]')).toHaveAttribute(
+      "content",
+      "Make important identifiers easy to copy. - 150 XLM bounty",
+    );
+
+    unmount();
+
+    expect(document.title).toBe("Original title");
+    expect(document.head.querySelector('meta[property="og:title"]')).toHaveAttribute("content", "Original OG title");
+    expect(document.head.querySelector('meta[property="og:description"]')).not.toBeInTheDocument();
+  });
 });
 
 describe("BountyDetailPage copy actions", () => {

--- a/frontend/src/BountyDetailPage.test.tsx
+++ b/frontend/src/BountyDetailPage.test.tsx
@@ -64,6 +64,48 @@ function renderDetail(detailBounty: Bounty = bounty) {
 
 afterEach(() => {
   vi.useRealTimers();
+  document.head.querySelectorAll("meta[property^='og:'], meta[name='twitter:card']").forEach((meta) => meta.remove());
+  document.title = "";
+});
+
+describe("BountyDetailPage social metadata", () => {
+  it("sets Open Graph and Twitter tags when bounty data loads", () => {
+    render(
+      <BountyDetailPage
+        {...detailProps(bounty)}
+        avatarUrl="https://example.com/avatar.png"
+      />,
+    );
+
+    expect(document.title).toBe("Copy button test bounty | Stellar Bounty Board");
+    expect(document.head.querySelector('meta[property="og:title"]')).toHaveAttribute("content", bounty.title);
+    expect(document.head.querySelector('meta[property="og:description"]')).toHaveAttribute(
+      "content",
+      "Make important identifiers easy to copy. - 150 XLM bounty",
+    );
+    expect(document.head.querySelector('meta[property="og:url"]')).toHaveAttribute("content", window.location.href);
+    expect(document.head.querySelector('meta[property="og:image"]')).toHaveAttribute("content", "https://example.com/avatar.png");
+    expect(document.head.querySelector('meta[name="twitter:card"]')).toHaveAttribute("content", "summary_large_image");
+  });
+
+  it("updates social tags when a different bounty is rendered", () => {
+    const { rerender } = renderDetail();
+    const updatedBounty: Bounty = {
+      ...bounty,
+      title: "Fresh security bounty",
+      summary: "Patch a critical edge case.",
+      amount: 250,
+      tokenSymbol: "USDC",
+    };
+
+    rerender(<BountyDetailPage {...detailProps(updatedBounty)} />);
+
+    expect(document.head.querySelector('meta[property="og:title"]')).toHaveAttribute("content", updatedBounty.title);
+    expect(document.head.querySelector('meta[property="og:description"]')).toHaveAttribute(
+      "content",
+      "Patch a critical edge case. - 250 USDC bounty",
+    );
+  });
 });
 
 describe("BountyDetailPage copy actions", () => {

--- a/frontend/src/BountyDetailPage.test.tsx
+++ b/frontend/src/BountyDetailPage.test.tsx
@@ -66,10 +66,14 @@ afterEach(() => {
   vi.useRealTimers();
   document.head.querySelectorAll("meta[property^='og:'], meta[name='twitter:card']").forEach((meta) => meta.remove());
   document.title = "";
+  window.history.replaceState(null, "", "/");
 });
 
 describe("BountyDetailPage social metadata", () => {
   it("sets Open Graph and Twitter tags when bounty data loads", () => {
+    window.history.replaceState(null, "", "/bounties/BNTY-42?utm_source=test#comments");
+    const expectedCanonicalUrl = new URL("/bounties/BNTY-42", window.location.origin).toString();
+
     render(
       <BountyDetailPage
         {...detailProps(bounty)}
@@ -83,7 +87,7 @@ describe("BountyDetailPage social metadata", () => {
       "content",
       "Make important identifiers easy to copy. - 150 XLM bounty",
     );
-    expect(document.head.querySelector('meta[property="og:url"]')).toHaveAttribute("content", window.location.href);
+    expect(document.head.querySelector('meta[property="og:url"]')).toHaveAttribute("content", expectedCanonicalUrl);
     expect(document.head.querySelector('meta[property="og:image"]')).toHaveAttribute("content", "https://example.com/avatar.png");
     expect(document.head.querySelector('meta[name="twitter:card"]')).toHaveAttribute("content", "summary_large_image");
   });

--- a/frontend/src/BountyDetailPage.tsx
+++ b/frontend/src/BountyDetailPage.tsx
@@ -123,7 +123,10 @@ function useBountySocialMeta(bounty: Bounty | null, avatarUrl: string) {
       };
     });
 
-    const canonicalUrl = window.location.href;
+    const canonical = new URL(window.location.href);
+    canonical.search = "";
+    canonical.hash = "";
+    const canonicalUrl = canonical.toString();
     const imageUrl = avatarUrl || new URL("/og-image.png", window.location.origin).toString();
     const description = `${bounty.summary} - ${bounty.amount} ${bounty.tokenSymbol} bounty`;
     const metaContents = [bounty.title, description, canonicalUrl, imageUrl, "summary_large_image"];

--- a/frontend/src/BountyDetailPage.tsx
+++ b/frontend/src/BountyDetailPage.tsx
@@ -74,32 +74,83 @@ const EVENT_LABELS: Record<string, string> = {
 };
 
 function upsertMetaTag(selector: string, attributes: Record<string, string>) {
-  let element = document.head.querySelector<HTMLMetaElement>(selector);
-
-  if (!element) {
-    element = document.createElement("meta");
-    document.head.appendChild(element);
-  }
+  const existingElement = document.head.querySelector<HTMLMetaElement>(selector);
+  const element: HTMLMetaElement = existingElement ?? document.createElement("meta");
 
   Object.entries(attributes).forEach(([name, value]) => {
     element.setAttribute(name, value);
   });
+
+  if (!existingElement) {
+    document.head.appendChild(element);
+  }
 }
+
+const SOCIAL_META_SPECS = [
+  {
+    selector: 'meta[property="og:title"]',
+    attributes: (content: string) => ({ property: "og:title", content }),
+  },
+  {
+    selector: 'meta[property="og:description"]',
+    attributes: (content: string) => ({ property: "og:description", content }),
+  },
+  {
+    selector: 'meta[property="og:url"]',
+    attributes: (content: string) => ({ property: "og:url", content }),
+  },
+  {
+    selector: 'meta[property="og:image"]',
+    attributes: (content: string) => ({ property: "og:image", content }),
+  },
+  {
+    selector: 'meta[name="twitter:card"]',
+    attributes: (content: string) => ({ name: "twitter:card", content }),
+  },
+];
 
 function useBountySocialMeta(bounty: Bounty | null, avatarUrl: string) {
   useEffect(() => {
     if (!bounty) return;
 
+    const previousTitle = document.title;
+    const previousMeta = SOCIAL_META_SPECS.map(({ selector }) => {
+      const element = document.head.querySelector<HTMLMetaElement>(selector);
+      return {
+        selector,
+        existed: Boolean(element),
+        content: element?.getAttribute("content") ?? null,
+      };
+    });
+
     const canonicalUrl = window.location.href;
     const imageUrl = avatarUrl || new URL("/og-image.png", window.location.origin).toString();
     const description = `${bounty.summary} - ${bounty.amount} ${bounty.tokenSymbol} bounty`;
+    const metaContents = [bounty.title, description, canonicalUrl, imageUrl, "summary_large_image"];
 
     document.title = `${bounty.title} | Stellar Bounty Board`;
-    upsertMetaTag('meta[property="og:title"]', { property: "og:title", content: bounty.title });
-    upsertMetaTag('meta[property="og:description"]', { property: "og:description", content: description });
-    upsertMetaTag('meta[property="og:url"]', { property: "og:url", content: canonicalUrl });
-    upsertMetaTag('meta[property="og:image"]', { property: "og:image", content: imageUrl });
-    upsertMetaTag('meta[name="twitter:card"]', { name: "twitter:card", content: "summary_large_image" });
+    SOCIAL_META_SPECS.forEach((spec, index) => {
+      upsertMetaTag(spec.selector, spec.attributes(metaContents[index]));
+    });
+
+    return () => {
+      document.title = previousTitle;
+      previousMeta.forEach(({ selector, existed, content }) => {
+        const element = document.head.querySelector<HTMLMetaElement>(selector);
+        if (!element) return;
+
+        if (!existed) {
+          element.remove();
+          return;
+        }
+
+        if (content === null) {
+          element.removeAttribute("content");
+        } else {
+          element.setAttribute("content", content);
+        }
+      });
+    };
   }, [avatarUrl, bounty]);
 }
 

--- a/frontend/src/BountyDetailPage.tsx
+++ b/frontend/src/BountyDetailPage.tsx
@@ -73,6 +73,36 @@ const EVENT_LABELS: Record<string, string> = {
   expired: "Bounty expired",
 };
 
+function upsertMetaTag(selector: string, attributes: Record<string, string>) {
+  let element = document.head.querySelector<HTMLMetaElement>(selector);
+
+  if (!element) {
+    element = document.createElement("meta");
+    document.head.appendChild(element);
+  }
+
+  Object.entries(attributes).forEach(([name, value]) => {
+    element.setAttribute(name, value);
+  });
+}
+
+function useBountySocialMeta(bounty: Bounty | null, avatarUrl: string) {
+  useEffect(() => {
+    if (!bounty) return;
+
+    const canonicalUrl = window.location.href;
+    const imageUrl = avatarUrl || new URL("/og-image.png", window.location.origin).toString();
+    const description = `${bounty.summary} - ${bounty.amount} ${bounty.tokenSymbol} bounty`;
+
+    document.title = `${bounty.title} | Stellar Bounty Board`;
+    upsertMetaTag('meta[property="og:title"]', { property: "og:title", content: bounty.title });
+    upsertMetaTag('meta[property="og:description"]', { property: "og:description", content: description });
+    upsertMetaTag('meta[property="og:url"]', { property: "og:url", content: canonicalUrl });
+    upsertMetaTag('meta[property="og:image"]', { property: "og:image", content: imageUrl });
+    upsertMetaTag('meta[name="twitter:card"]', { name: "twitter:card", content: "summary_large_image" });
+  }, [avatarUrl, bounty]);
+}
+
 function BountyTimeline({ events, formatTimestamp }: { events: BountyEvent[]; formatTimestamp: (v?: number) => string }) {
   if (!events || events.length === 0) return null;
 
@@ -118,6 +148,7 @@ export default function BountyDetailPage({
   formatTimestamp,
 }: Props) {
   const statusAnnouncement = useBountyStatusAnnouncement(bounty, statusCopy);
+  useBountySocialMeta(bounty, avatarUrl);
 
   function handlePrint() {
     window.print();


### PR DESCRIPTION
## Summary
- add dynamic Open Graph metadata for bounty detail pages
- set Twitter card metadata and document title from loaded bounty details
- cover metadata creation and updates with focused BountyDetailPage tests

Fixes #309

## Testing
- `npm test -- BountyDetailPage.test.tsx`

## Notes
- The broader frontend build is currently blocked by an unrelated existing TypeScript issue in `frontend/src/api.ts:158`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounty detail pages now set social sharing metadata (title, description, image, url, twitter card) and restore/clean up the page title and injected tags when the page is unmounted.

* **Tests**
  * Added tests for social metadata: verify meta tag contents, ensure updates when bounty data changes, and confirm cleanup/restoration after rerender/unmount.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/432?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->