### PR TITLE
Require submission checklist completion before submit

### DIFF
--- a/frontend/src/SubmissionChecklistModal.test.tsx
+++ b/frontend/src/SubmissionChecklistModal.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import SubmissionChecklistModal from "./SubmissionChecklistModal";
+import type { Bounty } from "./types";
+
+const validContributor = `G${"A".repeat(55)}`;
+
+const bounty: Bounty = {
+  id: "BNTY-285",
+  repo: "ritik4ever/stellar-bounty-board",
+  issueNumber: 285,
+  title: "Submission checklist bounty",
+  summary: "Block submission until checklist is complete.",
+  maintainer: `G${"B".repeat(55)}`,
+  contributor: validContributor,
+  tokenSymbol: "XLM",
+  amount: 100,
+  labels: [],
+  status: "reserved",
+  createdAt: 1_700_000_000,
+  deadlineAt: 1_700_086_400,
+  version: 1,
+  events: [],
+};
+
+function renderModal(overrides: Partial<ComponentProps<typeof SubmissionChecklistModal>> = {}) {
+  return render(
+    <SubmissionChecklistModal
+      bounty={bounty}
+      submitting={false}
+      error={null}
+      onSubmit={vi.fn()}
+      onClose={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function showModal(this: HTMLDialogElement) {
+    this.setAttribute("open", "");
+  });
+});
+
+describe("SubmissionChecklistModal", () => {
+  it("blocks submission until every checklist item is checked", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    renderModal({ onSubmit });
+
+    await user.clear(screen.getByLabelText(/contributor stellar address/i));
+    await user.type(screen.getByLabelText(/contributor stellar address/i), validContributor);
+    await user.type(screen.getByLabelText(/pull request or demo url/i), "https://github.com/owner/repo/pull/123");
+
+    const submitButton = screen.getByRole("button", { name: /submit work/i });
+    expect(submitButton).toBeDisabled();
+
+    await user.click(screen.getByRole("checkbox", { name: /pr is linked to the correct issue/i }));
+    await user.click(screen.getByRole("checkbox", { name: /pr description explains the changes/i }));
+    expect(submitButton).toBeDisabled();
+
+    await user.click(screen.getByRole("checkbox", { name: /all ci checks pass/i }));
+    expect(submitButton).toBeEnabled();
+
+    await user.click(submitButton);
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      contributor: validContributor,
+      prLink: "https://github.com/owner/repo/pull/123",
+      issueLinked: true,
+      descriptionExplainsChanges: true,
+      ciChecksPass: true,
+      notes: "",
+    });
+  });
+
+  it("closes without submitting when canceled", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onSubmit = vi.fn();
+
+    renderModal({ onClose, onSubmit });
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/SubmissionChecklistModal.tsx
+++ b/frontend/src/SubmissionChecklistModal.tsx
@@ -5,7 +5,9 @@ import type { Bounty } from "./types";
 export interface SubmissionFormData {
   contributor: string;
   prLink: string;
-  testsWritten: boolean;
+  issueLinked: boolean;
+  descriptionExplainsChanges: boolean;
+  ciChecksPass: boolean;
   notes: string;
 }
 
@@ -42,7 +44,11 @@ export default function SubmissionChecklistModal({
 }: Props) {
   const [contributor, setContributor] = useState(initialData?.contributor ?? bounty.contributor ?? "");
   const [prLink, setPrLink] = useState(initialData?.prLink ?? "");
-  const [testsWritten, setTestsWritten] = useState(initialData?.testsWritten ?? false);
+  const [issueLinked, setIssueLinked] = useState(initialData?.issueLinked ?? false);
+  const [descriptionExplainsChanges, setDescriptionExplainsChanges] = useState(
+    initialData?.descriptionExplainsChanges ?? false,
+  );
+  const [ciChecksPass, setCiChecksPass] = useState(initialData?.ciChecksPass ?? false);
   const [notes, setNotes] = useState(initialData?.notes ?? "");
   const [touched, setTouched] = useState({ contributor: false, prLink: false });
 
@@ -83,15 +89,19 @@ export default function SubmissionChecklistModal({
     STELLAR_PUBLIC_KEY_REGEX.test(contributor.trim()) &&
     prLink.trim() !== "" &&
     validateUrl(prLink) === null;
+  const isChecklistComplete = issueLinked && descriptionExplainsChanges && ciChecksPass;
+  const canSubmit = isValid && isChecklistComplete && !submitting;
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
     setTouched({ contributor: true, prLink: true });
-    if (!isValid) return;
+    if (!canSubmit) return;
     onSubmit({
       contributor: contributor.trim(),
       prLink: prLink.trim(),
-      testsWritten,
+      issueLinked,
+      descriptionExplainsChanges,
+      ciChecksPass,
       notes: notes.trim(),
     });
   }
@@ -175,30 +185,30 @@ export default function SubmissionChecklistModal({
             <legend>Pre-submission checklist</legend>
 
             <ChecklistItem
-              id="check-tests"
-              checked={testsWritten}
-              onChange={setTestsWritten}
+              id="check-linked"
+              checked={issueLinked}
+              onChange={setIssueLinked}
               disabled={submitting}
-              label="Tests written or updated"
-              hint="Unit or integration tests cover the changes"
+              label="PR is linked to the correct issue"
+              hint={`Issue #${bounty.issueNumber} in ${bounty.repo}`}
             />
 
             <ChecklistItem
               id="check-pr-desc"
-              checked={true}
-              onChange={() => {}}
-              disabled={true}
+              checked={descriptionExplainsChanges}
+              onChange={setDescriptionExplainsChanges}
+              disabled={submitting}
               label="PR description explains the changes"
               hint="Your PR has a clear title and description"
             />
 
             <ChecklistItem
-              id="check-linked"
-              checked={true}
-              onChange={() => {}}
-              disabled={true}
-              label="PR is linked to this issue"
-              hint={`Issue #${bounty.issueNumber} in ${bounty.repo}`}
+              id="check-ci"
+              checked={ciChecksPass}
+              onChange={setCiChecksPass}
+              disabled={submitting}
+              label="All CI checks pass"
+              hint="The latest PR checks are green"
             />
           </fieldset>
 
@@ -226,7 +236,7 @@ export default function SubmissionChecklistModal({
             <button
               type="submit"
               className="primary-button"
-              disabled={submitting}
+              disabled={!canSubmit}
             >
               {submitting ? "Submitting..." : "Submit work"}
             </button>


### PR DESCRIPTION
## Summary
- replaces the partially pre-checked submission checklist with the exact required checklist items from issue #285
- keeps the submit button disabled until contributor, PR URL, and all checklist items are complete
- adds Vitest coverage proving submission is blocked until every item is checked and canceling does not submit

Closes #285

## Verification
- [x] `npm --prefix frontend test -- SubmissionChecklistModal.test.tsx`
- [x] `git diff --check`

## Existing baseline notes
- `npm --prefix frontend test` is currently blocked by existing unrelated failures: empty `recommendations.test.ts`, empty/import-failing `toast.test.tsx`, and duplicate `scoreMatch` export in `src/recommendations.ts`.
- `npm --prefix frontend run build` is currently blocked before this change by `src/api.ts(158,1): error TS1128: Declaration or statement expected`.
