### PR TITLE
Add debounced bounty search filtering

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,6 +26,7 @@
         "@types/express": "^5.0.0",
         "@types/node": "^22.10.2",
         "@types/pino": "^7.0.5",
+        "@types/swagger-ui-express": "^4.1.8",
         "supertest": "^7.1.0",
         "tsx": "^4.21.0",
         "typescript": "^5.7.2",
@@ -1104,6 +1105,17 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@vitest/expect": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "@types/express": "^5.0.0",
     "@types/node": "^22.10.2",
     "@types/pino": "^7.0.5",
+    "@types/swagger-ui-express": "^4.1.8",
     "supertest": "^7.1.0",
     "tsx": "^4.21.0",
     "typescript": "^5.7.2",

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -124,6 +124,14 @@ export const submitBountySchema = z
     contributor: stellarAccountSchema.openapi({
       description: "Must match the contributor who reserved the bounty.",
     }),
+    submissionUrl: z
+      .string()
+      .trim()
+      .regex(GITHUB_PR_URL_REGEX, "Submission URL must be a GitHub pull request URL.")
+      .openapi({
+        example: "https://github.com/owner/repo/pull/99",
+        description: "GitHub pull request URL for the completed work.",
+      }),
 
     notes: z
       .string()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1034,7 +1034,7 @@ function App() {
                       <input
                         value={searchQuery}
                         onChange={(event) => setSearchQuery(event.target.value)}
-                        placeholder="Search repo, title, labels, status"
+                        placeholder="Search repo, title, summary, labels"
                       />
                     </div>
                   </label>

--- a/frontend/src/RecommendedBounties.tsx
+++ b/frontend/src/RecommendedBounties.tsx
@@ -135,10 +135,10 @@ export default function RecommendedBounties({ recommendations, loading }: Recomm
       ? recommendations
       : recommendations.filter(({ bounty }) => {
           const haystack = [
-            ...bounty.labels,
+            ...bounty.labels.map((label) => label.name),
             ...(bounty.tags ?? []),
-          ].map((t) => t.toLowerCase());
-          return haystack.some((t) => t.includes(activeTag.toLowerCase()));
+          ].map((tag) => tag.toLowerCase());
+          return haystack.some((tag) => tag.includes(activeTag.toLowerCase()));
         });
 
   if (loading) {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -148,7 +148,7 @@ async function requestBlob(path: string, options: RequestOptions = {}): Promise<
   throw formatRetryError(retryLabel, retryAttempts, message);
 }
 
-
+export async function listBounties(signal?: AbortSignal): Promise<Bounty[]> {
   const body = await requestJson<{ data: Bounty[] }>("/bounties", {
     retry: true,
     retryLabel: "Loading bounties",
@@ -211,6 +211,15 @@ export async function refundBounty(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ maintainer, transactionHash }),
+  });
+  return body.data;
+}
+
+export async function getBounty(id: string, signal?: AbortSignal): Promise<Bounty> {
+  const body = await requestJson<{ data: Bounty }>(`/bounties/${encodeURIComponent(id)}`, {
+    retry: true,
+    retryLabel: "Loading bounty",
+    signal,
   });
   return body.data;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { Toaster } from 'sonner'
-import App from './App.tsx'
+import App from './App'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/frontend/src/recommendations.test.ts
+++ b/frontend/src/recommendations.test.ts
@@ -1,1 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { scoreMatch } from "./recommendations";
+import { Bounty } from "./types";
 
+const bounty: Bounty = {
+  id: "BNTY-291",
+  repo: "ritik4ever/stellar-bounty-board",
+  issueNumber: 291,
+  title: "Add debounced React search",
+  summary: "Filter bounty cards with TypeScript and frontend state.",
+  maintainer: "maintainer",
+  tokenSymbol: "XLM",
+  amount: 100,
+  labels: [{ name: "frontend", color: "0f766e" }],
+  tags: ["React"],
+  status: "open",
+  createdAt: 1,
+  deadlineAt: 2,
+  version: 1,
+  events: [],
+};
+
+describe("scoreMatch", () => {
+  it("scores skills against labels, tags, title, and summary text", () => {
+    expect(scoreMatch(bounty, ["React", "TypeScript", "frontend"])).toBe(1);
+  });
+
+  it("returns zero when no skills match the bounty", () => {
+    expect(scoreMatch(bounty, ["Rust"])).toBe(0);
+  });
+});

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -34,9 +34,8 @@ export function scoreMatch(bounty: Bounty, skills: string[]): number {
   const bountyTokens: string[] = bounty.labels.map((l) => l.name.toLowerCase());
 
   // Also include bounty.tags if present (used in RecommendedBounties.tsx)
-  if (Array.isArray((bounty as Record<string, unknown>).tags)) {
-    const tags = (bounty as Record<string, unknown>).tags as string[];
-    bountyTokens.push(...tags.map((t: string) => t.toLowerCase()));
+  if (bounty.tags) {
+    bountyTokens.push(...bounty.tags.map((tag) => tag.toLowerCase()));
   }
 
   // Include title and summary for broader matching
@@ -107,37 +106,6 @@ const STATUS_WEIGHTS: Record<BountyStatus, number> = {
   "refunded": 0,
   "expired": 0,
 };
-
-function normalizeTerms(values: string[]): string[] {
-  return [...new Set(values.map((value) => value.trim().toLowerCase()).filter(Boolean))];
-}
-
-function getBountySkillTerms(bounty: Bounty): string[] {
-  return normalizeTerms(bounty.labels.map((label) => label.name));
-}
-
-export function scoreMatch(bounty: Bounty, skills: string[]): number {
-  const bountySkills = getBountySkillTerms(bounty);
-  const contributorSkills = normalizeTerms(skills);
-
-  if (bountySkills.length === 0 || contributorSkills.length === 0) {
-    return 0;
-  }
-
-  const bountySkillSet = new Set(bountySkills);
-  const contributorSkillSet = new Set(contributorSkills);
-  let overlap = 0;
-
-  for (const skill of bountySkillSet) {
-    if (contributorSkillSet.has(skill)) {
-      overlap += 1;
-    }
-  }
-
-  const unionSize = new Set([...bountySkillSet, ...contributorSkillSet]).size;
-
-  return unionSize > 0 ? Math.round((overlap / unionSize) * 100) / 100 : 0;
-}
 
 export function calculateRecommendationScore(
   bounty: Bounty,

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,1 +1,16 @@
 ﻿import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});

--- a/frontend/src/toast.test.tsx
+++ b/frontend/src/toast.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { toast } from 'sonner';
+import { Bounty } from './types';
 
 vi.mock('sonner', () => ({
   toast: {
@@ -26,17 +27,17 @@ vi.mock('./api', () => ({
 import * as api from './api';
 import App from './App';
 
-const baseBounty = {
+const baseBounty: Bounty = {
   id: 'BNTY-1',
   repo: 'ritik4ever/stellar-bounty-board',
   issueNumber: 1,
   title: 'Test bounty',
   summary: 'Summary',
   maintainer: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-  contributor: null,
   tokenSymbol: 'XLM',
   amount: 100,
   labels: [],
+  status: 'open',
   createdAt: 1_700_000_000,
   deadlineAt: 9_999_999_999,
   version: 1,
@@ -55,7 +56,7 @@ describe('Toast notifications for async bounty actions', () => {
   it('shows success toast when bounty is reserved', async () => {
     vi.mocked(api.listBounties).mockResolvedValue([{ ...baseBounty, status: 'open' }]);
     vi.mocked(window.prompt).mockReturnValue('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF');
-    vi.mocked(api.reserveBounty).mockResolvedValue(undefined);
+    vi.mocked(api.reserveBounty).mockResolvedValue({ ...baseBounty, status: 'reserved' });
 
     render(<App />);
     await waitFor(() => expect(screen.getByText('Test bounty')).toBeInTheDocument());
@@ -103,7 +104,7 @@ describe('Toast notifications for async bounty actions', () => {
     vi.mocked(window.prompt)
       .mockReturnValueOnce('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF')
       .mockReturnValueOnce('');
-    vi.mocked(api.releaseBounty).mockResolvedValue(undefined);
+    vi.mocked(api.releaseBounty).mockResolvedValue({ ...baseBounty, status: 'released' });
 
     render(<App />);
     await waitFor(() => expect(screen.getByText('Test bounty')).toBeInTheDocument());
@@ -143,7 +144,7 @@ describe('Toast notifications for async bounty actions', () => {
     vi.mocked(window.prompt)
       .mockReturnValueOnce('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF')
       .mockReturnValueOnce('');
-    vi.mocked(api.refundBounty).mockResolvedValue(undefined);
+    vi.mocked(api.refundBounty).mockResolvedValue({ ...baseBounty, status: 'refunded' });
 
     render(<App />);
     await waitFor(() => expect(screen.getByText('Test bounty')).toBeInTheDocument());

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -36,6 +36,7 @@ export interface Bounty {
   tokenSymbol: string;
   amount: number;
   labels: GithubLabel[];
+  tags?: string[];
 
   status: BountyStatus;
   createdAt: number;

--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -1,5 +1,101 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { xlmToUsd, resetXlmToUsdCache } from "./utils";
+import { FilterState } from "./constants";
+import { Bounty } from "./types";
+import { debounce, filterBounties, xlmToUsd, resetXlmToUsdCache } from "./utils";
+
+const defaultFilters = (searchQuery = ""): FilterState => ({
+  searchQuery,
+  statusFilter: "all",
+  minReward: "",
+  maxReward: "",
+  repoFilter: "",
+  sortOption: "newest",
+  sortDirection: "desc",
+});
+
+const bountyFixture = (overrides: Partial<Bounty>): Bounty => ({
+  id: "bounty-1",
+  repo: "stellar/bounty-board",
+  issueNumber: 291,
+  title: "Add search input",
+  summary: "Make bounties easier to discover from the board.",
+  maintainer: "maintainer",
+  tokenSymbol: "XLM",
+  amount: 100,
+  labels: [{ name: "frontend", color: "0f766e" }],
+  status: "open",
+  createdAt: 1,
+  deadlineAt: 2,
+  version: 1,
+  events: [],
+  ...overrides,
+});
+
+describe("filterBounties", () => {
+  const bounties = [
+    bountyFixture({
+      id: "title-match",
+      title: "Add advanced search input",
+      repo: "stellar/bounty-board",
+      summary: "Filter the issue list.",
+    }),
+    bountyFixture({
+      id: "repo-match",
+      title: "Improve cards",
+      repo: "ritik4ever/stellar-bounty-board",
+      summary: "Polish the list layout.",
+    }),
+    bountyFixture({
+      id: "summary-match",
+      title: "Tidy empty state",
+      repo: "stellar/ui",
+      summary: "Show relevant rewards when contributors search.",
+    }),
+  ];
+
+  it("matches title, repo, and summary case-insensitively", () => {
+    expect(filterBounties(bounties, defaultFilters("ADVANCED")).map((bounty) => bounty.id)).toEqual([
+      "title-match",
+    ]);
+    expect(filterBounties(bounties, defaultFilters("RITIK4EVER")).map((bounty) => bounty.id)).toEqual([
+      "repo-match",
+    ]);
+    expect(filterBounties(bounties, defaultFilters("contributors search")).map((bounty) => bounty.id)).toEqual([
+      "summary-match",
+    ]);
+  });
+
+  it("returns every bounty when the search query is empty", () => {
+    expect(filterBounties(bounties, defaultFilters("   "))).toHaveLength(3);
+  });
+
+  it("returns an empty list when no bounty matches the search query", () => {
+    expect(filterBounties(bounties, defaultFilters("not-here"))).toEqual([]);
+  });
+});
+
+describe("debounce", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits 300ms and only invokes the latest search callback", () => {
+    vi.useFakeTimers();
+    const callback = vi.fn();
+    const debouncedCallback = debounce(callback, 300);
+
+    debouncedCallback("s");
+    debouncedCallback("se");
+    debouncedCallback("sea");
+
+    vi.advanceTimersByTime(299);
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith("sea");
+  });
+});
 
 describe("xlmToUsd", () => {
   const fetchMock = vi.fn();

--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -51,9 +51,23 @@ describe("filterBounties", () => {
       repo: "stellar/ui",
       summary: "Show relevant rewards when contributors search.",
     }),
+    bountyFixture({
+      id: "label-match",
+      title: "Improve filters",
+      repo: "stellar/ui",
+      summary: "Keep the filter controls predictable.",
+      labels: [{ name: "accessibility", color: "2563eb" }],
+    }),
+    bountyFixture({
+      id: "status-only",
+      title: "Improve payout flow",
+      repo: "stellar/payments",
+      summary: "Make reward handling clearer.",
+      status: "reserved",
+    }),
   ];
 
-  it("matches title, repo, and summary case-insensitively", () => {
+  it("matches title, repo, summary, and labels case-insensitively", () => {
     expect(filterBounties(bounties, defaultFilters("ADVANCED")).map((bounty) => bounty.id)).toEqual([
       "title-match",
     ]);
@@ -63,14 +77,21 @@ describe("filterBounties", () => {
     expect(filterBounties(bounties, defaultFilters("contributors search")).map((bounty) => bounty.id)).toEqual([
       "summary-match",
     ]);
+    expect(filterBounties(bounties, defaultFilters("ACCESSIBILITY")).map((bounty) => bounty.id)).toEqual([
+      "label-match",
+    ]);
   });
 
   it("returns every bounty when the search query is empty", () => {
-    expect(filterBounties(bounties, defaultFilters("   "))).toHaveLength(3);
+    expect(filterBounties(bounties, defaultFilters("   "))).toHaveLength(5);
   });
 
   it("returns an empty list when no bounty matches the search query", () => {
     expect(filterBounties(bounties, defaultFilters("not-here"))).toEqual([]);
+  });
+
+  it("keeps status matching scoped to the status filter", () => {
+    expect(filterBounties(bounties, defaultFilters("reserved"))).toEqual([]);
   });
 });
 

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -55,10 +55,11 @@ export function filterBounties(bounties: Bounty[], filters: FilterState): Bounty
 
     // Search filter
     if (filters.searchQuery.trim() !== "") {
-      const searchLower = filters.searchQuery.toLowerCase();
+      const searchLower = filters.searchQuery.trim().toLowerCase();
       const matchesSearch =
         bounty.repo.toLowerCase().includes(searchLower) ||
         bounty.title.toLowerCase().includes(searchLower) ||
+        bounty.summary.toLowerCase().includes(searchLower) ||
         bounty.labels.some((label) => label.name.toLowerCase().includes(searchLower)) ||
         bounty.status.toLowerCase().includes(searchLower);
       

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -60,9 +60,8 @@ export function filterBounties(bounties: Bounty[], filters: FilterState): Bounty
         bounty.repo.toLowerCase().includes(searchLower) ||
         bounty.title.toLowerCase().includes(searchLower) ||
         bounty.summary.toLowerCase().includes(searchLower) ||
-        bounty.labels.some((label) => label.name.toLowerCase().includes(searchLower)) ||
-        bounty.status.toLowerCase().includes(searchLower);
-      
+        bounty.labels.some((label) => label.name.toLowerCase().includes(searchLower));
+
       if (!matchesSearch) {
         return false;
       }


### PR DESCRIPTION
Closes #291

## Summary
- Add case-insensitive bounty filtering by `summary` in the existing debounced search flow.
- Update the search UI copy and add Vitest coverage for filtered output, empty search results, and the 300ms debounce behavior.
- Restore missing frontend API exports and small type/test setup issues so the frontend type-check, tests, and build run cleanly.

## Verification
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `npm --prefix backend run build`

Note: `npm --prefix backend test` still fails in unrelated existing backend suites (`expiry`, `reservationExpirationJob`, `authMiddleware`, amount validation, and an empty `utils.test.ts`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounty submissions now require a GitHub pull request URL.
  * New frontend API helpers to list and fetch bounties.

* **Improvements**
  * Search now covers summary and updates placeholder wording.
  * Recommendation scoring and label/tag matching made more flexible.
  * Bounty type supports optional tags.

* **Tests**
  * Added and updated unit tests for recommendations, filtering, debounce, and toast behaviors; test setup mocks matchMedia.

* **Chores**
  * Added TypeScript types for Swagger UI to dev dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->