### PR TITLE
Enforce JSON content type for write routes

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -72,9 +72,18 @@ function requestContextMiddleware(req: Request, res: Response, next: NextFunctio
   next();
 }
 
+function requireJsonContentType(req: Request, res: Response, next: NextFunction): void {
+  if ((req.method === "POST" || req.method === "PATCH") && !req.is("application/json")) {
+    res.status(415).json({ error: "Content-Type must be application/json" });
+    return;
+  }
+  next();
+}
+
 export const app = express();
 
 app.use(cors(buildCorsOptions()));
+app.use(requireJsonContentType);
 
 // Parse JSON bodies; capture raw body for webhook signature verification
 app.use(

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -67,6 +67,24 @@ describe("API — bounty lifecycle routes", () => {
     expect(listRes.body.data.some((b: { id: string }) => b.id === id)).toBe(true);
   });
 
+  it("POST routes require application/json content type", async () => {
+    const app = await getApp();
+
+    await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+
+    const missing = await request(app).post("/api/bounties").expect(415);
+    expect(missing.body).toEqual({ error: "Content-Type must be application/json" });
+
+    const wrong = await request(app)
+      .post("/api/bounties")
+      .set("Content-Type", "text/plain")
+      .send(JSON.stringify(validCreateBody))
+      .expect(415);
+    expect(wrong.body).toEqual({ error: "Content-Type must be application/json" });
+
+    await request(app).get("/api/bounties").set("Content-Type", "text/plain").expect(200);
+  });
+
   it("POST create with invalid body returns 400", async () => {
     const app = await getApp();
     const res = await request(app)


### PR DESCRIPTION
Closes #281

## Summary
- add middleware that rejects POST/PATCH requests without `Content-Type: application/json`
- return 415 with `{ "error": "Content-Type must be application/json" }` for missing or wrong content type
- keep GET routes unaffected
- add integration coverage for correct, missing, and wrong content type

## Verification
- `npm --prefix backend test -- api.test.ts -t "content type"`
- `npm --prefix backend test -- api.test.ts -t "POST /api/bounties creates"`
- `git diff --check`

## Existing baseline note
- `npm --prefix backend test -- api.test.ts` still has 2 unrelated existing failures in amount validation tests: amount above 10000 and more than 7 decimal places currently return 201 instead of 400.