### PR TITLE
docs: add testing contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,13 @@
 This project is intentionally scoped as an MVP with obvious upgrade paths.
 
 If you want to seed good open-source work quickly:
+
 1. Pick one of the drafts in `docs/issues`.
 2. Open it as a GitHub issue with the suggested labels.
 3. Tag whether it is `good first issue`, `enhancement`, or `help wanted`.
 
 High-value contribution areas:
+
 - Wallet-authenticated payout flow
 - GitHub App or webhook integration
 - Soroban event indexing
@@ -29,26 +31,28 @@ We follow the [Conventional Commits](https://www.conventionalcommits.org/) stand
 ```
 
 **Rules:**
+
 - Keep `<subject>` under 50 characters, lowercase, no period
 - Use imperative mood ("add" not "added")
 - The `(<scope>)` is optional but recommended for clarity
 
 ### Commit Types
 
-| Type | Purpose | Example |
-|------|---------|---------|
-| `feat` | New feature | `feat(frontend): add wallet connection UI` |
-| `fix` | Bug fix | `fix(backend): correct bounty status transition logic` |
-| `docs` | Documentation only | `docs(CONTRIBUTING): add commit message guide` |
-| `test` | Test additions or fixes | `test(contract): add escrow release scenarios` |
-| `refactor` | Code refactoring (no behavior change) | `refactor(backend): extract validation to schema` |
-| `chore` | Tooling, dependencies, build scripts | `chore(deps): update Express to 4.18` |
-| `perf` | Performance improvements | `perf(frontend): memoize bounty list rendering` |
-| `ci` | CI/CD pipeline changes | `ci: add GitHub Actions workflow` |
+| Type       | Purpose                               | Example                                                |
+| ---------- | ------------------------------------- | ------------------------------------------------------ |
+| `feat`     | New feature                           | `feat(frontend): add wallet connection UI`             |
+| `fix`      | Bug fix                               | `fix(backend): correct bounty status transition logic` |
+| `docs`     | Documentation only                    | `docs(CONTRIBUTING): add commit message guide`         |
+| `test`     | Test additions or fixes               | `test(contract): add escrow release scenarios`         |
+| `refactor` | Code refactoring (no behavior change) | `refactor(backend): extract validation to schema`      |
+| `chore`    | Tooling, dependencies, build scripts  | `chore(deps): update Express to 4.18`                  |
+| `perf`     | Performance improvements              | `perf(frontend): memoize bounty list rendering`        |
+| `ci`       | CI/CD pipeline changes                | `ci: add GitHub Actions workflow`                      |
 
 ### Examples
 
 **Good:**
+
 ```
 feat(contract): implement release_bounty escrow transfer
 
@@ -60,9 +64,54 @@ Closes #42
 ```
 
 **Also good (for simple changes):**
+
 ```
 fix(api): reject negative bounty amounts
 ```
+
+## Testing
+
+Add or update tests with the smallest scope that proves the behavior you changed. Unit tests should cover pure helpers, validation rules, and status transitions. Integration tests should cover API routes, service interactions, and persistence behavior. End-to-end tests should be reserved for complete user journeys that need the frontend, backend, and browser together.
+
+### Running Tests
+
+From the repository root:
+
+```bash
+npm test
+```
+
+This runs the backend Vitest suite through the root `test` script. To keep the full workspace healthy, also run the frontend or package-specific commands when your change touches those areas.
+
+To run a single backend test file:
+
+```bash
+npx --prefix backend vitest run test/bountyStore.test.ts
+```
+
+To run tests in watch mode from the repository root:
+
+```bash
+npm run test:watch
+```
+
+To generate a coverage report:
+
+```bash
+npm run test:coverage
+```
+
+Vitest prints a summary in the terminal and writes the HTML report under `backend/coverage/`. Open `backend/coverage/index.html` to inspect uncovered lines and branches. Treat low or missing coverage on code you changed as a signal to add targeted tests before opening a PR.
+
+### Writing Tests
+
+- Put backend tests under `backend/test/` and keep file names close to the code under test.
+- Reuse shared fixtures from `backend/test/fixtures.ts` for common bounty, submission, user, and repository data.
+- Add new fixtures only when several tests need the same setup. Keep one-off values inside the test so the scenario stays readable.
+- Prefer deterministic dates, IDs, and amounts. Avoid depending on the current clock unless the behavior being tested is time-sensitive.
+- Cover success and failure paths for validation, state transitions, and API responses.
+
+Use unit tests for utilities such as date helpers, amount formatting, and schema validation. Use integration tests when a route or service needs to prove request handling, storage updates, or cross-module behavior. Use end-to-end tests only when the user-facing flow cannot be verified confidently at a lower level.
 
 ## Pull Request Checklist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Closes #42
 
 **Also good (for simple changes):**
 
-```
+```text
 fix(api): reject negative bounty amounts
 ```
 
@@ -83,10 +83,12 @@ npm test
 
 This runs the backend Vitest suite through the root `test` script. To keep the full workspace healthy, also run the frontend or package-specific commands when your change touches those areas.
 
+Note: in a fresh checkout, unrelated backend tests may currently fail around reservation expiration, auth status codes, API amount validation, and webhook timeout behavior. Treat those as existing suite issues unless your PR changes the affected paths.
+
 To run a single backend test file:
 
 ```bash
-npx --prefix backend vitest run test/bountyStore.test.ts
+npm --prefix backend exec -- vitest run test/bountyStore.test.ts
 ```
 
 To run tests in watch mode from the repository root:
@@ -111,7 +113,7 @@ Vitest prints a summary in the terminal and writes the HTML report under `backen
 - Prefer deterministic dates, IDs, and amounts. Avoid depending on the current clock unless the behavior being tested is time-sensitive.
 - Cover success and failure paths for validation, state transitions, and API responses.
 
-Use unit tests for utilities such as date helpers, amount formatting, and schema validation. Use integration tests when a route or service needs to prove request handling, storage updates, or cross-module behavior. Use end-to-end tests only when the user-facing flow cannot be verified confidently at a lower level.
+Prefer unit tests for utilities such as date helpers, amount formatting, and schema validation. Use integration tests when a route or service needs to prove request handling, storage updates, or cross-module behavior. Reserve end-to-end tests for user-facing flows that cannot be verified confidently at a lower level.
 
 ## Pull Request Checklist
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "@types/express": "^5.0.0",
     "@types/node": "^22.10.2",
     "@types/pino": "^7.0.5",
+    "@vitest/coverage-v8": "^3.0.5",
     "supertest": "^7.1.0",
     "tsx": "^4.21.0",
     "typescript": "^5.7.2",


### PR DESCRIPTION
## Summary

Closes #378.

Adds a dedicated Testing section to CONTRIBUTING.md covering how contributors should run tests, choose between unit/integration/e2e coverage, generate coverage reports, and reuse shared fixtures.

## Verification

- `npm --prefix backend install` completed after installing root dependencies with scripts disabled to satisfy the local file dependency on Windows
- `npm --prefix backend exec -- vitest run test/bountyStore.test.ts` passed: 16 tests
- `git diff --check` passed

Note: `npm test` currently fails on existing unrelated backend tests in this fresh checkout, including reservation expiration, auth status-code, API amount validation, webhook timeout, and an empty `backend/test/utils.test.ts` suite. `npm run test:coverage` is also blocked by missing `@vitest/coverage-v8`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured contribution guidelines with explicit numbered checklists for improved clarity and easier navigation
  * Added comprehensive testing section including instructions for running tests, watch mode, coverage generation, and guidelines for writing unit, integration, and end-to-end tests
  * Enhanced commit convention documentation with specific formatting rules and improved examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->