### PR TITLE
Tighten mutation rate limits

### DIFF
--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -18,13 +18,15 @@ const WINDOW_MS = Number(process.env.RATE_LIMIT_WINDOW_MS ?? 60_000);
 const READ_MAX = Number(process.env.RATE_LIMIT_READ_MAX ?? 120);
 const MUTATION_MAX = Number(process.env.RATE_LIMIT_MUTATION_MAX ?? 10);
 
-const isTest = process.env.NODE_ENV === "test";
+function shouldSkipRateLimits(): boolean {
+  return process.env.NODE_ENV === "test" && process.env.RATE_LIMIT_TEST_MODE !== "true";
+}
 
 /** No-op middleware so test suites can hit routes freely. */
 const passthrough: RequestHandler = (_req, _res, next) => next();
 
 function makeLimiter(limit: number, options: { getOnly?: boolean } = {}): RequestHandler {
-  if (isTest) {
+  if (shouldSkipRateLimits()) {
     return passthrough;
   }
   return rateLimit({

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -17,6 +17,10 @@ beforeEach(async () => {
 
 afterEach(() => {
   delete process.env.BOUNTY_STORE_PATH;
+  delete process.env.RATE_LIMIT_TEST_MODE;
+  delete process.env.RATE_LIMIT_WINDOW_MS;
+  delete process.env.RATE_LIMIT_READ_MAX;
+  delete process.env.RATE_LIMIT_MUTATION_MAX;
   try {
     fs.unlinkSync(storeFile);
   } catch {
@@ -294,6 +298,33 @@ describe("API — bounty lifecycle routes", () => {
       .send({ contributor: CONTRIBUTOR })
       .expect(400);
     expect(res.body.error).toMatch(/not found/i);
+  });
+
+  it("rate limits repeated mutation requests", async () => {
+    process.env.RATE_LIMIT_TEST_MODE = "true";
+    process.env.RATE_LIMIT_READ_MAX = "50";
+    process.env.RATE_LIMIT_MUTATION_MAX = "2";
+    process.env.RATE_LIMIT_WINDOW_MS = "60000";
+    vi.resetModules();
+
+    const app = await getApp();
+    const { body: created } = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+    const id = created.data.id as string;
+
+    const first = await request(app)
+      .post(`/api/bounties/${id}/reserve`)
+      .send({ contributor: CONTRIBUTOR })
+      .expect(200);
+
+    expect(first.headers["ratelimit"]).toBeDefined();
+
+    const limited = await request(app)
+      .post(`/api/bounties/${id}/reserve`)
+      .send({ contributor: OTHER_ACCOUNT })
+      .expect(429);
+
+    expect(limited.headers["retry-after"]).toBeDefined();
+    expect(limited.headers["ratelimit"]).toBeDefined();
   });
 });
 


### PR DESCRIPTION
Fixes #349

Adds a global 120/min limiter and a stricter 10/min limiter for the bounty mutation routes. The limits can be tuned with env vars, and 429s include `Retry-After`.

Checked:
- `npm.cmd --prefix backend run build` (fails on existing type issues: missing swagger-ui-express declarations and submit schema not exposing submissionUrl)
- `npm.cmd --prefix backend test` (new rate-limit test passes; existing unrelated tests still fail)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented tiered rate limiting with separate configurable limits for read and write operations.
  * Rate-limited responses now include `Retry-After` headers for better client handling.

* **Tests**
  * Added integration test validating mutation rate limiting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->