### PR TITLE
Add amount range filters for bounties API

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -120,6 +120,26 @@ function parsePaginationValue(
   return parsed;
 }
 
+function parseOptionalAmountFilter(raw: unknown, field: string): number | undefined {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`${field} must be a number.`);
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${field} must be a number.`);
+  }
+  if (parsed < 0) {
+    throw new Error(`${field} must be greater than or equal to 0.`);
+  }
+
+  return parsed;
+}
+
 function jsonError(res: Response, req: Request, statusCode: number, message: string) {
   res.status(statusCode).json({ error: message, requestId: req.requestId });
 }
@@ -155,8 +175,26 @@ app.get("/worker/health", (_req: Request, res: Response) => {
 });
 
 app.get("/api/bounties", (req: Request, res: Response) => {
-  const q = typeof req.query.q === "string" ? req.query.q : undefined;
-  res.json({ data: listBounties({ q }) });
+  try {
+    const q = typeof req.query.q === "string" ? req.query.q : undefined;
+    const minAmount = parseOptionalAmountFilter(req.query.minAmount, "minAmount");
+    const maxAmount = parseOptionalAmountFilter(req.query.maxAmount, "maxAmount");
+
+    if (minAmount !== undefined && maxAmount !== undefined && minAmount > maxAmount) {
+      jsonError(res, req, 400, "minAmount must be less than or equal to maxAmount.");
+      return;
+    }
+
+    const data = listBounties({ q }).filter((bounty) => {
+      if (minAmount !== undefined && bounty.amount < minAmount) return false;
+      if (maxAmount !== undefined && bounty.amount > maxAmount) return false;
+      return true;
+    });
+
+    res.json({ data });
+  } catch (error) {
+    sendError(res, req, error);
+  }
 });
 
 app.get("/api/leaderboard", (_req: Request, res: Response) => {

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -54,6 +54,34 @@ describe("API — health and listing", () => {
     const res = await request(app).get("/api/open-issues").expect(200);
     expect(res.body).toHaveProperty("data");
   });
+
+  it("GET /api/bounties filters by amount range", async () => {
+    const app = await getApp();
+
+    await request(app).post("/api/bounties").send({ ...validCreateBody, amount: 25 }).expect(201);
+    await request(app).post("/api/bounties").send({ ...validCreateBody, issueNumber: 124, amount: 75 }).expect(201);
+    await request(app).post("/api/bounties").send({ ...validCreateBody, issueNumber: 125, amount: 150 }).expect(201);
+
+    const res = await request(app)
+      .get("/api/bounties")
+      .query({ minAmount: 50, maxAmount: 100 })
+      .expect(200);
+
+    expect(res.body.data.map((b: { amount: number }) => b.amount)).toEqual([75]);
+  });
+
+  it("GET /api/bounties validates amount range filters", async () => {
+    const app = await getApp();
+
+    const invalidNumber = await request(app).get("/api/bounties").query({ minAmount: "abc" }).expect(400);
+    expect(invalidNumber.body.error).toMatch(/minAmount/i);
+
+    const invalidRange = await request(app)
+      .get("/api/bounties")
+      .query({ minAmount: 100, maxAmount: 50 })
+      .expect(400);
+    expect(invalidRange.body.error).toMatch(/minAmount/i);
+  });
 });
 
 describe("API — bounty lifecycle routes", () => {

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -70,6 +70,32 @@ describe("API — health and listing", () => {
     expect(res.body.data.map((b: { amount: number }) => b.amount)).toEqual([75]);
   });
 
+  it("GET /api/bounties filters by minAmount only", async () => {
+    const app = await getApp();
+
+    await request(app).post("/api/bounties").send({ ...validCreateBody, amount: 25 }).expect(201);
+    await request(app).post("/api/bounties").send({ ...validCreateBody, issueNumber: 124, amount: 75 }).expect(201);
+    await request(app).post("/api/bounties").send({ ...validCreateBody, issueNumber: 125, amount: 150 }).expect(201);
+
+    const res = await request(app).get("/api/bounties").query({ minAmount: 50 }).expect(200);
+    const amounts = res.body.data.map((b: { amount: number }) => b.amount).sort((a: number, b: number) => a - b);
+
+    expect(amounts).toEqual([75, 150]);
+  });
+
+  it("GET /api/bounties filters by maxAmount only", async () => {
+    const app = await getApp();
+
+    await request(app).post("/api/bounties").send({ ...validCreateBody, amount: 25 }).expect(201);
+    await request(app).post("/api/bounties").send({ ...validCreateBody, issueNumber: 124, amount: 75 }).expect(201);
+    await request(app).post("/api/bounties").send({ ...validCreateBody, issueNumber: 125, amount: 150 }).expect(201);
+
+    const res = await request(app).get("/api/bounties").query({ maxAmount: 100 }).expect(200);
+    const amounts = res.body.data.map((b: { amount: number }) => b.amount).sort((a: number, b: number) => a - b);
+
+    expect(amounts).toEqual([25, 75]);
+  });
+
   it("GET /api/bounties validates amount range filters", async () => {
     const app = await getApp();
 


### PR DESCRIPTION
## Summary
- Adds `minAmount` and `maxAmount` query params to `GET /api/bounties`
- Validates numeric filters and rejects inverted ranges
- Filters after existing `q` search so filters compose cleanly
- Adds API tests for valid range filtering and validation failures

Closes #262.

## Test notes
- `npm test -- test/api.test.ts`: new range-filter tests pass; existing unrelated amount validation tests fail on current main because API returns 201 for boundary cases expected as 400.
- `npm test`: existing failures also present outside this change (`expireStaleReservations` export/reservation/auth expectations). New tests pass.
- `git diff --check`: clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added amount range filtering for bounties—use `minAmount` and `maxAmount` query parameters to narrow results
  * Improved validation to reject invalid amount values and requests where minimum exceeds maximum (HTTP 400)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->