### PR TITLE
Add sorting support to bounty list API

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,6 +6,7 @@ import { buildCorsOptions } from "./middleware/corsOptions";
 import { generateOpenApiDocument } from "./docs/openapi";
 
 import {
+  type BountySortField,
   createBounty,
   listBountyAuditLogs,
   listBounties,
@@ -36,6 +37,8 @@ import {
 import { handleGitHubPrEvent } from "./webhooks/githubPrHandler";
 
 const INCOMING_REQUEST_ID = /^[a-zA-Z0-9-]{1,128}$/;
+const BOUNTY_SORT_FIELDS = new Set<BountySortField>(["amount", "deadline", "createdAt"]);
+const SORT_ORDERS = new Set(["asc", "desc"]);
 
 
 
@@ -120,6 +123,26 @@ function parsePaginationValue(
   return parsed;
 }
 
+function parseBountySort(raw: unknown): BountySortField | undefined {
+  if (raw === undefined || raw === null || raw === "") {
+    return undefined;
+  }
+  if (typeof raw !== "string" || !BOUNTY_SORT_FIELDS.has(raw as BountySortField)) {
+    throw new Error("sort must be one of: amount, deadline, createdAt.");
+  }
+  return raw as BountySortField;
+}
+
+function parseSortOrder(raw: unknown): "asc" | "desc" | undefined {
+  if (raw === undefined || raw === null || raw === "") {
+    return undefined;
+  }
+  if (typeof raw !== "string" || !SORT_ORDERS.has(raw)) {
+    throw new Error("order must be either asc or desc.");
+  }
+  return raw as "asc" | "desc";
+}
+
 function jsonError(res: Response, req: Request, statusCode: number, message: string) {
   res.status(statusCode).json({ error: message, requestId: req.requestId });
 }
@@ -155,8 +178,14 @@ app.get("/worker/health", (_req: Request, res: Response) => {
 });
 
 app.get("/api/bounties", (req: Request, res: Response) => {
-  const q = typeof req.query.q === "string" ? req.query.q : undefined;
-  res.json({ data: listBounties({ q }) });
+  try {
+    const q = typeof req.query.q === "string" ? req.query.q : undefined;
+    const sort = parseBountySort(req.query.sort);
+    const order = parseSortOrder(req.query.order);
+    res.json({ data: listBounties({ q, sort, order }) });
+  } catch (error) {
+    sendError(res, req, error);
+  }
 });
 
 app.get("/api/leaderboard", (_req: Request, res: Response) => {

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -81,10 +81,23 @@ registry.registerPath({
   tags: ["Bounties"],
   summary: "List all bounties",
   description:
-    "Returns every bounty record sorted by creation date (newest first). " +
+    "Returns every bounty record sorted by creation date (newest first) unless `sort` and `order` are provided. " +
     "Bounties whose deadline has passed are automatically transitioned to `expired` before the list is returned.",
+  request: {
+    query: z.object({
+      sort: z.enum(["amount", "deadline", "createdAt"]).optional().openapi({
+        example: "createdAt",
+        description: "Field used to sort the returned bounties.",
+      }),
+      order: z.enum(["asc", "desc"]).optional().openapi({
+        example: "desc",
+        description: "Sort direction. Defaults to descending.",
+      }),
+    }),
+  },
   responses: {
     200: jsonResponse("Array of all bounty records.", z.object({ data: z.array(bountyRecordSchema) })),
+    400: errorResponse("Sort field or order is invalid."),
   },
 });
 

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -347,11 +347,31 @@ function persistUpdated(records: BountyRecord[], updated: BountyRecord): BountyR
 export interface ListBountiesOptions {
   /** Case-insensitive substring filter applied to title, summary, and labels. */
   q?: string;
+  sort?: BountySortField;
+  order?: SortOrder;
+}
+
+export type BountySortField = "amount" | "deadline" | "createdAt";
+export type SortOrder = "asc" | "desc";
+
+function compareBounties(a: BountyRecord, b: BountyRecord, sort: BountySortField): number {
+  if (sort === "amount") {
+    return a.amount - b.amount;
+  }
+  if (sort === "deadline") {
+    return a.deadlineAt - b.deadlineAt;
+  }
+  return a.createdAt - b.createdAt;
 }
 
 export function listBounties(options: ListBountiesOptions = {}): BountyRecord[] {
   const records = normalizeRecords(readStore());
-  let sorted = [...records].sort((a, b) => b.createdAt - a.createdAt);
+  const sort = options.sort ?? "createdAt";
+  const direction = options.order === "asc" ? 1 : -1;
+  let sorted = [...records].sort((a, b) => {
+    const primary = compareBounties(a, b, sort) * direction;
+    return primary || b.createdAt - a.createdAt || a.id.localeCompare(b.id);
+  });
 
   const q = options.q?.trim().toLowerCase();
   if (q) {

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -35,6 +35,39 @@ async function getApp() {
   return app;
 }
 
+async function createSortableBounties(app: Awaited<ReturnType<typeof getApp>>) {
+  vi.useFakeTimers();
+  try {
+    vi.setSystemTime(new Date("2030-01-01T00:00:00Z"));
+    await request(app)
+      .post("/api/bounties")
+      .send({ ...validCreateBody, issueNumber: 101, title: "Amount Low", amount: 25, deadlineDays: 30 })
+      .expect(201);
+
+    vi.setSystemTime(new Date("2030-01-02T00:00:00Z"));
+    await request(app)
+      .post("/api/bounties")
+      .send({ ...validCreateBody, issueNumber: 102, title: "Amount High", amount: 150, deadlineDays: 10 })
+      .expect(201);
+
+    vi.setSystemTime(new Date("2030-01-03T00:00:00Z"));
+    await request(app)
+      .post("/api/bounties")
+      .send({ ...validCreateBody, issueNumber: 103, title: "Amount Mid", amount: 75, deadlineDays: 20 })
+      .expect(201);
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+async function listTitles(app: Awaited<ReturnType<typeof getApp>>, sort?: string, order?: string): Promise<string[]> {
+  const query: Record<string, string> = {};
+  if (sort) query.sort = sort;
+  if (order) query.order = order;
+  const res = await request(app).get("/api/bounties").query(query).expect(200);
+  return res.body.data.map((bounty: { title: string }) => bounty.title);
+}
+
 describe("API — health and listing", () => {
   it("GET /api/health returns ok", async () => {
     const app = await getApp();
@@ -47,6 +80,25 @@ describe("API — health and listing", () => {
     const app = await getApp();
     const res = await request(app).get("/api/bounties").expect(200);
     expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it("GET /api/bounties sorts by supported fields in both directions", async () => {
+    const app = await getApp();
+    await createSortableBounties(app);
+
+    await expect(listTitles(app)).resolves.toEqual(["Amount Mid", "Amount High", "Amount Low"]);
+    await expect(listTitles(app, "createdAt", "asc")).resolves.toEqual(["Amount Low", "Amount High", "Amount Mid"]);
+    await expect(listTitles(app, "createdAt", "desc")).resolves.toEqual(["Amount Mid", "Amount High", "Amount Low"]);
+    await expect(listTitles(app, "amount", "asc")).resolves.toEqual(["Amount Low", "Amount Mid", "Amount High"]);
+    await expect(listTitles(app, "amount", "desc")).resolves.toEqual(["Amount High", "Amount Mid", "Amount Low"]);
+    await expect(listTitles(app, "deadline", "asc")).resolves.toEqual(["Amount High", "Amount Mid", "Amount Low"]);
+    await expect(listTitles(app, "deadline", "desc")).resolves.toEqual(["Amount Low", "Amount Mid", "Amount High"]);
+  });
+
+  it("GET /api/bounties rejects invalid sort fields", async () => {
+    const app = await getApp();
+    const res = await request(app).get("/api/bounties").query({ sort: "status" }).expect(400);
+    expect(res.body.error).toMatch(/sort/i);
   });
 
   it("GET /api/open-issues returns data", async () => {


### PR DESCRIPTION
Closes #247

## Summary
- add `sort=amount|deadline|createdAt` and `order=asc|desc` handling to `GET /api/bounties`
- keep the default list order as `createdAt desc`
- return 400 for unsupported sort/order query values
- document the query parameters in the OpenAPI spec
- add integration coverage for every accepted sort field in both directions

## Verification
- `npm --prefix backend test -- api.test.ts -t "sort"`
- `git diff --check`

## Existing baseline note
- `npm --prefix backend test -- api.test.ts` still has 2 unrelated existing failures in amount validation tests: amount above 10000 and more than 7 decimal places currently return 201 instead of 400.