### PR TITLE
fix: Add expiration status badge with color coding to BountyCard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -207,6 +207,28 @@ function bountyCardPropsEqual(prev: BountyCardProps, next: BountyCardProps): boo
 }
 
 const BountyCard = memo(function BountyCard({ bounty, onOpen, renderActionButton }: BountyCardProps) {
+  const getStatusColor = (status: BountyStatus, deadlineAt: number): string => {
+    if (status === "expired" || status === "released" || status === "refunded") {
+      return "grey";
+    }
+    if (status === "disputed") {
+      return "blue";
+    }
+    
+    const now = Date.now();
+    const timeRemaining = deadlineAt - now;
+    
+    if (timeRemaining < 24 * 60 * 60 * 1000) {
+      return "red";
+    }
+    if (timeRemaining < 7 * 24 * 60 * 60 * 1000) {
+      return "yellow";
+    }
+    return "green";
+  };
+
+  const statusColor = getStatusColor(bounty.status, bounty.deadlineAt);
+
   return (
     <article
       className="bounty-card"
@@ -223,7 +245,7 @@ const BountyCard = memo(function BountyCard({ bounty, onOpen, renderActionButton
       <div className="bounty-card__top">
         <div>
           <span
-            className={`status-pill status-pill--${bounty.status}`}
+            className={`status-pill status-pill--${statusColor}`}
             title={statusCopy[bounty.status].description}
             aria-label={`${statusCopy[bounty.status].label}: ${statusCopy[bounty.status].description}`}
           >


### PR DESCRIPTION
## Fix

Added expiration-based color coding to BountyCard status badge.

- Green: expires > 7 days
- Yellow: expires in 1-7 days
- Red: expires in < 24 hours
- Grey: expired/released/refunded

Closes #376

 Generated by bounty-bot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Bounty status colors now incorporate deadline urgency: terminal statuses display as grey, disputed as blue, and others shift between red (within 24h), yellow (within 7d), or green based on deadline proximity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->