### PR TITLE
Validate submission PR repository

### DIFF
--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { sendNotification, type NotificationRecipient } from "./notificationService";
 import { logStructured } from "../logger";
+import { assertGitHubPrMatchesRepo } from "../validation/prUrl";
 
 export type BountyStatus =
   | "open"
@@ -479,6 +480,7 @@ export async function submitBounty(
     if (bounty.contributor !== contributor) {
       throw new Error("Only the reserved contributor can submit this bounty.");
     }
+    assertGitHubPrMatchesRepo(submissionUrl, bounty.repo);
 
     const now = nowInSeconds();
     const updated: BountyRecord = {

--- a/backend/src/validation/prUrl.ts
+++ b/backend/src/validation/prUrl.ts
@@ -4,7 +4,12 @@ const GITHUB_PR_URL_REGEX = /^https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9
 
 export function extractGitHubPrRepo(submissionUrl: string): string | null {
   try {
-    const parsedUrl = new URL(submissionUrl.trim());
+    const normalizedUrl = submissionUrl.trim();
+    if (!GITHUB_PR_URL_REGEX.test(normalizedUrl)) {
+      return null;
+    }
+
+    const parsedUrl = new URL(normalizedUrl);
     if (parsedUrl.hostname !== "github.com") {
       return null;
     }
@@ -15,6 +20,14 @@ export function extractGitHubPrRepo(submissionUrl: string): string | null {
     }
 
     if (!/^\d+$/.test(number)) {
+      return null;
+    }
+
+    if (
+      parsedUrl.search !== "" ||
+      parsedUrl.hash !== "" ||
+      parsedUrl.pathname !== `/${owner}/${repo}/pull/${number}`
+    ) {
       return null;
     }
 

--- a/backend/src/validation/prUrl.ts
+++ b/backend/src/validation/prUrl.ts
@@ -2,6 +2,40 @@ import { z } from "zod";
 
 const GITHUB_PR_URL_REGEX = /^https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/pull\/\d+$/;
 
+export function extractGitHubPrRepo(submissionUrl: string): string | null {
+  try {
+    const parsedUrl = new URL(submissionUrl.trim());
+    if (parsedUrl.hostname !== "github.com") {
+      return null;
+    }
+
+    const [owner, repo, segment, number, ...extraSegments] = parsedUrl.pathname.split("/").filter(Boolean);
+    if (!owner || !repo || segment !== "pull" || !number || extraSegments.length > 0) {
+      return null;
+    }
+
+    if (!/^\d+$/.test(number)) {
+      return null;
+    }
+
+    return `${owner}/${repo}`;
+  } catch {
+    return null;
+  }
+}
+
+export function assertGitHubPrMatchesRepo(submissionUrl: string, bountyRepo: string): void {
+  const prRepo = extractGitHubPrRepo(submissionUrl);
+  if (!prRepo) {
+    throw new Error("Submission URL must follow format https://github.com/<owner>/<repo>/pull/<number>");
+  }
+
+  // GitHub owner and repository names are case-insensitive for URL matching.
+  if (prRepo.toLowerCase() !== bountyRepo.trim().toLowerCase()) {
+    throw new Error(`Submission URL must point to a pull request in ${bountyRepo}.`);
+  }
+}
+
 export const githubPrUrlSchema = z
   .string()
   .trim()

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -124,6 +124,10 @@ export const submitBountySchema = z
     contributor: stellarAccountSchema.openapi({
       description: "Must match the contributor who reserved the bounty.",
     }),
+    submissionUrl: githubPrUrlSchema.openapi({
+      example: "https://github.com/owner/repo/pull/99",
+      description: "GitHub pull request URL for the submitted work.",
+    }),
 
     notes: z
       .string()

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -169,6 +169,72 @@ describe("API — bounty lifecycle routes", () => {
     expect(logs.body.pagination.total).toBe(3);
   });
 
+  it("rejects a submission URL from a different GitHub repo", async () => {
+    const app = await getApp();
+    const { body: created } = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+    const id = created.data.id as string;
+
+    await request(app)
+      .post(`/api/bounties/${id}/reserve`)
+      .send({ contributor: CONTRIBUTOR })
+      .expect(200);
+
+    const res = await request(app)
+      .post(`/api/bounties/${id}/submit`)
+      .send({
+        contributor: CONTRIBUTOR,
+        submissionUrl: "https://github.com/other-owner/other-repo/pull/1",
+      })
+      .expect(400);
+
+    expect(res.body.error).toContain("owner/repo-name");
+  });
+
+  it("rejects a non-GitHub submission URL", async () => {
+    const app = await getApp();
+    const { body: created } = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+    const id = created.data.id as string;
+
+    await request(app)
+      .post(`/api/bounties/${id}/reserve`)
+      .send({ contributor: CONTRIBUTOR })
+      .expect(200);
+
+    const res = await request(app)
+      .post(`/api/bounties/${id}/submit`)
+      .send({
+        contributor: CONTRIBUTOR,
+        submissionUrl: "https://gitlab.com/owner/repo-name/-/merge_requests/1",
+      })
+      .expect(400);
+
+    expect(res.body.error).toMatch(/github\.com/i);
+  });
+
+  it("accepts a matching private-style GitHub repo URL", async () => {
+    const app = await getApp();
+    const { body: created } = await request(app)
+      .post("/api/bounties")
+      .send({ ...validCreateBody, repo: "private-owner/private-repo", issueNumber: 100 })
+      .expect(201);
+    const id = created.data.id as string;
+
+    await request(app)
+      .post(`/api/bounties/${id}/reserve`)
+      .send({ contributor: CONTRIBUTOR })
+      .expect(200);
+
+    const res = await request(app)
+      .post(`/api/bounties/${id}/submit`)
+      .send({
+        contributor: CONTRIBUTOR,
+        submissionUrl: "https://github.com/private-owner/private-repo/pull/7",
+      })
+      .expect(200);
+
+    expect(res.body.data.submissionUrl).toBe("https://github.com/private-owner/private-repo/pull/7");
+  });
+
   it("GET /api/bounties/:id/audit-logs supports pagination", async () => {
     const app = await getApp();
     const { body: created } = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
@@ -319,7 +385,7 @@ describe("GET /api/leaderboard", () => {
     await request(app).post(`/api/bounties/${id}/reserve`).send({ contributor: CONTRIBUTOR }).expect(200);
     await request(app)
       .post(`/api/bounties/${id}/submit`)
-      .send({ contributor: CONTRIBUTOR, submissionUrl: "https://github.com/owner/repo/pull/1" })
+      .send({ contributor: CONTRIBUTOR, submissionUrl: "https://github.com/owner/repo-name/pull/1" })
       .expect(200);
     await request(app).post(`/api/bounties/${id}/release`).send({ maintainer: MAINTAINER }).expect(200);
 
@@ -341,7 +407,7 @@ describe("GET /api/leaderboard", () => {
       await request(app).post(`/api/bounties/${id}/reserve`).send({ contributor: CONTRIBUTOR }).expect(200);
       await request(app)
         .post(`/api/bounties/${id}/submit`)
-        .send({ contributor: CONTRIBUTOR, submissionUrl: `https://github.com/owner/repo/pull/${i + 1}` })
+        .send({ contributor: CONTRIBUTOR, submissionUrl: `https://github.com/owner/repo-name/pull/${i + 1}` })
         .expect(200);
       await request(app).post(`/api/bounties/${id}/release`).send({ maintainer: MAINTAINER }).expect(200);
     }
@@ -358,14 +424,14 @@ describe("GET /api/leaderboard", () => {
     // CONTRIBUTOR gets one bounty released
     const { body: c1 } = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
     await request(app).post(`/api/bounties/${c1.data.id}/reserve`).send({ contributor: CONTRIBUTOR }).expect(200);
-    await request(app).post(`/api/bounties/${c1.data.id}/submit`).send({ contributor: CONTRIBUTOR, submissionUrl: "https://github.com/o/r/pull/1" }).expect(200);
+    await request(app).post(`/api/bounties/${c1.data.id}/submit`).send({ contributor: CONTRIBUTOR, submissionUrl: "https://github.com/owner/repo-name/pull/1" }).expect(200);
     await request(app).post(`/api/bounties/${c1.data.id}/release`).send({ maintainer: MAINTAINER }).expect(200);
 
     // OTHER_ACCOUNT gets two bounties released (more XLM)
     for (let i = 0; i < 2; i++) {
       const { body: c2 } = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
       await request(app).post(`/api/bounties/${c2.data.id}/reserve`).send({ contributor: OTHER_ACCOUNT }).expect(200);
-      await request(app).post(`/api/bounties/${c2.data.id}/submit`).send({ contributor: OTHER_ACCOUNT, submissionUrl: `https://github.com/o/r/pull/${i + 10}` }).expect(200);
+      await request(app).post(`/api/bounties/${c2.data.id}/submit`).send({ contributor: OTHER_ACCOUNT, submissionUrl: `https://github.com/owner/repo-name/pull/${i + 10}` }).expect(200);
       await request(app).post(`/api/bounties/${c2.data.id}/release`).send({ maintainer: MAINTAINER }).expect(200);
     }
 
@@ -380,7 +446,7 @@ describe("GET /api/leaderboard", () => {
     const id = created.data.id as string;
 
     await request(app).post(`/api/bounties/${id}/reserve`).send({ contributor: CONTRIBUTOR }).expect(200);
-    await request(app).post(`/api/bounties/${id}/submit`).send({ contributor: CONTRIBUTOR, submissionUrl: "https://github.com/o/r/pull/1" }).expect(200);
+    await request(app).post(`/api/bounties/${id}/submit`).send({ contributor: CONTRIBUTOR, submissionUrl: "https://github.com/owner/repo-name/pull/1" }).expect(200);
     await request(app).post(`/api/bounties/${id}/release`).send({ maintainer: MAINTAINER }).expect(200);
 
     const res = await request(app).get("/api/leaderboard").expect(200);

--- a/backend/test/authMiddleware.test.ts
+++ b/backend/test/authMiddleware.test.ts
@@ -89,7 +89,7 @@ describe("Stellar auth middleware", () => {
     await request(app).post(`/api/bounties/${id}/reserve`).send({ contributor: validMaintainerPublicKey }).expect(200);
     await request(app)
       .post(`/api/bounties/${id}/submit`)
-      .send({ contributor: validMaintainerPublicKey, submissionUrl: "https://example.com/pr/1" })
+      .send({ contributor: validMaintainerPublicKey, submissionUrl: "https://github.com/owner/repo/pull/1" })
       .expect(200);
 
     const payload = { maintainer: validMaintainerPublicKey, transactionHash: "a".repeat(64) };

--- a/backend/test/bountyStore.test.ts
+++ b/backend/test/bountyStore.test.ts
@@ -261,7 +261,7 @@ describe("bountyStore — invalid transitions and errors", () => {
     await reserveBounty(b.id, CONTRIBUTOR);
     await expect(async () => await reserveBounty(b.id, CONTRIBUTOR)).rejects.toThrow(/only open/i);
 
-    await submitBounty(b.id, CONTRIBUTOR, "https://example.com/pr/1");
+    await submitBounty(b.id, CONTRIBUTOR, "https://github.com/acme/widget/pull/1");
     await expect(async () => await reserveBounty(b.id, CONTRIBUTOR)).rejects.toThrow(/only open/i);
 
     await releaseBounty(b.id, MAINTAINER);
@@ -296,10 +296,10 @@ describe("bountyStore — invalid transitions and errors", () => {
       labels: [],
     });
 
-    await expect(async () => await submitBounty(b.id, CONTRIBUTOR, "https://example.com/pr/1")).rejects.toThrow(/only reserved/i);
+    await expect(async () => await submitBounty(b.id, CONTRIBUTOR, "https://github.com/acme/widget/pull/1")).rejects.toThrow(/only reserved/i);
 
     await reserveBounty(b.id, CONTRIBUTOR);
-    await expect(async () => await submitBounty(b.id, OTHER_ACCOUNT, "https://example.com/pr/1")).rejects.toThrow(/reserved contributor/i);
+    await expect(async () => await submitBounty(b.id, OTHER_ACCOUNT, "https://github.com/acme/widget/pull/1")).rejects.toThrow(/reserved contributor/i);
   });
 
   it("release: requires maintainer and submitted status", async () => {
@@ -321,7 +321,7 @@ describe("bountyStore — invalid transitions and errors", () => {
     await reserveBounty(b.id, CONTRIBUTOR);
     await expect(async () => await releaseBounty(b.id, MAINTAINER)).rejects.toThrow(/only submitted/i);
 
-    await submitBounty(b.id, CONTRIBUTOR, "https://example.com/pr/1");
+    await submitBounty(b.id, CONTRIBUTOR, "https://github.com/acme/widget/pull/1");
     await expect(async () => await releaseBounty(b.id, OTHER_ACCOUNT)).rejects.toThrow(/maintainer address/i);
 
     const released = await releaseBounty(b.id, MAINTAINER);
@@ -357,7 +357,7 @@ describe("bountyStore — invalid transitions and errors", () => {
       labels: [],
     });
     await reserveBounty(flow.id, CONTRIBUTOR);
-    await submitBounty(flow.id, CONTRIBUTOR, "https://example.com/pr/1");
+    await submitBounty(flow.id, CONTRIBUTOR, "https://github.com/acme/widget/pull/1");
     await expect(async () => await refundBounty(flow.id, MAINTAINER)).rejects.toThrow(/submitted bounties/i);
 
     const rel = await createBounty({
@@ -372,7 +372,7 @@ describe("bountyStore — invalid transitions and errors", () => {
       labels: [],
     });
     await reserveBounty(rel.id, CONTRIBUTOR);
-    await submitBounty(rel.id, CONTRIBUTOR, "https://example.com/pr/1");
+    await submitBounty(rel.id, CONTRIBUTOR, "https://github.com/acme/widget/pull/1");
     await releaseBounty(rel.id, MAINTAINER);
     await expect(async () => await refundBounty(rel.id, MAINTAINER)).rejects.toThrow(/finalized/i);
 

--- a/backend/test/githubPrWebhook.test.ts
+++ b/backend/test/githubPrWebhook.test.ts
@@ -60,7 +60,7 @@ describe("GitHub webhook PR auto-release", () => {
   it("Merged PR triggers bounty release automatically", async () => {
     const { createBounty, reserveBounty, submitBounty, listBounties } = await getStoreStore();
     const app = await getApp();
-    const prUrl = "https://github.com/owner/repo/pull/100";
+    const prUrl = "https://github.com/owner/repo-name/pull/100";
     
     // Create, reserve, submit
     const bounty = await createBounty(validCreateBody);
@@ -88,7 +88,7 @@ describe("GitHub webhook PR auto-release", () => {
   it("Closed-but-not-merged PR does not trigger release", async () => {
     const { createBounty, reserveBounty, submitBounty, listBounties } = await getStoreStore();
     const app = await getApp();
-    const prUrl = "https://github.com/owner/repo/pull/101";
+    const prUrl = "https://github.com/owner/repo-name/pull/101";
     
     // Create, reserve, submit
     const bounty = await createBounty(validCreateBody);
@@ -114,8 +114,8 @@ describe("GitHub webhook PR auto-release", () => {
   it("Bounty without matching PR URL is ignored gracefully", async () => {
     const { createBounty, reserveBounty, submitBounty, listBounties } = await getStoreStore();
     const app = await getApp();
-    const prUrl = "https://github.com/owner/repo/pull/102";
-    const differentPrUrl = "https://github.com/owner/repo/pull/999";
+    const prUrl = "https://github.com/owner/repo-name/pull/102";
+    const differentPrUrl = "https://github.com/owner/repo-name/pull/999";
     
     // Create, reserve, submit
     const bounty = await createBounty(validCreateBody);
@@ -141,7 +141,7 @@ describe("GitHub webhook PR auto-release", () => {
   it("Manual release still works if webhook was not received", async () => {
     const { createBounty, reserveBounty, submitBounty } = await getStoreStore();
     const app = await getApp();
-    const prUrl = "https://github.com/owner/repo/pull/103";
+    const prUrl = "https://github.com/owner/repo-name/pull/103";
     
     const bounty = await createBounty(validCreateBody);
     await reserveBounty(bounty.id, CONTRIBUTOR);

--- a/backend/test/prUrl.test.ts
+++ b/backend/test/prUrl.test.ts
@@ -16,6 +16,22 @@ describe("GitHub PR URL validation", () => {
     expect(extractGitHubPrRepo("https://gitlab.com/owner/repo-name/-/merge_requests/42")).toBeNull();
   });
 
+  it("rejects malformed GitHub PR URL variants", () => {
+    const malformedUrls = [
+      "https://github.com/owner/repo-name/pull/42/",
+      "https://github.com/owner/repo-name/pull/42?tab=files",
+      "https://github.com/owner/repo-name/pull/42#discussion_r1",
+      "https://github.com:443/owner/repo-name/pull/42",
+    ];
+
+    for (const malformedUrl of malformedUrls) {
+      expect(extractGitHubPrRepo(malformedUrl)).toBeNull();
+      expect(() => assertGitHubPrMatchesRepo(malformedUrl, "owner/repo-name")).toThrow(
+        /Submission URL must follow format/,
+      );
+    }
+  });
+
   it("accepts a matching private-style GitHub repository URL", () => {
     expect(() =>
       assertGitHubPrMatchesRepo("https://github.com/private-owner/private-repo/pull/7", "private-owner/private-repo"),

--- a/backend/test/prUrl.test.ts
+++ b/backend/test/prUrl.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { assertGitHubPrMatchesRepo, extractGitHubPrRepo } from "../src/validation/prUrl";
+
+describe("GitHub PR URL validation", () => {
+  it("extracts the repository from a valid GitHub PR URL", () => {
+    expect(extractGitHubPrRepo("https://github.com/owner/repo-name/pull/42")).toBe("owner/repo-name");
+  });
+
+  it("rejects a PR URL from the wrong repository", () => {
+    expect(() =>
+      assertGitHubPrMatchesRepo("https://github.com/other-owner/other-repo/pull/42", "owner/repo-name"),
+    ).toThrow(/owner\/repo-name/);
+  });
+
+  it("rejects a non-GitHub PR URL", () => {
+    expect(extractGitHubPrRepo("https://gitlab.com/owner/repo-name/-/merge_requests/42")).toBeNull();
+  });
+
+  it("accepts a matching private-style GitHub repository URL", () => {
+    expect(() =>
+      assertGitHubPrMatchesRepo("https://github.com/private-owner/private-repo/pull/7", "private-owner/private-repo"),
+    ).not.toThrow();
+  });
+});

--- a/backend/test/reservationExpirationJob.test.ts
+++ b/backend/test/reservationExpirationJob.test.ts
@@ -162,7 +162,7 @@ describe("expireStaleReservations", () => {
       deadlineDays: 30, labels: [],
     });
     store.reserveBounty(bounty.id, CONTRIBUTOR);
-    store.submitBounty(bounty.id, CONTRIBUTOR, "https://github.com/pr/1");
+    store.submitBounty(bounty.id, CONTRIBUTOR, "https://github.com/test/repo/pull/1");
 
     const { expireStaleReservations } = await loadJob();
     const result = expireStaleReservations(0); // TTL 0 would expire anything reserved


### PR DESCRIPTION
Closes #261

## Summary
- add shared submission URL validation that extracts the GitHub PR repository and compares it against the bounty repository
- reject non-GitHub PR URLs, malformed PR URLs, and PRs opened against a different repository with HTTP 400 errors
- add focused URL validation tests plus API/store coverage for matching, mismatched, non-GitHub, and private-style GitHub repository URLs

## Validation
- npm --prefix backend run build
- npm --prefix backend test -- test/prUrl.test.ts
- npm --prefix backend test -- test/api.test.ts -t "submission URL|private-style"
- npm --prefix backend test -- test/bountyStore.test.ts
- npm --prefix backend test -- test/githubPrWebhook.test.ts
- npm --prefix backend test -- test/authMiddleware.test.ts -t "allows release"

Note: the full `npm --prefix backend test` suite currently has unrelated existing failures around amount validation, expiry utility exports, an empty utils test file, auth missing-signature ordering, and reservation expiration setup. The focused tests above cover this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounty submissions now require a valid GitHub PR URL that matches the bounty’s repository; invalid, non-GitHub, or mismatched PR URLs are rejected. The submission payload now includes a documented PR URL field with an example.
* **Tests**
  * Added and updated tests covering PR URL validation, matching/mismatched repos, malformed URLs, and related submission flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->