### PR TITLE
Add deadline filters to bounty list API

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -120,6 +120,23 @@ function parsePaginationValue(
   return parsed;
 }
 
+function parseIsoDateQuery(raw: unknown, field: string): number | undefined {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`${field} must be an ISO 8601 date string.`);
+  }
+
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${field} must be a valid ISO 8601 date string.`);
+  }
+
+  return Math.floor(parsed / 1000);
+}
+
 function jsonError(res: Response, req: Request, statusCode: number, message: string) {
   res.status(statusCode).json({ error: message, requestId: req.requestId });
 }
@@ -155,8 +172,14 @@ app.get("/worker/health", (_req: Request, res: Response) => {
 });
 
 app.get("/api/bounties", (req: Request, res: Response) => {
-  const q = typeof req.query.q === "string" ? req.query.q : undefined;
-  res.json({ data: listBounties({ q }) });
+  try {
+    const q = typeof req.query.q === "string" ? req.query.q : undefined;
+    const deadlineBefore = parseIsoDateQuery(req.query.deadlineBefore, "deadlineBefore");
+    const deadlineAfter = parseIsoDateQuery(req.query.deadlineAfter, "deadlineAfter");
+    res.json({ data: listBounties({ q, deadlineBefore, deadlineAfter }) });
+  } catch (error) {
+    sendError(res, req, error);
+  }
 });
 
 app.get("/api/leaderboard", (_req: Request, res: Response) => {

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -347,6 +347,8 @@ function persistUpdated(records: BountyRecord[], updated: BountyRecord): BountyR
 export interface ListBountiesOptions {
   /** Case-insensitive substring filter applied to title, summary, and labels. */
   q?: string;
+  deadlineBefore?: number;
+  deadlineAfter?: number;
 }
 
 export function listBounties(options: ListBountiesOptions = {}): BountyRecord[] {
@@ -361,6 +363,16 @@ export function listBounties(options: ListBountiesOptions = {}): BountyRecord[] 
         b.summary.toLowerCase().includes(q) ||
         b.labels.some((l) => l.toLowerCase().includes(q)),
     );
+  }
+
+  if (options.deadlineBefore !== undefined) {
+    const deadlineBefore = options.deadlineBefore;
+    sorted = sorted.filter((bounty) => bounty.deadlineAt <= deadlineBefore);
+  }
+
+  if (options.deadlineAfter !== undefined) {
+    const deadlineAfter = options.deadlineAfter;
+    sorted = sorted.filter((bounty) => bounty.deadlineAt >= deadlineAfter);
   }
 
   return sorted;

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -49,6 +49,51 @@ describe("API — health and listing", () => {
     expect(Array.isArray(res.body.data)).toBe(true);
   });
 
+  it("GET /api/bounties filters by deadline range", async () => {
+    const app = await getApp();
+    const soon = await request(app)
+      .post("/api/bounties")
+      .send({ ...validCreateBody, issueNumber: 201, title: "Soon bounty", deadlineDays: 5 })
+      .expect(201);
+    const middle = await request(app)
+      .post("/api/bounties")
+      .send({ ...validCreateBody, issueNumber: 202, title: "Middle bounty", deadlineDays: 15 })
+      .expect(201);
+    const later = await request(app)
+      .post("/api/bounties")
+      .send({ ...validCreateBody, issueNumber: 203, title: "Later bounty", deadlineDays: 30 })
+      .expect(201);
+
+    const beforeMiddle = new Date((middle.body.data.deadlineAt - 1) * 1000).toISOString();
+    const afterMiddle = new Date((middle.body.data.deadlineAt + 1) * 1000).toISOString();
+    const middleStart = new Date((soon.body.data.deadlineAt + 1) * 1000).toISOString();
+    const middleEnd = new Date((later.body.data.deadlineAt - 1) * 1000).toISOString();
+
+    const before = await request(app).get("/api/bounties").query({ deadlineBefore: beforeMiddle }).expect(200);
+    expect(before.body.data.map((bounty: { title: string }) => bounty.title)).toEqual(["Soon bounty"]);
+
+    const after = await request(app).get("/api/bounties").query({ deadlineAfter: afterMiddle }).expect(200);
+    expect(after.body.data.map((bounty: { title: string }) => bounty.title)).toEqual(["Later bounty"]);
+
+    const combined = await request(app)
+      .get("/api/bounties")
+      .query({ deadlineAfter: middleStart, deadlineBefore: middleEnd })
+      .expect(200);
+    expect(combined.body.data.map((bounty: { title: string }) => bounty.title)).toEqual(["Middle bounty"]);
+
+    const combinedWithSearch = await request(app)
+      .get("/api/bounties")
+      .query({ q: "later", deadlineBefore: middleEnd })
+      .expect(200);
+    expect(combinedWithSearch.body.data).toEqual([]);
+  });
+
+  it("GET /api/bounties rejects invalid deadline filters", async () => {
+    const app = await getApp();
+    const res = await request(app).get("/api/bounties").query({ deadlineBefore: "not-a-date" }).expect(400);
+    expect(res.body.error).toMatch(/deadlineBefore/i);
+  });
+
   it("GET /api/open-issues returns data", async () => {
     const app = await getApp();
     const res = await request(app).get("/api/open-issues").expect(200);


### PR DESCRIPTION
Closes #263

## Summary
- add `deadlineBefore` and `deadlineAfter` query params to `GET /api/bounties`
- validate date filters and return 400 for invalid values
- combine deadline filters with existing `q` search via AND logic
- add integration coverage for before, after, combined range, search+deadline, and invalid dates

## Verification
- `npm --prefix backend test -- api.test.ts -t "deadline"`
- `git diff --check`

## Existing baseline note
- `npm --prefix backend test -- api.test.ts` still has 2 unrelated existing failures in amount validation tests: amount above 10000 and more than 7 decimal places currently return 201 instead of 400.