### PR TITLE
Cache computed bounty metrics

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -388,8 +388,16 @@ app.get("/api/metrics", (_req: Request, res: Response) => {
     const metrics = getGlobalMetrics();
     res.json({ data: metrics });
   } catch (error) {
+    sendError(res, _req, error);
+  }
+});
 
-
+app.get("/api/stats", (_req: Request, res: Response) => {
+  try {
+    const metrics = getGlobalMetrics();
+    res.json({ data: metrics });
+  } catch (error) {
+    sendError(res, _req, error);
   }
 });
 

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -189,6 +189,7 @@ function readStore(): BountyRecord[] {
 
 function writeStore(records: BountyRecord[]): void {
   fs.writeFileSync(getStorePath(), JSON.stringify(records, null, 2));
+  invalidateMetricsCache();
 }
 
 function readAuditStore(): BountyAuditLogRecord[] {
@@ -685,57 +686,94 @@ export interface GlobalMetrics {
   uniqueContributors: number;
 }
 
-export function getGlobalMetrics(): GlobalMetrics {
-  const bounties = listBounties();
-  const totalFunded = bounties.reduce((sum, b) => sum + b.amount, 0);
-  const released = bounties.filter((b) => b.status === "released");
-  const totalReleased = released.reduce((sum, b) => sum + b.amount, 0);
-  const uniqueMaintainers = new Set(bounties.map((b) => b.maintainer)).size;
-  const uniqueContributors = new Set(
-    bounties.filter((b) => b.contributor).map((b) => b.contributor as string),
-  ).size;
-  return {
-    totalBounties: bounties.length,
-    openCount: bounties.filter((b) => b.status === "open").length,
-    reservedCount: bounties.filter((b) => b.status === "reserved").length,
-    submittedCount: bounties.filter((b) => b.status === "submitted").length,
-    releasedCount: released.length,
-    refundedCount: bounties.filter((b) => b.status === "refunded").length,
-    expiredCount: bounties.filter((b) => b.status === "expired").length,
-    totalFunded,
-    totalReleased,
-    uniqueMaintainers,
-    uniqueContributors,
-  };
-}
-
-
 export interface LeaderboardEntry {
   address: string;
   totalXlm: number;
   bountiesCompleted: number;
 }
 
-export function getLeaderboard(limit = 10): LeaderboardEntry[] {
-  const entries = new Map<string, LeaderboardEntry>();
+export interface ComputedMetrics {
+  global: GlobalMetrics;
+  leaderboard: LeaderboardEntry[];
+}
 
-  for (const bounty of listBounties()) {
-    if (bounty.status !== "released" || !bounty.contributor) {
-      continue;
-    }
+const METRICS_CACHE_TTL_MS = 30_000;
+let cachedMetrics: { computedAt: number; value: ComputedMetrics } | null = null;
 
-    const entry = entries.get(bounty.contributor) ?? {
-      address: bounty.contributor,
-      totalXlm: 0,
-      bountiesCompleted: 0,
-    };
+function invalidateMetricsCache(): void {
+  cachedMetrics = null;
+}
 
-    entry.totalXlm += bounty.amount;
-    entry.bountiesCompleted += 1;
-    entries.set(bounty.contributor, entry);
+export function computeMetrics(): ComputedMetrics {
+  const now = Date.now();
+  if (cachedMetrics && now - cachedMetrics.computedAt < METRICS_CACHE_TTL_MS) {
+    return cachedMetrics.value;
   }
 
-  return Array.from(entries.values())
-    .sort((a, b) => b.totalXlm - a.totalXlm || b.bountiesCompleted - a.bountiesCompleted)
-    .slice(0, limit);
+  const bounties = listBounties();
+  const maintainers = new Set<string>();
+  const contributors = new Set<string>();
+  const leaderboardEntries = new Map<string, LeaderboardEntry>();
+  const global: GlobalMetrics = {
+    totalBounties: bounties.length,
+    openCount: 0,
+    reservedCount: 0,
+    submittedCount: 0,
+    releasedCount: 0,
+    refundedCount: 0,
+    expiredCount: 0,
+    totalFunded: 0,
+    totalReleased: 0,
+    uniqueMaintainers: 0,
+    uniqueContributors: 0,
+  };
+
+  for (const bounty of bounties) {
+    global.totalFunded += bounty.amount;
+    maintainers.add(bounty.maintainer);
+
+    if (bounty.status === "open") global.openCount += 1;
+    if (bounty.status === "reserved") global.reservedCount += 1;
+    if (bounty.status === "submitted") global.submittedCount += 1;
+    if (bounty.status === "released") global.releasedCount += 1;
+    if (bounty.status === "refunded") global.refundedCount += 1;
+    if (bounty.status === "expired") global.expiredCount += 1;
+
+    if (bounty.contributor) {
+      contributors.add(bounty.contributor);
+    }
+
+    if (bounty.status === "released" && bounty.contributor) {
+      global.totalReleased += bounty.amount;
+      const entry = leaderboardEntries.get(bounty.contributor) ?? {
+        address: bounty.contributor,
+        totalXlm: 0,
+        bountiesCompleted: 0,
+      };
+      entry.totalXlm += bounty.amount;
+      entry.bountiesCompleted += 1;
+      leaderboardEntries.set(bounty.contributor, entry);
+    }
+  }
+
+  global.uniqueMaintainers = maintainers.size;
+  global.uniqueContributors = contributors.size;
+
+  const value = {
+    global,
+    leaderboard: Array.from(leaderboardEntries.values()).sort(
+      (a, b) => b.totalXlm - a.totalXlm || b.bountiesCompleted - a.bountiesCompleted,
+    ),
+  };
+  cachedMetrics = { computedAt: now, value };
+  return value;
+}
+
+
+export function getGlobalMetrics(): GlobalMetrics {
+  return computeMetrics().global;
+}
+
+export function getLeaderboard(limit = 10): LeaderboardEntry[] {
+  return computeMetrics().leaderboard.slice(0, limit);
 }

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -54,6 +54,15 @@ describe("API — health and listing", () => {
     const res = await request(app).get("/api/open-issues").expect(200);
     expect(res.body).toHaveProperty("data");
   });
+
+  it("GET /api/stats returns global metrics", async () => {
+    const app = await getApp();
+    await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+
+    const res = await request(app).get("/api/stats").expect(200);
+    expect(res.body.data.totalBounties).toBe(1);
+    expect(res.body.data.totalFunded).toBe(validCreateBody.amount);
+  });
 });
 
 describe("API — bounty lifecycle routes", () => {

--- a/backend/test/bountyStore.test.ts
+++ b/backend/test/bountyStore.test.ts
@@ -478,6 +478,89 @@ describe("bountyStore — event history and metrics", () => {
     expect(metrics.uniqueMaintainers).toBeGreaterThan(0);
   });
 
+  it("computeMetrics returns cached metrics and invalidates on writes", async () => {
+    const { computeMetrics, createBounty, reserveBounty, submitBounty, releaseBounty } = await loadStore();
+
+    const first = await createBounty({
+      repo: "acme/widget",
+      issueNumber: 1,
+      title: "Fix the widget spinner",
+      summary: "Ensure the loading state does not flash when latency is high for users.",
+      maintainer: MAINTAINER,
+      tokenSymbol: "usdc",
+      amount: 100,
+      deadlineDays: 14,
+      labels: [],
+    });
+
+    await createBounty({
+      repo: "acme/widget",
+      issueNumber: 2,
+      title: "Add dark mode",
+      summary: "Implement dark mode support for the widget component.",
+      maintainer: MAINTAINER,
+      tokenSymbol: "usdc",
+      amount: 50,
+      deadlineDays: 14,
+      labels: [],
+    });
+
+    await createBounty({
+      repo: "acme/api",
+      issueNumber: 3,
+      title: "Document the API client",
+      summary: "Add usage examples for the public bounty board API client.",
+      maintainer: OTHER_ACCOUNT,
+      tokenSymbol: "xlm",
+      amount: 25,
+      deadlineDays: 14,
+      labels: [],
+    });
+
+    await reserveBounty(first.id, CONTRIBUTOR);
+    await submitBounty(first.id, CONTRIBUTOR, "https://github.com/acme/widget/pull/1");
+    await releaseBounty(first.id, MAINTAINER, "a".repeat(64));
+
+    const metrics = computeMetrics();
+    expect(computeMetrics()).toBe(metrics);
+    expect(metrics.global).toMatchObject({
+      totalBounties: 3,
+      openCount: 2,
+      releasedCount: 1,
+      totalFunded: 175,
+      totalReleased: 100,
+      uniqueMaintainers: 2,
+      uniqueContributors: 1,
+    });
+    expect(metrics.leaderboard).toEqual([{ address: CONTRIBUTOR, totalXlm: 100, bountiesCompleted: 1 }]);
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(Date.now() + 31_000);
+      expect(computeMetrics()).not.toBe(metrics);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const refreshedMetrics = computeMetrics();
+    await createBounty({
+      repo: "acme/widget",
+      issueNumber: 4,
+      title: "Improve onboarding copy",
+      summary: "Clarify the first-run onboarding copy for maintainers.",
+      maintainer: MAINTAINER,
+      tokenSymbol: "xlm",
+      amount: 10,
+      deadlineDays: 14,
+      labels: [],
+    });
+
+    const updatedMetrics = computeMetrics();
+    expect(updatedMetrics).not.toBe(refreshedMetrics);
+    expect(updatedMetrics.global.totalBounties).toBe(4);
+    expect(updatedMetrics.global.totalFunded).toBe(185);
+  });
+
   it("race condition prevention: version mismatch on reserve", async () => {
     const { createBounty, reserveBounty } = await loadStore();
 


### PR DESCRIPTION
Closes #282

## Summary
- add exported `computeMetrics()` in `bountyStore.ts`
- compute global metrics and leaderboard data in one pass
- cache computed metrics for 30 seconds and invalidate automatically on store writes
- add `/api/stats` while keeping `/api/metrics` intact
- keep `/api/leaderboard` backed by the shared computed metrics snapshot

## Verification
- `npm --prefix backend test -- bountyStore.test.ts -t "computeMetrics"`
- `npm --prefix backend test -- bountyStore.test.ts`
- `npm --prefix backend test -- api.test.ts -t "GET /api/stats"`
- `npm --prefix backend test -- api.test.ts -t "leaderboard"`
- `git diff --check`

## Existing baseline note
- `npm --prefix backend test -- api.test.ts` still has 2 unrelated existing failures in amount validation tests: amount above 10000 and more than 7 decimal places currently return 201 instead of 400.