### PR TITLE
feat: add EmptyState component with contextual messages and Clear filters button (#306)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,6 +47,7 @@ import BountyDetailPage from "./BountyDetailPage";
 import UsdAmount from "./UsdAmount";
 
 import SkeletonBountyCard from "./SkeletonBountyCard";
+import EmptyState from "./EmptyState";
 
 const STELLAR_PUBLIC_KEY_HINT = "Expected Stellar public key (starts with G and is 56 characters).";
 const STELLAR_PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
@@ -1292,28 +1293,14 @@ function App() {
                   ))}
                 </div>
               ) : (
-                <div className="empty-state">
-                  <div className="empty-state__content">
-                    <h3>No bounties found</h3>
-                    <p>
-                      {debouncedSearchQuery && (
-                        <>No bounties match "<strong>{debouncedSearchQuery}</strong>"</>
-                      ) || statusFilter !== "all" || minReward || maxReward || repoFilter ? (
-                        <>No bounties match the current filters</>
-                      ) : (
-                        <>No bounties available yet</>
-                      )}
-                    </p>
-                    <div className="empty-state__suggestions">
-                      <p><strong>Suggestions:</strong></p>
-                      <ul>
-                        <li>Try adjusting your search terms or filters</li>
-                        <li>Check back later for new bounties</li>
-                        <li>Browse all repositories to see available opportunities</li>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
+                <EmptyState
+                  searchQuery={debouncedSearchQuery}
+                  statusFilter={statusFilter}
+                  minReward={minReward}
+                  maxReward={maxReward}
+                  repoFilter={repoFilter}
+                  onClearFilters={clearFilters}
+                />
               )}
             </section>
           </main>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -617,8 +617,12 @@ function App() {
     };
   }, [detailId]);
 
+  const effectiveRepoFilter = useMemo(
+    () => (repoRoute ? `${repoRoute.owner}/${repoRoute.name}` : repoFilter),
+    [repoRoute, repoFilter],
+  );
+
   const filteredBounties = useMemo(() => {
-    const effectiveRepoFilter = repoRoute ? `${repoRoute.owner}/${repoRoute.name}` : repoFilter;
     const filtered = filterBounties(bounties, {
       searchQuery: debouncedSearchQuery,
       statusFilter,
@@ -1298,7 +1302,7 @@ function App() {
                   statusFilter={statusFilter}
                   minReward={minReward}
                   maxReward={maxReward}
-                  repoFilter={repoFilter}
+                  repoFilter={effectiveRepoFilter}
                   onClearFilters={clearFilters}
                 />
               )}

--- a/frontend/src/EmptyState.test.tsx
+++ b/frontend/src/EmptyState.test.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import EmptyState from "./EmptyState";
+import type { EmptyStateProps } from "./EmptyState";
+
+function renderEmptyState(props: Partial<EmptyStateProps> = {}) {
+  return render(<EmptyState {...props} />);
+}
+
+describe("EmptyState", () => {
+  it("renders the default message when no filters are active", () => {
+    renderEmptyState();
+    expect(screen.getByText("No bounties found")).toBeInTheDocument();
+    expect(screen.getByText("No bounties available yet")).toBeInTheDocument();
+  });
+
+  it("shows a search-specific message when searchQuery is provided", () => {
+    renderEmptyState({ searchQuery: "react hooks" });
+    expect(screen.getByText(/No bounties match/i)).toBeInTheDocument();
+    expect(screen.getByText("react hooks")).toBeInTheDocument();
+  });
+
+  it("shows a status-specific message for a non-'all' status filter", () => {
+    renderEmptyState({ statusFilter: "open" });
+    expect(screen.getByText("No open bounties")).toBeInTheDocument();
+  });
+
+  it("omits the status message when statusFilter is 'all'", () => {
+    renderEmptyState({ statusFilter: "all" });
+    // 'all' is treated as no filter — should show the default
+    expect(screen.getByText("No bounties available yet")).toBeInTheDocument();
+  });
+
+  it("shows a repo-specific message when repoFilter is provided", () => {
+    renderEmptyState({ repoFilter: "ritik4ever/stellar-bounty-board" });
+    expect(
+      screen.getByText("No bounties in ritik4ever/stellar-bounty-board"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a reward-range message when minReward or maxReward is set", () => {
+    renderEmptyState({ minReward: "10", maxReward: "100" });
+    expect(
+      screen.getByText("No XLM bounties in this reward range"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the Clear filters button when filters are active and a callback is provided", async () => {
+    const onClear = vi.fn();
+    renderEmptyState({ searchQuery: "something", onClearFilters: onClear });
+
+    const button = screen.getByRole("button", { name: /clear filters/i });
+    expect(button).toBeInTheDocument();
+
+    await userEvent.click(button);
+    expect(onClear).toHaveBeenCalledOnce();
+  });
+
+  it("does not render the Clear filters button when no filters are active", () => {
+    renderEmptyState({ onClearFilters: vi.fn() });
+    expect(
+      screen.queryByRole("button", { name: /clear filters/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders for empty result arrays (no filters) gracefully", () => {
+    const { container } = renderEmptyState();
+    expect(container.querySelector(".empty-state")).toBeInTheDocument();
+    expect(
+      screen.getByText("Create the first bounty to get started"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/EmptyState.tsx
+++ b/frontend/src/EmptyState.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+
+export interface EmptyStateProps {
+  /** Current search query (debounced) */
+  searchQuery?: string;
+  /** Current status filter */
+  statusFilter?: string;
+  /** Minimum reward filter */
+  minReward?: string;
+  /** Maximum reward filter */
+  maxReward?: string;
+  /** Repository filter */
+  repoFilter?: string;
+  /** Callback to reset all active filters */
+  onClearFilters?: () => void;
+}
+
+/**
+ * Renders a contextual empty state when the filtered bounty list returns zero results.
+ *
+ * The message varies by active filter so users understand why the board is blank.
+ * When filters are active, a "Clear filters" button resets them to see all bounties.
+ */
+export default function EmptyState({
+  searchQuery,
+  statusFilter,
+  minReward,
+  maxReward,
+  repoFilter,
+  onClearFilters,
+}: EmptyStateProps) {
+  const hasFilters = Boolean(
+    searchQuery ||
+      (statusFilter && statusFilter !== "all") ||
+      minReward ||
+      maxReward ||
+      repoFilter,
+  );
+
+  const message = (() => {
+    if (searchQuery) {
+      return (
+        <>
+          No bounties match "<strong>{searchQuery}</strong>"
+        </>
+      );
+    }
+    if (statusFilter && statusFilter !== "all") {
+      return <>No {statusFilter} bounties</>;
+    }
+    if (minReward || maxReward) {
+      return <>No XLM bounties in this reward range</>;
+    }
+    if (repoFilter) {
+      return <>No bounties in {repoFilter}</>;
+    }
+    return <>No bounties available yet</>;
+  })();
+
+  return (
+    <div className="empty-state">
+      <div className="empty-state__content">
+        <h3>No bounties found</h3>
+        <p>{message}</p>
+        {hasFilters && onClearFilters && (
+          <button
+            type="button"
+            className="secondary-button"
+            onClick={onClearFilters}
+            style={{ marginTop: 16 }}
+          >
+            Clear filters
+          </button>
+        )}
+        <div className="empty-state__suggestions">
+          <p>
+            <strong>Suggestions:</strong>
+          </p>
+          <ul>
+            {hasFilters ? (
+              <>
+                <li>Try adjusting your search terms or filters</li>
+                <li>Check back later for new bounties</li>
+                <li>Browse all repositories to see available opportunities</li>
+              </>
+            ) : (
+              <>
+                <li>Check back later for new bounties</li>
+                <li>Create the first bounty to get started</li>
+              </>
+            )}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/EmptyState.tsx
+++ b/frontend/src/EmptyState.tsx
@@ -1,10 +1,11 @@
 import React from "react";
+import type { BountyStatus } from "./types";
 
 export interface EmptyStateProps {
   /** Current search query (debounced) */
   searchQuery?: string;
   /** Current status filter */
-  statusFilter?: string;
+  statusFilter?: "all" | BountyStatus;
   /** Minimum reward filter */
   minReward?: string;
   /** Maximum reward filter */
@@ -29,19 +30,22 @@ export default function EmptyState({
   repoFilter,
   onClearFilters,
 }: EmptyStateProps) {
+  const trimmedSearch = searchQuery?.trim();
+  const trimmedRepo = repoFilter?.trim();
+
   const hasFilters = Boolean(
-    searchQuery ||
+    trimmedSearch ||
       (statusFilter && statusFilter !== "all") ||
       minReward ||
       maxReward ||
-      repoFilter,
+      trimmedRepo,
   );
 
   const message = (() => {
-    if (searchQuery) {
+    if (trimmedSearch) {
       return (
         <>
-          No bounties match "<strong>{searchQuery}</strong>"
+          No bounties match "<strong>{trimmedSearch}</strong>"
         </>
       );
     }
@@ -51,8 +55,8 @@ export default function EmptyState({
     if (minReward || maxReward) {
       return <>No XLM bounties in this reward range</>;
     }
-    if (repoFilter) {
-      return <>No bounties in {repoFilter}</>;
+    if (trimmedRepo) {
+      return <>No bounties in {trimmedRepo}</>;
     }
     return <>No bounties available yet</>;
   })();


### PR DESCRIPTION
## Summary

Extracts the inline empty state JSX from `App.tsx` into a dedicated `EmptyState` component with:

- **Contextual messages** that vary by active filter:
  - Search query: 'No bounties match "<query>"'
  - Status filter: 'No open bounties' / 'No submitted bounties' / etc.
  - Reward range: 'No XLM bounties in this reward range'
  - Repo filter: 'No bounties in owner/repo'
  - No filters: 'No bounties available yet'
- **Clear filters button** rendered when any filters are active, resetting all filters
- **9 Vitest tests** covering all filter states, the clear action, and the no-filter default

## Test Plan

```bash
cd frontend && npm install && npx vitest run EmptyState.test.tsx
# 9 tests pass ✓
```

Also verified no regression in the full test suite (`npx vitest run`) — 17 tests pass, 2 pre-existing failures in unrelated files.

## Related Issue

Refs #306

## Bounty Note

Stellar Wave 75 points — `EmptyState` component for zero-result bounty list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized contextual empty-state UI for the bounty board with messages reflecting search, filters, and reward range.

* **Refactor**
  * App now uses the centralized empty state and computes the effective repository filter for accurate results.
  * Shows a “Clear filters” action when filters are active.

* **Tests**
  * Added thorough tests covering empty-state messages, clear-filters behavior, and conditional rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->