### PR TITLE
Sanitize bounty title and summary fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Backend (`backend`, default port `3001`)
 - Express REST API
 - File-backed JSON persistence in `backend/data/bounties.json`
 - Validation with Zod
+- Bounty titles and summaries are HTML-encoded before storage; the React frontend renders them through JSX so React's built-in escaping remains the primary XSS defense.
 
 Contract (`contracts`)
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
         "express-rate-limit": "^8.3.1",
+        "express-validator": "^7.3.2",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
         "stellar-bounty-board": "file:..",
@@ -1969,6 +1970,19 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.3.2.tgz",
+      "integrity": "sha512-ctLw1Vl6dXVH62dIQMDdTAQkrh480mkFuG6/SGXOaVlwPNukhRAe7EgJIMJ2TSAni8iwHBRp530zAZE5ZPF2IA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.18.1",
+        "validator": "~13.15.23"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/fast-copy": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
@@ -2391,6 +2405,12 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/loupe": {
@@ -3578,6 +3598,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
     "express-rate-limit": "^8.3.1",
+    "express-validator": "^7.3.2",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "stellar-bounty-board": "file:..",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,6 @@
 import cors from "cors";
 import express, { Request, Response, NextFunction } from "express";
+import { body } from "express-validator";
 import { randomUUID } from "node:crypto";
 import swaggerUi from "swagger-ui-express";
 import { buildCorsOptions } from "./middleware/corsOptions";
@@ -231,7 +232,12 @@ app.get("/api/bounties/released/export.csv", (req: Request, res: Response) => {
   }
 });
 
-app.post("/api/bounties", limiter, async (req: Request, res: Response) => {
+const sanitizeBountyTextFields = [
+  body("title").trim().escape(),
+  body("summary").trim().escape(),
+];
+
+app.post("/api/bounties", limiter, sanitizeBountyTextFields, async (req: Request, res: Response) => {
   const parsed = createBountySchema.safeParse(req.body);
   if (!parsed.success) {
     jsonError(res, req, 400, zodErrorMessage(parsed.error));

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -150,6 +150,36 @@ function nowInSeconds(): number {
   return Math.floor(Date.now() / 1000);
 }
 
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+function sanitizeBountyText(value: string): string {
+  return value
+    .trim()
+    .replace(/&(?!(?:amp|lt|gt|quot|#39|#[0-9]+|#x[0-9a-fA-F]+);)/g, HTML_ESCAPE_MAP["&"])
+    .replace(/[<>"']/g, (char) => HTML_ESCAPE_MAP[char]);
+}
+
+function sanitizeBountyRecord(record: BountyRecord): BountyRecord {
+  const title = sanitizeBountyText(record.title);
+  const summary = sanitizeBountyText(record.summary);
+
+  if (title === record.title && summary === record.summary) {
+    return record;
+  }
+
+  return {
+    ...record,
+    title,
+    summary,
+  };
+}
+
 function ensureStore(): void {
   const storePath = getStorePath();
   fs.mkdirSync(path.dirname(storePath), { recursive: true });
@@ -253,26 +283,31 @@ function normalizeRecords(records: BountyRecord[]): BountyRecord[] {
   const auditEntries: CreateAuditLogInput[] = [];
 
   const next = records.map((record) => {
+    const sanitized = sanitizeBountyRecord(record);
+    if (sanitized !== record) {
+      changed = true;
+    }
+
     // Ensure events array exists (for backward compatibility)
-    const events: BountyEvent[] = record.events || [{ type: "created" as const, timestamp: record.createdAt }];
+    const events: BountyEvent[] = sanitized.events || [{ type: "created" as const, timestamp: sanitized.createdAt }];
 
     // Check for expired deadline
-    if ((record.status === "open" || record.status === "reserved") && now > record.deadlineAt) {
+    if ((sanitized.status === "open" || sanitized.status === "reserved") && now > sanitized.deadlineAt) {
       changed = true;
       auditEntries.push({
-        bountyId: record.id,
-        fromStatus: record.status,
+        bountyId: sanitized.id,
+        fromStatus: sanitized.status,
         toStatus: "expired",
         transition: "expire",
         actor: "system",
         timestamp: now,
         metadata: {
           reason: "deadline_passed",
-          deadlineAt: record.deadlineAt,
+          deadlineAt: sanitized.deadlineAt,
         },
       });
       return {
-        ...record,
+        ...sanitized,
         status: "expired" as const,
         events: [
           ...events,
@@ -283,14 +318,14 @@ function normalizeRecords(records: BountyRecord[]): BountyRecord[] {
 
     // Check for expired reservation (timeout without submission)
     if (
-      record.status === "reserved" &&
-      record.reservedAt &&
-      record.reservationTimeoutSeconds &&
-      now > record.reservedAt + record.reservationTimeoutSeconds
+      sanitized.status === "reserved" &&
+      sanitized.reservedAt &&
+      sanitized.reservationTimeoutSeconds &&
+      now > sanitized.reservedAt + sanitized.reservationTimeoutSeconds
     ) {
       changed = true;
       return {
-        ...record,
+        ...sanitized,
         status: "open" as const,
         contributor: undefined,
         reservedAt: undefined,
@@ -302,17 +337,17 @@ function normalizeRecords(records: BountyRecord[]): BountyRecord[] {
     }
 
     // Ensure version and events exist for backward compatibility
-    if (!record.version || !record.events) {
+    if (!sanitized.version || !sanitized.events) {
       changed = true;
       return {
-        ...record,
-        version: record.version || 1,
+        ...sanitized,
+        version: sanitized.version || 1,
         events,
-        reservationTimeoutSeconds: record.reservationTimeoutSeconds || 604800,
+        reservationTimeoutSeconds: sanitized.reservationTimeoutSeconds || 604800,
       };
     }
 
-    return record;
+    return sanitized;
   });
 
   if (changed) {
@@ -390,8 +425,8 @@ export async function createBounty(input: CreateBountyInput): Promise<BountyReco
       id: nextId(records),
       repo: input.repo,
       issueNumber: input.issueNumber,
-      title: input.title,
-      summary: input.summary,
+      title: sanitizeBountyText(input.title),
+      summary: sanitizeBountyText(input.summary),
       maintainer: input.maintainer,
       tokenSymbol: input.tokenSymbol.toUpperCase(),
       amount: Number(input.amount.toFixed(2)),

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -67,6 +67,22 @@ describe("API — bounty lifecycle routes", () => {
     expect(listRes.body.data.some((b: { id: string }) => b.id === id)).toBe(true);
   });
 
+  it("POST /api/bounties sanitizes title and summary", async () => {
+    const app = await getApp();
+    const createRes = await request(app)
+      .post("/api/bounties")
+      .send({
+        ...validCreateBody,
+        title: "  <script>alert(1)</script> Fix title  ",
+        summary: "  <img src=x onerror=alert(1)> Summary with enough detail & context.  ",
+      })
+      .expect(201);
+
+    expect(createRes.body.data.title).toBe("&lt;script&gt;alert(1)&lt;&#x2F;script&gt; Fix title");
+    expect(createRes.body.data.summary).toContain("&lt;img src=x onerror=alert(1)&gt;");
+    expect(createRes.body.data.summary).toContain("&amp; context.");
+  });
+
   it("POST create with invalid body returns 400", async () => {
     const app = await getApp();
     const res = await request(app)

--- a/backend/test/bountyStore.test.ts
+++ b/backend/test/bountyStore.test.ts
@@ -118,6 +118,33 @@ describe("bountyStore lifecycle — happy paths", () => {
     expect(refunded.refundedTxHash).toBe(txHash);
   });
 
+  it("sanitizes bounty title and summary before storage and listing", async () => {
+    const { createBounty, listBounties } = await loadStore();
+    const created = await createBounty({
+      repo: "acme/widget",
+      issueNumber: 4,
+      title: "  <script>alert(1)</script> Fix title  ",
+      summary: "  <img src=x onerror=alert(1)> Summary with enough detail & context.  ",
+      maintainer: MAINTAINER,
+      tokenSymbol: "XLM",
+      amount: 25,
+      deadlineDays: 7,
+      labels: [],
+    });
+
+    expect(created.title).toBe("&lt;script&gt;alert(1)&lt;/script&gt; Fix title");
+    expect(created.summary).toContain("&lt;img src=x onerror=alert(1)&gt;");
+    expect(created.summary).toContain("&amp; context.");
+
+    const raw = JSON.parse(fs.readFileSync(storeFile, "utf8")) as BountyRecord[];
+    expect(raw[0].title).toBe(created.title);
+    expect(raw[0].summary).toBe(created.summary);
+
+    const listed = listBounties().find((bounty) => bounty.id === created.id);
+    expect(listed?.title).toBe(created.title);
+    expect(listed?.summary).toBe(created.summary);
+  });
+
   it("create → reserve → refund", async () => {
     const { createBounty, reserveBounty, refundBounty } = await loadStore();
     const created = await createBounty({


### PR DESCRIPTION
Closes #277

## Summary
- add `express-validator` sanitizers for `title` and `summary` on bounty creation
- HTML-encode and trim bounty text before storage in the bounty store
- normalize loaded records so existing unsafe text is sanitized before output
- document React JSX auto-escaping as the primary frontend XSS defense
- add API and store coverage for script/tag payloads

## Verification
- `npm --prefix backend test -- bountyStore.test.ts`
- `npm --prefix backend test -- api.test.ts -t "sanitizes title"`
- `npm --prefix backend test -- api.test.ts -t "POST /api/bounties creates"`
- `git diff --check`

## Existing baseline notes
- `npm --prefix backend test -- api.test.ts` still has 2 unrelated existing failures in amount validation tests: amount above 10000 and more than 7 decimal places currently return 201 instead of 400.
- `npm --prefix backend run build` still fails on existing baseline TypeScript issues: missing `@types/swagger-ui-express` and `submissionUrl` not existing on the current submit body type.