### PR TITLE
Prevent replay attacks in Stellar signature auth

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3,6 +3,7 @@ import express, { Request, Response, NextFunction } from "express";
 import { randomUUID } from "node:crypto";
 import swaggerUi from "swagger-ui-express";
 import { buildCorsOptions } from "./middleware/corsOptions";
+import { createStellarSignatureAuthMiddleware } from "./middleware/auth";
 import { generateOpenApiDocument } from "./docs/openapi";
 
 import {
@@ -86,6 +87,8 @@ app.use(requestContextMiddleware);
 
 const swaggerDoc = generateOpenApiDocument();
 app.use("/api/docs", swaggerUi.serve, swaggerUi.setup(swaggerDoc));
+const releaseAuth = createStellarSignatureAuthMiddleware("release");
+const refundAuth = createStellarSignatureAuthMiddleware("refund");
 
 function parseId(raw: string | string[] | undefined): string {
   return bountyIdSchema.parse(Array.isArray(raw) ? raw[0] : raw);
@@ -281,7 +284,7 @@ app.post("/api/bounties/:id/submit", limiter, async (req: Request, res: Response
   }
 });
 
-app.post("/api/bounties/:id/release", limiter, async (req: Request, res: Response) => {
+app.post("/api/bounties/:id/release", limiter, releaseAuth, async (req: Request, res: Response) => {
   const parsedBody = maintainerActionSchema.safeParse(req.body);
   if (!parsedBody.success) {
     jsonError(res, req, 400, zodErrorMessage(parsedBody.error));
@@ -300,7 +303,7 @@ app.post("/api/bounties/:id/release", limiter, async (req: Request, res: Respons
   }
 });
 
-app.post("/api/bounties/:id/refund", limiter, async (req: Request, res: Response) => {
+app.post("/api/bounties/:id/refund", limiter, refundAuth, async (req: Request, res: Response) => {
   const parsedBody = maintainerActionSchema.safeParse(req.body);
   if (!parsedBody.success) {
     jsonError(res, req, 400, zodErrorMessage(parsedBody.error));

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -5,6 +5,12 @@ const HEADER_SIGNATURE = "x-stellar-signature";
 const HEADER_PUBLIC_KEY = "x-stellar-public-key";
 const ENV_PUBLIC_KEY = "MAINTAINER_PUBLIC_KEY";
 const ENV_PUBLIC_KEYS = "MAINTAINER_PUBLIC_KEYS";
+const REPLAY_WINDOW_SECONDS = 60;
+const MAX_NONCE_LENGTH = 128;
+
+type SignedAction = "release" | "refund";
+
+const usedNonces = new Map<string, number>();
 
 interface RawBodyRequest extends Request {
   rawBody?: Buffer;
@@ -72,7 +78,60 @@ function verifyStellarSignature(publicKey: string, payload: Buffer, signatureHea
   return false;
 }
 
-export function createStellarSignatureAuthMiddleware(): RequestHandler {
+function nowInSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function cleanupExpiredNonces(now: number): void {
+  for (const [nonceKey, expiresAt] of usedNonces.entries()) {
+    if (expiresAt <= now) {
+      usedNonces.delete(nonceKey);
+    }
+  }
+}
+
+function getSignedActionValue(req: Request, key: string): unknown {
+  return req.body && typeof req.body === "object" ? (req.body as Record<string, unknown>)[key] : undefined;
+}
+
+function validateReplayProtection(req: Request, publicKey: string, expectedAction: SignedAction): string | undefined {
+  const action = getSignedActionValue(req, "action");
+  if (action !== expectedAction) {
+    return `Signed payload action must be ${expectedAction}.`;
+  }
+
+  const bountyId = getSignedActionValue(req, "bountyId");
+  if (typeof bountyId !== "string" || bountyId !== req.params.id) {
+    return "Signed payload bountyId must match the request bounty id.";
+  }
+
+  const timestamp = getSignedActionValue(req, "timestamp");
+  if (typeof timestamp !== "number" || !Number.isInteger(timestamp)) {
+    return "Signed payload timestamp must be a Unix epoch timestamp in seconds.";
+  }
+
+  const now = nowInSeconds();
+  if (Math.abs(now - timestamp) > REPLAY_WINDOW_SECONDS) {
+    return "Signed payload timestamp is outside the allowed replay window.";
+  }
+
+  const nonce = getSignedActionValue(req, "nonce");
+  if (typeof nonce !== "string" || nonce.trim().length === 0 || nonce.length > MAX_NONCE_LENGTH) {
+    return "Signed payload nonce is required and must be 1-128 characters.";
+  }
+
+  cleanupExpiredNonces(now);
+
+  const nonceKey = `${publicKey}:${nonce}`;
+  if (usedNonces.has(nonceKey)) {
+    return "Signed payload nonce has already been used.";
+  }
+
+  usedNonces.set(nonceKey, now + REPLAY_WINDOW_SECONDS);
+  return undefined;
+}
+
+export function createStellarSignatureAuthMiddleware(expectedAction: SignedAction): RequestHandler {
   return (req, res, next) => {
     if (process.env.NODE_ENV === "test") {
       next();
@@ -112,6 +171,12 @@ export function createStellarSignatureAuthMiddleware(): RequestHandler {
     const maintainer = typeof req.body?.maintainer === "string" ? req.body.maintainer : undefined;
     if (maintainer && maintainer !== publicKeyHeader) {
       res.status(401).json({ error: "Request maintainer does not match signer public key." });
+      return;
+    }
+
+    const replayError = validateReplayProtection(req, publicKeyHeader, expectedAction);
+    if (replayError) {
+      res.status(401).json({ error: replayError });
       return;
     }
 

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -124,6 +124,10 @@ export const submitBountySchema = z
     contributor: stellarAccountSchema.openapi({
       description: "Must match the contributor who reserved the bounty.",
     }),
+    submissionUrl: githubPrUrlSchema.openapi({
+      example: "https://github.com/owner/repo/pull/99",
+      description: "GitHub pull request URL for the submitted work.",
+    }),
 
     notes: z
       .string()
@@ -148,6 +152,22 @@ export const maintainerActionSchema = z
         example: "0".repeat(64),
         description: "Optional transaction hash for the release/refund action (64-char hex).",
       }),
+    action: z.enum(["release", "refund"]).optional().openapi({
+      example: "release",
+      description: "Signed action name. Required when Stellar signature auth is enforced.",
+    }),
+    bountyId: bountyIdSchema.optional().openapi({
+      example: "BNT-0001",
+      description: "Signed bounty id. Required when Stellar signature auth is enforced.",
+    }),
+    timestamp: z.number().int().optional().openapi({
+      example: 1710000000,
+      description: "Unix timestamp in seconds. Required for signed requests and must be within 60 seconds.",
+    }),
+    nonce: z.string().trim().min(1).max(128).optional().openapi({
+      example: "8c7e4c2f-9f74-4d5f-8c72-2e79b0f79f41",
+      description: "Single-use replay-prevention nonce. Required when Stellar signature auth is enforced.",
+    }),
   })
   .openapi("MaintainerActionRequest");
 

--- a/backend/test/authMiddleware.test.ts
+++ b/backend/test/authMiddleware.test.ts
@@ -47,6 +47,41 @@ function signJsonPayload(payload: unknown): string {
   return signature.toString("base64");
 }
 
+function signedMaintainerPayload(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    maintainer: validMaintainerPublicKey,
+    transactionHash: "a".repeat(64),
+    action: "release",
+    bountyId: id,
+    timestamp: Math.floor(Date.now() / 1000),
+    nonce: randomUUID(),
+    ...overrides,
+  };
+}
+
+async function createSubmittedBounty(app: Awaited<ReturnType<typeof getApp>>): Promise<string> {
+  const { body: created } = await request(app).post("/api/bounties").send({
+    repo: "owner/repo",
+    issueNumber: 123,
+    title: "Test bounty",
+    summary: "Confirm signed release payload passes auth middleware.",
+    maintainer: validMaintainerPublicKey,
+    tokenSymbol: "XLM",
+    amount: 10,
+    deadlineDays: 14,
+  }).expect(201);
+
+  const id = created.data.id as string;
+
+  await request(app).post(`/api/bounties/${id}/reserve`).send({ contributor: validMaintainerPublicKey }).expect(200);
+  await request(app)
+    .post(`/api/bounties/${id}/submit`)
+    .send({ contributor: validMaintainerPublicKey, submissionUrl: "https://github.com/owner/repo/pull/1" })
+    .expect(200);
+
+  return id;
+}
+
 describe("Stellar auth middleware", () => {
   it("returns 401 when Stellar signature headers are missing", async () => {
     const app = await getApp();
@@ -73,26 +108,8 @@ describe("Stellar auth middleware", () => {
 
   it("allows release when Stellar payload is signed by the configured maintainer key", async () => {
     const app = await getApp();
-    const { body: created } = await request(app).post("/api/bounties").send({
-      repo: "owner/repo",
-      issueNumber: 123,
-      title: "Test bounty",
-      summary: "Confirm signed release payload passes auth middleware.",
-      maintainer: validMaintainerPublicKey,
-      tokenSymbol: "XLM",
-      amount: 10,
-      deadlineDays: 14,
-    }).expect(201);
-
-    const id = created.data.id as string;
-
-    await request(app).post(`/api/bounties/${id}/reserve`).send({ contributor: validMaintainerPublicKey }).expect(200);
-    await request(app)
-      .post(`/api/bounties/${id}/submit`)
-      .send({ contributor: validMaintainerPublicKey, submissionUrl: "https://example.com/pr/1" })
-      .expect(200);
-
-    const payload = { maintainer: validMaintainerPublicKey, transactionHash: "a".repeat(64) };
+    const id = await createSubmittedBounty(app);
+    const payload = signedMaintainerPayload(id);
     const signature = signJsonPayload(payload);
 
     const res = await request(app)
@@ -103,5 +120,76 @@ describe("Stellar auth middleware", () => {
       .expect(200);
 
     expect(res.body.data.status).toBe("released");
+  });
+
+  it("rejects a signed release payload with a stale timestamp", async () => {
+    const app = await getApp();
+    const id = await createSubmittedBounty(app);
+    const payload = signedMaintainerPayload(id, { timestamp: Math.floor(Date.now() / 1000) - 61 });
+    const signature = signJsonPayload(payload);
+
+    const res = await request(app)
+      .post(`/api/bounties/${id}/release`)
+      .set("X-Stellar-Public-Key", validMaintainerPublicKey)
+      .set("X-Stellar-Signature", signature)
+      .send(payload)
+      .expect(401);
+
+    expect(res.body.error).toMatch(/timestamp/i);
+  });
+
+  it("rejects a signed release payload with the wrong action", async () => {
+    const app = await getApp();
+    const id = await createSubmittedBounty(app);
+    const payload = signedMaintainerPayload(id, { action: "refund" });
+    const signature = signJsonPayload(payload);
+
+    const res = await request(app)
+      .post(`/api/bounties/${id}/release`)
+      .set("X-Stellar-Public-Key", validMaintainerPublicKey)
+      .set("X-Stellar-Signature", signature)
+      .send(payload)
+      .expect(401);
+
+    expect(res.body.error).toMatch(/action/i);
+  });
+
+  it("rejects a signed release payload for a different bounty id", async () => {
+    const app = await getApp();
+    const id = await createSubmittedBounty(app);
+    const payload = signedMaintainerPayload(id, { bountyId: "BNT-9999" });
+    const signature = signJsonPayload(payload);
+
+    const res = await request(app)
+      .post(`/api/bounties/${id}/release`)
+      .set("X-Stellar-Public-Key", validMaintainerPublicKey)
+      .set("X-Stellar-Signature", signature)
+      .send(payload)
+      .expect(401);
+
+    expect(res.body.error).toMatch(/bountyId/i);
+  });
+
+  it("rejects a replayed signed release nonce", async () => {
+    const app = await getApp();
+    const id = await createSubmittedBounty(app);
+    const payload = signedMaintainerPayload(id);
+    const signature = signJsonPayload(payload);
+
+    await request(app)
+      .post(`/api/bounties/${id}/release`)
+      .set("X-Stellar-Public-Key", validMaintainerPublicKey)
+      .set("X-Stellar-Signature", signature)
+      .send(payload)
+      .expect(200);
+
+    const replay = await request(app)
+      .post(`/api/bounties/${id}/release`)
+      .set("X-Stellar-Public-Key", validMaintainerPublicKey)
+      .set("X-Stellar-Signature", signature)
+      .send(payload)
+      .expect(401);
+
+    expect(replay.body.error).toMatch(/nonce/i);
   });
 });


### PR DESCRIPTION
Closes #345

## Summary
- mount Stellar signature auth on maintainer-only `release` and `refund` mutation routes
- require signed maintainer payloads to include `action`, `bountyId`, `timestamp`, and `nonce`
- reject stale timestamps outside a 60-second replay window, wrong action, mismatched bounty id, and reused nonce values
- keep nonce replay state in memory with TTL cleanup for the 60-second window
- include the missing `submissionUrl` submit schema field so the backend typecheck can run cleanly from this branch

## Notes
The issue asks for nonce-based deduplication but the listed required payload fields only name `action`, `bountyId`, and `timestamp`. This PR includes an explicit `nonce` field because the acceptance criteria require a replayed nonce to fail.

## Validation
- `npm --prefix backend run build`
- `git diff --check`
- `npm --prefix backend test -- test/authMiddleware.test.ts`
- `npm --prefix backend test -- test/api.test.ts -t "reserve → submit → release|refund returns refunded|wrong maintainer"`

Full `npm --prefix backend test` still has unrelated baseline failures: amount upper-bound/decimal validation expectations, missing `expireStaleReservations` export in `test/expiry.test.ts`, reservation expiration state setup failures, and an empty `test/utils.test.ts` suite. The focused replay-auth tests pass and cover fresh, stale, wrong action, wrong bounty id, and replayed nonce cases.
