### PR TITLE
Add ETag support for bounty detail responses

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -363,6 +363,13 @@ app.get("/api/bounties/:id", (req: Request, res: Response) => {
       jsonError(res, req, 404, "Bounty not found.");
       return;
     }
+    const etag = `"${bounty.version}"`;
+    res.setHeader("ETag", etag);
+    res.setHeader("Cache-Control", "max-age=5");
+    if (req.headers["if-none-match"] === etag) {
+      res.status(304).end();
+      return;
+    }
     res.json({ data: bounty });
   } catch (error) {
     sendError(res, req, error, 400);

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -67,6 +67,31 @@ describe("API — bounty lifecycle routes", () => {
     expect(listRes.body.data.some((b: { id: string }) => b.id === id)).toBe(true);
   });
 
+  it("GET /api/bounties/:id supports ETag conditional requests", async () => {
+    const app = await getApp();
+    const createRes = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+    const id = createRes.body.data.id as string;
+
+    const firstGet = await request(app).get(`/api/bounties/${id}`).expect(200);
+    expect(firstGet.headers.etag).toBe(`"${createRes.body.data.version}"`);
+    expect(firstGet.headers["cache-control"]).toBe("max-age=5");
+
+    await request(app).get(`/api/bounties/${id}`).set("If-None-Match", firstGet.headers.etag).expect(304);
+
+    const reserveRes = await request(app)
+      .post(`/api/bounties/${id}/reserve`)
+      .send({ contributor: CONTRIBUTOR })
+      .expect(200);
+
+    const afterVersionChange = await request(app)
+      .get(`/api/bounties/${id}`)
+      .set("If-None-Match", firstGet.headers.etag)
+      .expect(200);
+    expect(afterVersionChange.headers.etag).toBe(`"${reserveRes.body.data.version}"`);
+    expect(afterVersionChange.headers.etag).not.toBe(firstGet.headers.etag);
+    expect(afterVersionChange.body.data.version).toBe(reserveRes.body.data.version);
+  });
+
   it("POST create with invalid body returns 400", async () => {
     const app = await getApp();
     const res = await request(app)


### PR DESCRIPTION
Closes #278

## Summary
- add `ETag: "<version>"` and `Cache-Control: max-age=5` headers to `GET /api/bounties/:id`
- return `304 Not Modified` when `If-None-Match` matches the current bounty version
- cover the 200 -> 304 -> 200-after-version-change flow with an integration test

## Verification
- `npm --prefix backend test -- api.test.ts -t "ETag conditional"`
- `git diff --check`

## Existing baseline note
- `npm --prefix backend test -- api.test.ts` still has 2 unrelated existing failures in amount validation tests: amount above 10000 and more than 7 decimal places currently return 201 instead of 400.