### PR TITLE
Add live USD conversion for bounty amounts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,8 +23,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "jsdom": "^24.1.3",
         "typescript": "^5.6.3",
-        "vite": "^5.4.11",
-
+        "vite": "^5.4.11"
       }
     },
     "..": {
@@ -41,8 +40,7 @@
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express-rate-limit": "^5.1.3",
-        "@types/swagger-ui-express": "^4.1.8",
-
+        "@types/swagger-ui-express": "^4.1.8"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3805,4 +3803,3 @@
       "license": "ISC"
     }
   }
-}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,7 +39,7 @@ import SubmissionChecklistModal, { type SubmissionFormData } from "./SubmissionC
 import { BountyRecommendation, ContributorProfile, createDefaultProfile, generateRecommendations, updateProfileFromBounties } from "./recommendations";
 import RecommendedBounties from "./RecommendedBounties";
 import { statusCopy, actionCopy, readInitialFilters, FilterState, statusOptions, statusGlossary, sortOptions } from "./constants";
-import { filterBounties, getRewardBounds, getActiveRewardLabel, getContributorMetrics, getUniqueRepos, getRepoMetrics, sortBounties, debounce, SortOption, SortState, xlmToUsd } from "./utils";
+import { filterBounties, getRewardBounds, getActiveRewardLabel, getContributorMetrics, getUniqueRepos, getRepoMetrics, sortBounties, debounce, SortOption, SortState } from "./utils";
 import { Bounty, CreateBountyPayload, OpenIssue, BountyStatus } from "./types";
 
 import GitHubIssuePreviewCard from "./GitHubIssuePreviewCard";
@@ -142,34 +142,10 @@ function formatTimestamp(value?: number): string {
 }
 
 const BountyAmount = memo(function BountyAmount({ bounty }: { bounty: Bounty }) {
-  const [usdAmount, setUsdAmount] = useState<string | null>(null);
-
-  useEffect(() => {
-    let active = true;
-
-    if (bounty.tokenSymbol.toUpperCase() !== "XLM") {
-      setUsdAmount(null);
-      return () => {
-        active = false;
-      };
-    }
-
-    setUsdAmount(null);
-    void xlmToUsd(bounty.amount).then((value) => {
-      if (active) {
-        setUsdAmount(value);
-      }
-    });
-
-    return () => {
-      active = false;
-    };
-  }, [bounty.amount, bounty.tokenSymbol]);
-
   return (
     <div className="amount-chip">
       <strong>{bounty.amount} {bounty.tokenSymbol}</strong>
-      {usdAmount && <span>{usdAmount}</span>}
+      <UsdAmount amount={bounty.amount} tokenSymbol={bounty.tokenSymbol} />
     </div>
   );
 });
@@ -1219,6 +1195,7 @@ function App() {
                               </div>
                               <div className="amount-chip">
                                 {bounty.amount} {bounty.tokenSymbol}
+                                <UsdAmount amount={bounty.amount} tokenSymbol={bounty.tokenSymbol} />
                               </div>
                             </div>
 
@@ -1454,6 +1431,7 @@ function App() {
                         </div>
                         <div className="amount-chip">
                           {bounty.amount} {bounty.tokenSymbol}
+                          <UsdAmount amount={bounty.amount} tokenSymbol={bounty.tokenSymbol} />
                         </div>
                       </div>
 

--- a/frontend/src/BountyDetailPage.tsx
+++ b/frontend/src/BountyDetailPage.tsx
@@ -186,9 +186,7 @@ export default function BountyDetailPage({
               </div>
               <div className="amount-chip">
                 {bounty.amount} {bounty.tokenSymbol}
-                {bounty.tokenSymbol === "XLM" && (
-                  <UsdAmount amount={bounty.amount} />
-                )}
+                <UsdAmount amount={bounty.amount} tokenSymbol={bounty.tokenSymbol} />
               </div>
             </div>
 

--- a/frontend/src/RecommendedBounties.tsx
+++ b/frontend/src/RecommendedBounties.tsx
@@ -69,9 +69,7 @@ function BountyRecommendationCard({ recommendation }: { recommendation: BountyRe
         </div>
         <div className="amount-chip">
           {bounty.amount} {bounty.tokenSymbol}
-          {bounty.tokenSymbol === "XLM" && (
-            <UsdAmount amount={bounty.amount} />
-          )}
+          <UsdAmount amount={bounty.amount} tokenSymbol={bounty.tokenSymbol} />
         </div>
       </div>
 
@@ -135,7 +133,7 @@ export default function RecommendedBounties({ recommendations, loading }: Recomm
       ? recommendations
       : recommendations.filter(({ bounty }) => {
           const haystack = [
-            ...bounty.labels,
+            ...bounty.labels.map((label) => label.name),
             ...(bounty.tags ?? []),
           ].map((t) => t.toLowerCase());
           return haystack.some((t) => t.includes(activeTag.toLowerCase()));

--- a/frontend/src/UsdAmount.test.tsx
+++ b/frontend/src/UsdAmount.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import UsdAmount from "./UsdAmount";
+import { resetXlmToUsdCache } from "./utils";
+
+describe("UsdAmount", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    resetXlmToUsdCache();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows a loading state while fetching the XLM/USD rate", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ stellar: { usd: 0.125 } }),
+    });
+
+    render(<UsdAmount amount={100} tokenSymbol="XLM" />);
+
+    expect(screen.getByText("(Loading USD...)")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("($12.50)")).toBeInTheDocument());
+  });
+
+  it("renders USDC bounties 1:1 without fetching the XLM/USD rate", async () => {
+    render(<UsdAmount amount={25} tokenSymbol="USDC" />);
+
+    await waitFor(() => expect(screen.getByText("($25.00)")).toBeInTheDocument());
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/UsdAmount.tsx
+++ b/frontend/src/UsdAmount.tsx
@@ -3,22 +3,37 @@ import { xlmToUsd } from "./utils";
 
 interface UsdAmountProps {
   amount: number;
+  tokenSymbol?: string;
 }
 
-export default function UsdAmount({ amount }: UsdAmountProps) {
-  const [usdValue, setUsdValue] = useState<string>("");
+export default function UsdAmount({ amount, tokenSymbol = "XLM" }: UsdAmountProps) {
+  const [usdValue, setUsdValue] = useState<string | null>(null);
 
   useEffect(() => {
     let active = true;
-    xlmToUsd(amount).then((value) => {
+    const normalizedToken = tokenSymbol.toUpperCase();
+
+    if (normalizedToken !== "XLM" && normalizedToken !== "USDC") {
+      setUsdValue("");
+      return () => {
+        active = false;
+      };
+    }
+
+    setUsdValue(null);
+    xlmToUsd(amount, normalizedToken).then((value) => {
       if (active) setUsdValue(value);
     });
     return () => {
       active = false;
     };
-  }, [amount]);
+  }, [amount, tokenSymbol]);
 
-  if (!usdValue) return null;
+  if (usdValue === "") return null;
+
+  if (usdValue === null) {
+    return <span className="usd-amount">(Loading USD...)</span>;
+  }
 
   return <span className="usd-amount">({usdValue})</span>;
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -148,10 +148,19 @@ async function requestBlob(path: string, options: RequestOptions = {}): Promise<
   throw formatRetryError(retryLabel, retryAttempts, message);
 }
 
-
+export async function listBounties(signal?: AbortSignal): Promise<Bounty[]> {
   const body = await requestJson<{ data: Bounty[] }>("/bounties", {
     retry: true,
     retryLabel: "Loading bounties",
+    signal,
+  });
+  return body.data;
+}
+
+export async function getBounty(id: string, signal?: AbortSignal): Promise<Bounty> {
+  const body = await requestJson<{ data: Bounty }>(`/bounties/${id}`, {
+    retry: true,
+    retryLabel: "Loading bounty",
     signal,
   });
   return body.data;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { Toaster } from 'sonner'
-import App from './App.tsx'
+import App from './App'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/frontend/src/recommendations.test.ts
+++ b/frontend/src/recommendations.test.ts
@@ -1,1 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { createDefaultProfile, generateRecommendations } from "./recommendations";
 
+describe("recommendations", () => {
+  it("returns no recommendations for an empty bounty list", () => {
+    expect(generateRecommendations([], createDefaultProfile())).toEqual([]);
+  });
+});

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -34,8 +34,8 @@ export function scoreMatch(bounty: Bounty, skills: string[]): number {
   const bountyTokens: string[] = bounty.labels.map((l) => l.name.toLowerCase());
 
   // Also include bounty.tags if present (used in RecommendedBounties.tsx)
-  if (Array.isArray((bounty as Record<string, unknown>).tags)) {
-    const tags = (bounty as Record<string, unknown>).tags as string[];
+  if (Array.isArray((bounty as unknown as Record<string, unknown>).tags)) {
+    const tags = (bounty as unknown as Record<string, unknown>).tags as string[];
     bountyTokens.push(...tags.map((t: string) => t.toLowerCase()));
   }
 
@@ -107,37 +107,6 @@ const STATUS_WEIGHTS: Record<BountyStatus, number> = {
   "refunded": 0,
   "expired": 0,
 };
-
-function normalizeTerms(values: string[]): string[] {
-  return [...new Set(values.map((value) => value.trim().toLowerCase()).filter(Boolean))];
-}
-
-function getBountySkillTerms(bounty: Bounty): string[] {
-  return normalizeTerms(bounty.labels.map((label) => label.name));
-}
-
-export function scoreMatch(bounty: Bounty, skills: string[]): number {
-  const bountySkills = getBountySkillTerms(bounty);
-  const contributorSkills = normalizeTerms(skills);
-
-  if (bountySkills.length === 0 || contributorSkills.length === 0) {
-    return 0;
-  }
-
-  const bountySkillSet = new Set(bountySkills);
-  const contributorSkillSet = new Set(contributorSkills);
-  let overlap = 0;
-
-  for (const skill of bountySkillSet) {
-    if (contributorSkillSet.has(skill)) {
-      overlap += 1;
-    }
-  }
-
-  const unionSize = new Set([...bountySkillSet, ...contributorSkillSet]).size;
-
-  return unionSize > 0 ? Math.round((overlap / unionSize) * 100) / 100 : 0;
-}
 
 export function calculateRecommendationScore(
   bounty: Bounty,

--- a/frontend/src/toast.test.tsx
+++ b/frontend/src/toast.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { toast } from 'sonner';
+import type { Bounty } from './types';
 
 vi.mock('sonner', () => ({
   toast: {
@@ -33,19 +34,32 @@ const baseBounty = {
   title: 'Test bounty',
   summary: 'Summary',
   maintainer: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-  contributor: null,
   tokenSymbol: 'XLM',
   amount: 100,
   labels: [],
+  status: 'open',
   createdAt: 1_700_000_000,
   deadlineAt: 9_999_999_999,
   version: 1,
   events: [],
-};
+} satisfies Bounty;
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(api.listOpenIssues).mockResolvedValue([]);
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
   window.prompt = vi.fn();
   window.alert = vi.fn();
 });
@@ -55,7 +69,7 @@ describe('Toast notifications for async bounty actions', () => {
   it('shows success toast when bounty is reserved', async () => {
     vi.mocked(api.listBounties).mockResolvedValue([{ ...baseBounty, status: 'open' }]);
     vi.mocked(window.prompt).mockReturnValue('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF');
-    vi.mocked(api.reserveBounty).mockResolvedValue(undefined);
+    vi.mocked(api.reserveBounty).mockResolvedValue({ ...baseBounty, status: 'reserved' });
 
     render(<App />);
     await waitFor(() => expect(screen.getByText('Test bounty')).toBeInTheDocument());
@@ -103,7 +117,7 @@ describe('Toast notifications for async bounty actions', () => {
     vi.mocked(window.prompt)
       .mockReturnValueOnce('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF')
       .mockReturnValueOnce('');
-    vi.mocked(api.releaseBounty).mockResolvedValue(undefined);
+    vi.mocked(api.releaseBounty).mockResolvedValue({ ...baseBounty, status: 'released' });
 
     render(<App />);
     await waitFor(() => expect(screen.getByText('Test bounty')).toBeInTheDocument());
@@ -143,7 +157,7 @@ describe('Toast notifications for async bounty actions', () => {
     vi.mocked(window.prompt)
       .mockReturnValueOnce('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF')
       .mockReturnValueOnce('');
-    vi.mocked(api.refundBounty).mockResolvedValue(undefined);
+    vi.mocked(api.refundBounty).mockResolvedValue({ ...baseBounty, status: 'refunded' });
 
     render(<App />);
     await waitFor(() => expect(screen.getByText('Test bounty')).toBeInTheDocument());

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -36,6 +36,7 @@ export interface Bounty {
   tokenSymbol: string;
   amount: number;
   labels: GithubLabel[];
+  tags?: string[];
 
   status: BountyStatus;
   createdAt: number;

--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -11,6 +11,7 @@ describe("xlmToUsd", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -37,6 +38,29 @@ describe("xlmToUsd", () => {
     await expect(xlmToUsd(25)).resolves.toBe("$5.00");
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the last known XLM/USD rate when a refresh fails", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-28T00:00:00.000Z"));
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ stellar: { usd: 0.2 } }),
+    });
+
+    await expect(xlmToUsd(10)).resolves.toBe("$2.00");
+
+    vi.setSystemTime(new Date("2026-05-28T00:06:00.000Z"));
+    fetchMock.mockRejectedValueOnce(new Error("network unavailable"));
+
+    await expect(xlmToUsd(25)).resolves.toBe("$5.00");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("formats USDC bounties 1:1 without fetching XLM/USD", async () => {
+    await expect(xlmToUsd(42.5, "USDC")).resolves.toBe("$42.50");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("falls back gracefully when the rate fetch fails", async () => {

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -158,12 +158,31 @@ const XLM_USD_PRICE_URL =
 const XLM_USD_CACHE_MS = 5 * 60 * 1000;
 
 let cachedXlmUsdRate: { rate: number; fetchedAt: number } | null = null;
+let pendingXlmUsdRate: Promise<number> | null = null;
+
+function formatUsd(amount: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}
 
 async function fetchXlmUsdRate(): Promise<number> {
   if (cachedXlmUsdRate && Date.now() - cachedXlmUsdRate.fetchedAt < XLM_USD_CACHE_MS) {
     return cachedXlmUsdRate.rate;
   }
 
+  if (pendingXlmUsdRate) {
+    return pendingXlmUsdRate;
+  }
+
+  pendingXlmUsdRate = requestXlmUsdRate();
+  return pendingXlmUsdRate;
+}
+
+async function requestXlmUsdRate(): Promise<number> {
   const controller = new AbortController();
   const timeoutId = window.setTimeout(() => controller.abort(), 5000);
 
@@ -182,20 +201,32 @@ async function fetchXlmUsdRate(): Promise<number> {
 
     cachedXlmUsdRate = { rate, fetchedAt: Date.now() };
     return rate;
+  } catch (error) {
+    if (cachedXlmUsdRate) {
+      return cachedXlmUsdRate.rate;
+    }
+
+    throw error;
   } finally {
     window.clearTimeout(timeoutId);
+    pendingXlmUsdRate = null;
   }
 }
 
-export async function xlmToUsd(amount: number): Promise<string> {
+export async function xlmToUsd(amount: number, tokenSymbol = "XLM"): Promise<string> {
+  const normalizedToken = tokenSymbol.toUpperCase();
+
+  if (normalizedToken === "USDC") {
+    return formatUsd(amount);
+  }
+
+  if (normalizedToken !== "XLM") {
+    return "USD unavailable";
+  }
+
   try {
     const rate = await fetchXlmUsdRate();
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(amount * rate);
+    return formatUsd(amount * rate);
   } catch {
     return "USD unavailable";
   }
@@ -203,6 +234,7 @@ export async function xlmToUsd(amount: number): Promise<string> {
 
 export function resetXlmToUsdCache(): void {
   cachedXlmUsdRate = null;
+  pendingXlmUsdRate = null;
 }
 
 export function getContributorMetrics(bounties: Bounty[], contributorAddress?: string) {


### PR DESCRIPTION
## Summary
- adds live XLM/USD conversion handling with loading and stale fallback states
- treats USDC amounts as 1:1 USD and displays converted values consistently across bounty cards, details, and recommendations
- adds focused tests for USD conversion utilities and `UsdAmount`
- hardens existing frontend build/test blockers so the frontend suite is green from this branch

## Verification
- `npm --prefix frontend test -- --run src/utils.test.ts src/UsdAmount.test.tsx --reporter=dot` — 2 files, 7 tests passed
- `npm --prefix frontend test -- --reporter=dot` — 5 files, 20 tests passed
- `npm --prefix frontend run build` — passed
- `git diff --check` — passed

## Notes
- Backend tests/build were not run in this separate frontend-only clone because `backend/node_modules` is not installed here.
- Payout rail: Base USDC `0x1E5E9C09A2946094737724B9B0EAea819581f5d3`

Closes #288
