### PR TITLE
Add Helmet security headers to Express app

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
         "express-rate-limit": "^8.3.1",
+        "helmet": "^8.2.0",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
         "stellar-bounty-board": "file:..",
@@ -2248,6 +2249,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/help-me": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
     "express-rate-limit": "^8.3.1",
+    "helmet": "^8.2.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "stellar-bounty-board": "file:..",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,6 @@
 import cors from "cors";
 import express, { Request, Response, NextFunction } from "express";
+import helmet from "helmet";
 import { randomUUID } from "node:crypto";
 import swaggerUi from "swagger-ui-express";
 import { buildCorsOptions } from "./middleware/corsOptions";
@@ -75,6 +76,16 @@ function requestContextMiddleware(req: Request, res: Response, next: NextFunctio
 export const app = express();
 
 app.use(cors(buildCorsOptions()));
+// API-only hardening: block browser execution contexts and keep Express internals hidden.
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'none'"],
+      },
+    },
+  }),
+);
 
 // Parse JSON bodies; capture raw body for webhook signature verification
 app.use(

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -43,6 +43,15 @@ describe("API — health and listing", () => {
     expect(res.body.service).toContain("bounty-board");
   });
 
+  it("GET /api/health returns security headers", async () => {
+    const app = await getApp();
+    const res = await request(app).get("/api/health").expect(200);
+    expect(res.headers["content-security-policy"]).toContain("default-src 'none'");
+    expect(res.headers["x-frame-options"]).toBeDefined();
+    expect(res.headers["strict-transport-security"]).toBeDefined();
+    expect(res.headers["x-powered-by"]).toBeUndefined();
+  });
+
   it("GET /api/bounties returns data array", async () => {
     const app = await getApp();
     const res = await request(app).get("/api/bounties").expect(200);


### PR DESCRIPTION
Closes #269

## Summary
- add `helmet` middleware immediately after CORS
- configure API CSP with `default-src 'none'`
- remove the Express `X-Powered-By` header via Helmet
- add integration coverage for CSP, frame, HSTS, and powered-by headers

## Verification
- `npm --prefix backend test -- api.test.ts -t "security headers"`
- `git diff --check`

## Existing baseline notes
- `npm --prefix backend test -- api.test.ts` still has 2 unrelated existing failures in amount validation tests: amount above 10000 and more than 7 decimal places currently return 201 instead of 400.
- `npm --prefix backend run build` still fails on existing baseline TypeScript issues: missing `@types/swagger-ui-express` and `submissionUrl` not existing on the current submit body type.