### PR TITLE
Harden bounty URL validation against SSRF

### DIFF
--- a/backend/src/validation/prUrl.ts
+++ b/backend/src/validation/prUrl.ts
@@ -2,10 +2,43 @@ import { z } from "zod";
 
 const GITHUB_PR_URL_REGEX = /^https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/pull\/\d+$/;
 
+export function isPrivateNetworkHostname(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase().replace(/^\[|\]$/g, "");
+
+  if (normalized === "localhost" || normalized === "::1" || normalized === "0:0:0:0:0:0:0:1") {
+    return true;
+  }
+
+  if (
+    normalized === "0.0.0.0" ||
+    normalized.startsWith("127.") ||
+    normalized.startsWith("10.") ||
+    normalized.startsWith("192.168.") ||
+    normalized.startsWith("169.254.")
+  ) {
+    return true;
+  }
+
+  return /^172\.(1[6-9]|2\d|3[01])\./.test(normalized);
+}
+
+function isServerFetchSafeUrl(url: string): boolean {
+  try {
+    const parsedUrl = new URL(url);
+    return parsedUrl.protocol === "https:" && !isPrivateNetworkHostname(parsedUrl.hostname);
+  } catch {
+    return false;
+  }
+}
+
 export const githubPrUrlSchema = z
   .string()
   .trim()
   .url()
+  // Keep this strict because submissionUrl may later be fetched server-side for PR previews or webhook reconciliation.
+  .refine((url) => isServerFetchSafeUrl(url), {
+    message: "Submission URL must be an HTTPS URL on a public host",
+  })
   .refine(
     (url) => {
       try {

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -124,6 +124,10 @@ export const submitBountySchema = z
     contributor: stellarAccountSchema.openapi({
       description: "Must match the contributor who reserved the bounty.",
     }),
+    submissionUrl: githubPrUrlSchema.openapi({
+      example: "https://github.com/owner/repo/pull/99",
+      description: "GitHub pull request URL for the submitted work.",
+    }),
 
     notes: z
       .string()

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -76,6 +76,15 @@ describe("API — bounty lifecycle routes", () => {
     expect(res.body.error).toBeDefined();
   });
 
+  it("POST create rejects repo values that look like URLs", async () => {
+    const app = await getApp();
+    const res = await request(app)
+      .post("/api/bounties")
+      .send({ ...validCreateBody, repo: "https://127.0.0.1/private/repo" })
+      .expect(400);
+    expect(res.body.error).toMatch(/repo/i);
+  });
+
   it("POST create with amount below 1 XLM returns 400", async () => {
     const app = await getApp();
     const res = await request(app)
@@ -264,6 +273,34 @@ describe("API — bounty lifecycle routes", () => {
       .send({ maintainer: MAINTAINER })
       .expect(400);
     expect(res.body.error).toMatch(/submitted/i);
+  });
+
+  it("POST submit rejects private IP submission URLs", async () => {
+    const app = await getApp();
+    const { body: created } = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+    const id = created.data.id as string;
+
+    await request(app).post(`/api/bounties/${id}/reserve`).send({ contributor: CONTRIBUTOR }).expect(200);
+
+    const res = await request(app)
+      .post(`/api/bounties/${id}/submit`)
+      .send({ contributor: CONTRIBUTOR, submissionUrl: "https://127.0.0.1/owner/repo/pull/1" })
+      .expect(400);
+    expect(res.body.error).toMatch(/Submission URL/i);
+  });
+
+  it("POST submit rejects data URI submission URLs", async () => {
+    const app = await getApp();
+    const { body: created } = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+    const id = created.data.id as string;
+
+    await request(app).post(`/api/bounties/${id}/reserve`).send({ contributor: CONTRIBUTOR }).expect(200);
+
+    const res = await request(app)
+      .post(`/api/bounties/${id}/submit`)
+      .send({ contributor: CONTRIBUTOR, submissionUrl: "data:text/plain,https://github.com/owner/repo/pull/1" })
+      .expect(400);
+    expect(res.body.error).toMatch(/Submission URL/i);
   });
 
   it("wrong maintainer on release returns 400", async () => {

--- a/backend/test/authMiddleware.test.ts
+++ b/backend/test/authMiddleware.test.ts
@@ -89,7 +89,7 @@ describe("Stellar auth middleware", () => {
     await request(app).post(`/api/bounties/${id}/reserve`).send({ contributor: validMaintainerPublicKey }).expect(200);
     await request(app)
       .post(`/api/bounties/${id}/submit`)
-      .send({ contributor: validMaintainerPublicKey, submissionUrl: "https://example.com/pr/1" })
+      .send({ contributor: validMaintainerPublicKey, submissionUrl: "https://github.com/owner/repo/pull/1" })
       .expect(200);
 
     const payload = { maintainer: validMaintainerPublicKey, transactionHash: "a".repeat(64) };

--- a/backend/test/ssrfValidation.test.ts
+++ b/backend/test/ssrfValidation.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { createBountySchema, submitBountySchema } from "../src/validation/schemas";
+import { CONTRIBUTOR, validCreateBody } from "./fixtures";
+
+describe("SSRF-safe bounty input validation", () => {
+  it("accepts a valid GitHub pull request submission URL", () => {
+    const result = submitBountySchema.safeParse({
+      contributor: CONTRIBUTOR,
+      submissionUrl: "https://github.com/owner/repo/pull/123",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a private IP submission URL", () => {
+    const result = submitBountySchema.safeParse({
+      contributor: CONTRIBUTOR,
+      submissionUrl: "https://127.0.0.1/internal/pull/1",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a localhost submission URL", () => {
+    const result = submitBountySchema.safeParse({
+      contributor: CONTRIBUTOR,
+      submissionUrl: "https://localhost/owner/repo/pull/1",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a data URI submission URL", () => {
+    const result = submitBountySchema.safeParse({
+      contributor: CONTRIBUTOR,
+      submissionUrl: "data:text/plain,https://github.com/owner/repo/pull/1",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a repo in owner/repo format", () => {
+    const result = createBountySchema.safeParse(validCreateBody);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects repo values that look like URLs", () => {
+    const result = createBountySchema.safeParse({
+      ...validCreateBody,
+      repo: "https://127.0.0.1/private/repo",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #348

## Summary
- harden `submissionUrl` validation so submissions must use `https://github.com/<owner>/<repo>/pull/<number>` on a public HTTPS host
- keep private network hosts such as localhost, 127.0.0.1, RFC1918 ranges, and link-local IPs out of server-side-fetchable URL inputs
- ensure `submissionUrl` is part of the submit request schema and add tests for SSRF-style inputs
- cover repo values that look like URLs so `repo` remains restricted to `owner/repo`

## Validation
- `npm --prefix backend run build`
- `git diff --check`
- `npm --prefix backend test -- test/ssrfValidation.test.ts`
- `npm --prefix backend test -- test/api.test.ts -t "repo values|private IP submission|data URI submission|reserve → submit → release"`
- `npm --prefix backend test -- test/authMiddleware.test.ts -t "allows release"`

Full `npm --prefix backend test` still has unrelated baseline failures on this branch: amount upper-bound/decimal validation expectations, missing `expireStaleReservations` export in `test/expiry.test.ts`, one unsigned release auth ordering expectation, reservation expiration state setup, and an empty `test/utils.test.ts` suite. The focused SSRF validation and API coverage above pass.
