### PR TITLE
Add bounty list skeleton loading state

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Bounty } from "./types";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+  Toaster: () => null,
+}));
+
+vi.mock("./api", () => ({
+  createBounty: vi.fn(),
+  exportReleasedPayoutsCsv: vi.fn(),
+  getBounty: vi.fn(),
+  listBounties: vi.fn(),
+  listOpenIssues: vi.fn(),
+  refundBounty: vi.fn(),
+  releaseBounty: vi.fn(),
+  reserveBounty: vi.fn(),
+  submitBounty: vi.fn(),
+}));
+
+import * as api from "./api";
+import App from "./App";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+const bounty: Bounty = {
+  id: "BNTY-284",
+  repo: "ritik4ever/stellar-bounty-board",
+  issueNumber: 284,
+  title: "Skeleton replacement bounty",
+  summary: "Shows the real card after the initial fetch finishes.",
+  maintainer: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  tokenSymbol: "XLM",
+  amount: 75,
+  labels: [],
+  status: "open",
+  createdAt: 1_700_000_000,
+  deadlineAt: 9_999_999_999,
+  version: 1,
+  events: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.history.replaceState(null, "", "/");
+  vi.mocked(api.listOpenIssues).mockResolvedValue([]);
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+describe("App bounty list loading state", () => {
+  it("shows six skeleton cards while the initial bounty fetch is pending", async () => {
+    const bountiesRequest = deferred<Bounty[]>();
+    vi.mocked(api.listBounties).mockReturnValueOnce(bountiesRequest.promise);
+
+    render(<App />);
+
+    const skeletonList = screen.getByTestId("bounty-skeleton-list");
+    expect(skeletonList).toHaveAttribute("aria-busy", "true");
+    expect(within(skeletonList).getAllByTestId("skeleton-bounty-card")).toHaveLength(6);
+
+    bountiesRequest.resolve([bounty]);
+
+    await waitFor(() => expect(screen.getByText("Skeleton replacement bounty")).toBeInTheDocument());
+    expect(screen.queryByTestId("bounty-skeleton-list")).not.toBeInTheDocument();
+  });
+
+  it("shows a retry button when the initial bounty fetch fails", async () => {
+    vi.mocked(api.listBounties)
+      .mockRejectedValueOnce(new Error("Loading failed"))
+      .mockResolvedValueOnce([bounty]);
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("Loading failed"));
+
+    await userEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    await waitFor(() => expect(screen.getByText("Skeleton replacement bounty")).toBeInTheDocument());
+    expect(api.listBounties).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -346,7 +346,7 @@ function App() {
   }, [detailId]);
 
 
-  async function refresh(signal?: AbortSignal): Promise<void> {
+  const refresh = useCallback(async (signal?: AbortSignal): Promise<void> => {
     const [bountyData, issueData] = await Promise.all([
       listBounties(signal),
       listOpenIssues(signal),
@@ -361,26 +361,29 @@ function App() {
         setDetailBounty(refreshedDetailBounty);
       }
     }
-  }
+  }, []);
+
+  const loadInitialData = useCallback(async (signal?: AbortSignal): Promise<void> => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await refresh(signal);
+    } catch (err) {
+      if (signal?.aborted) return;
+      setError(err instanceof Error ? err.message : "Failed to load project data.");
+    } finally {
+      if (!signal?.aborted) {
+        setLoading(false);
+      }
+    }
+  }, [refresh]);
 
   useEffect(() => {
     const controller = new AbortController();
     const { signal } = controller;
 
-    async function bootstrap() {
-      try {
-        await refresh(signal);
-      } catch (err) {
-        if (signal.aborted) return; // component unmounted — ignore
-        setError(err instanceof Error ? err.message : "Failed to load project data.");
-      } finally {
-        if (!signal.aborted) {
-          setLoading(false);
-        }
-      }
-    }
-
-    void bootstrap();
+    void loadInitialData(signal);
 
     const timer = window.setInterval(() => {
       const pollController = new AbortController();
@@ -395,7 +398,7 @@ function App() {
       controller.abort();
       window.clearInterval(timer);
     };
-  }, []);
+  }, [loadInitialData, refresh]);
 
   useEffect(() => {
     if (pathname.startsWith("/bounties/") || pathname.startsWith("/repo/")) return;
@@ -861,7 +864,14 @@ function App() {
             </article>
           </section>
 
-          {error && <div className="error-banner">{error}</div>}
+          {error && (
+            <div className="error-banner" role="alert">
+              <span>{error}</span>
+              <button className="ghost-button" type="button" onClick={() => void loadInitialData()}>
+                Try again
+              </button>
+            </div>
+          )}
 
           {profileContributor && (
             <RecommendedBounties
@@ -1151,8 +1161,8 @@ function App() {
               </section>
 
               {loading ? (
-                <div className="board-list">
-                  {Array.from({ length: 3 }).map((_, i) => (
+                <div className="board-list" aria-busy="true" data-testid="bounty-skeleton-list">
+                  {Array.from({ length: 6 }).map((_, i) => (
                     <SkeletonBountyCard key={i} />
                   ))}
                 </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -308,6 +308,7 @@ function App() {
   const [submitting, setSubmitting] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [initialLoadError, setInitialLoadError] = useState<string | null>(null);
 
   const [searchQuery, setSearchQuery] = useState(initialFilters.searchQuery);
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(initialFilters.searchQuery);
@@ -366,12 +367,15 @@ function App() {
   const loadInitialData = useCallback(async (signal?: AbortSignal): Promise<void> => {
     setLoading(true);
     setError(null);
+    setInitialLoadError(null);
 
     try {
       await refresh(signal);
     } catch (err) {
       if (signal?.aborted) return;
-      setError(err instanceof Error ? err.message : "Failed to load project data.");
+      const message = err instanceof Error ? err.message : "Failed to load project data.";
+      setError(message);
+      setInitialLoadError(message);
     } finally {
       if (!signal?.aborted) {
         setLoading(false);
@@ -864,12 +868,18 @@ function App() {
             </article>
           </section>
 
-          {error && (
+          {initialLoadError && (
             <div className="error-banner" role="alert">
-              <span>{error}</span>
+              <span>{initialLoadError}</span>
               <button className="ghost-button" type="button" onClick={() => void loadInitialData()}>
                 Try again
               </button>
+            </div>
+          )}
+
+          {error && !initialLoadError && (
+            <div className="error-banner" role="alert">
+              <span>{error}</span>
             </div>
           )}
 

--- a/frontend/src/RecommendedBounties.tsx
+++ b/frontend/src/RecommendedBounties.tsx
@@ -135,9 +135,9 @@ export default function RecommendedBounties({ recommendations, loading }: Recomm
       ? recommendations
       : recommendations.filter(({ bounty }) => {
           const haystack = [
-            ...bounty.labels,
+            ...bounty.labels.map((label) => label.name),
             ...(bounty.tags ?? []),
-          ].map((t) => t.toLowerCase());
+          ].map((tag) => tag.toLowerCase());
           return haystack.some((t) => t.includes(activeTag.toLowerCase()));
         });
 

--- a/frontend/src/SkeletonBountyCard.tsx
+++ b/frontend/src/SkeletonBountyCard.tsx
@@ -7,7 +7,7 @@ import { memo } from "react";
  */
 function SkeletonBountyCardBase() {
   return (
-    <article className="bounty-card skeleton-card" aria-hidden="true">
+    <article className="bounty-card skeleton-card" aria-hidden="true" data-testid="skeleton-bounty-card">
       <div className="bounty-card__top">
         <div>
           <span className="skeleton-block skeleton-pill" />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -148,10 +148,19 @@ async function requestBlob(path: string, options: RequestOptions = {}): Promise<
   throw formatRetryError(retryLabel, retryAttempts, message);
 }
 
-
+export async function listBounties(signal?: AbortSignal): Promise<Bounty[]> {
   const body = await requestJson<{ data: Bounty[] }>("/bounties", {
     retry: true,
     retryLabel: "Loading bounties",
+    signal,
+  });
+  return body.data;
+}
+
+export async function getBounty(id: string, signal?: AbortSignal): Promise<Bounty> {
+  const body = await requestJson<{ data: Bounty }>(`/bounties/${encodeURIComponent(id)}`, {
+    retry: true,
+    retryLabel: "Loading bounty",
     signal,
   });
   return body.data;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -282,6 +282,7 @@ textarea {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 12px;
   margin-bottom: 20px;
   padding: 14px 18px;
@@ -289,6 +290,10 @@ textarea {
   background: #fff0eb;
   border: 1px solid rgba(184, 85, 75, 0.22);
   color: #7a2e25;
+}
+
+.error-banner .ghost-button {
+  flex: 0 0 auto;
 }
 
 .content-grid {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -279,6 +279,10 @@ textarea {
 }
 
 .error-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
   margin-bottom: 20px;
   padding: 14px 18px;
   border-radius: 18px;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { Toaster } from 'sonner'
-import App from './App.tsx'
+import App from './App'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/frontend/src/recommendations.test.ts
+++ b/frontend/src/recommendations.test.ts
@@ -24,4 +24,16 @@ describe("scoreMatch", () => {
   it("scores matching skills from bounty labels and text", () => {
     expect(scoreMatch(bounty, ["frontend", "react"])).toBe(1);
   });
+
+  it("scores matching skills from bounty tags", () => {
+    const taggedBounty: Bounty = {
+      ...bounty,
+      labels: [],
+      title: "General improvements",
+      summary: "No explicit skill words here.",
+      tags: ["TypeScript"],
+    };
+
+    expect(scoreMatch(taggedBounty, ["typescript"])).toBe(1);
+  });
 });

--- a/frontend/src/recommendations.test.ts
+++ b/frontend/src/recommendations.test.ts
@@ -1,1 +1,27 @@
+import { describe, expect, it } from "vitest";
 
+import { scoreMatch } from "./recommendations";
+import type { Bounty } from "./types";
+
+const bounty: Bounty = {
+  id: "BNTY-SKILL",
+  repo: "ritik4ever/stellar-bounty-board",
+  issueNumber: 12,
+  title: "React frontend improvements",
+  summary: "Make the dashboard easier to scan.",
+  maintainer: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  tokenSymbol: "XLM",
+  amount: 50,
+  labels: [{ name: "frontend", color: "1d76db" }],
+  status: "open",
+  createdAt: 1_700_000_000,
+  deadlineAt: 9_999_999_999,
+  version: 1,
+  events: [],
+};
+
+describe("scoreMatch", () => {
+  it("scores matching skills from bounty labels and text", () => {
+    expect(scoreMatch(bounty, ["frontend", "react"])).toBe(1);
+  });
+});

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -34,9 +34,8 @@ export function scoreMatch(bounty: Bounty, skills: string[]): number {
   const bountyTokens: string[] = bounty.labels.map((l) => l.name.toLowerCase());
 
   // Also include bounty.tags if present (used in RecommendedBounties.tsx)
-  if (Array.isArray((bounty as Record<string, unknown>).tags)) {
-    const tags = (bounty as Record<string, unknown>).tags as string[];
-    bountyTokens.push(...tags.map((t: string) => t.toLowerCase()));
+  if (Array.isArray(bounty.tags)) {
+    bountyTokens.push(...bounty.tags.map((t) => t.toLowerCase()));
   }
 
   // Include title and summary for broader matching
@@ -107,37 +106,6 @@ const STATUS_WEIGHTS: Record<BountyStatus, number> = {
   "refunded": 0,
   "expired": 0,
 };
-
-function normalizeTerms(values: string[]): string[] {
-  return [...new Set(values.map((value) => value.trim().toLowerCase()).filter(Boolean))];
-}
-
-function getBountySkillTerms(bounty: Bounty): string[] {
-  return normalizeTerms(bounty.labels.map((label) => label.name));
-}
-
-export function scoreMatch(bounty: Bounty, skills: string[]): number {
-  const bountySkills = getBountySkillTerms(bounty);
-  const contributorSkills = normalizeTerms(skills);
-
-  if (bountySkills.length === 0 || contributorSkills.length === 0) {
-    return 0;
-  }
-
-  const bountySkillSet = new Set(bountySkills);
-  const contributorSkillSet = new Set(contributorSkills);
-  let overlap = 0;
-
-  for (const skill of bountySkillSet) {
-    if (contributorSkillSet.has(skill)) {
-      overlap += 1;
-    }
-  }
-
-  const unionSize = new Set([...bountySkillSet, ...contributorSkillSet]).size;
-
-  return unionSize > 0 ? Math.round((overlap / unionSize) * 100) / 100 : 0;
-}
 
 export function calculateRecommendationScore(
   bounty: Bounty,

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,1 +1,17 @@
-﻿import '@testing-library/jest-dom';
+import "@testing-library/jest-dom";
+
+if (!window.matchMedia) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+}

--- a/frontend/src/toast.test.tsx
+++ b/frontend/src/toast.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { toast } from 'sonner';
+import type { Bounty } from './types';
 
 vi.mock('sonner', () => ({
   toast: {
@@ -26,14 +27,13 @@ vi.mock('./api', () => ({
 import * as api from './api';
 import App from './App';
 
-const baseBounty = {
+const baseBounty: Omit<Bounty, 'status'> = {
   id: 'BNTY-1',
   repo: 'ritik4ever/stellar-bounty-board',
   issueNumber: 1,
   title: 'Test bounty',
   summary: 'Summary',
   maintainer: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-  contributor: null,
   tokenSymbol: 'XLM',
   amount: 100,
   labels: [],
@@ -42,6 +42,14 @@ const baseBounty = {
   version: 1,
   events: [],
 };
+
+function bountyWith(overrides: Partial<Bounty> = {}): Bounty {
+  return {
+    ...baseBounty,
+    status: 'open',
+    ...overrides,
+  };
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -53,9 +61,11 @@ beforeEach(() => {
 describe('Toast notifications for async bounty actions', () => {
 
   it('shows success toast when bounty is reserved', async () => {
-    vi.mocked(api.listBounties).mockResolvedValue([{ ...baseBounty, status: 'open' }]);
+    vi.mocked(api.listBounties).mockResolvedValue([bountyWith()]);
     vi.mocked(window.prompt).mockReturnValue('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF');
-    vi.mocked(api.reserveBounty).mockResolvedValue(undefined);
+    vi.mocked(api.reserveBounty).mockResolvedValue(
+      bountyWith({ status: 'reserved', contributor: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF' }),
+    );
 
     render(<App />);
     await waitFor(() => expect(screen.getByText('Test bounty')).toBeInTheDocument());
@@ -67,7 +77,7 @@ describe('Toast notifications for async bounty actions', () => {
   });
 
   it('shows error toast when reserve fails', async () => {
-    vi.mocked(api.listBounties).mockResolvedValue([{ ...baseBounty, status: 'open' }]);
+    vi.mocked(api.listBounties).mockResolvedValue([bountyWith()]);
     vi.mocked(window.prompt).mockReturnValue('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF');
     vi.mocked(api.reserveBounty).mockRejectedValue(new Error('Network error'));
 
@@ -81,7 +91,7 @@ describe('Toast notifications for async bounty actions', () => {
   });
 
   it('shows error toast with Freighter rejection message', async () => {
-    vi.mocked(api.listBounties).mockResolvedValue([{ ...baseBounty, status: 'open' }]);
+    vi.mocked(api.listBounties).mockResolvedValue([bountyWith()]);
     vi.mocked(window.prompt).mockReturnValue('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF');
     vi.mocked(api.reserveBounty).mockRejectedValue(new Error('User declined access'));
 
@@ -95,15 +105,16 @@ describe('Toast notifications for async bounty actions', () => {
   });
 
   it('shows success toast when bounty is released', async () => {
-    vi.mocked(api.listBounties).mockResolvedValue([{
-      ...baseBounty,
+    vi.mocked(api.listBounties).mockResolvedValue([bountyWith({
       status: 'submitted',
       contributor: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGKCEL9LGAQLHFLQ2GN7SY',
-    }]);
+    })]);
     vi.mocked(window.prompt)
       .mockReturnValueOnce('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF')
       .mockReturnValueOnce('');
-    vi.mocked(api.releaseBounty).mockResolvedValue(undefined);
+    vi.mocked(api.releaseBounty).mockResolvedValue(
+      bountyWith({ status: 'released', contributor: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGKCEL9LGAQLHFLQ2GN7SY' }),
+    );
 
     render(<App />);
     await waitFor(() => expect(screen.getByText('Test bounty')).toBeInTheDocument());
@@ -115,11 +126,10 @@ describe('Toast notifications for async bounty actions', () => {
   });
 
   it('shows error toast when release fails', async () => {
-    vi.mocked(api.listBounties).mockResolvedValue([{
-      ...baseBounty,
+    vi.mocked(api.listBounties).mockResolvedValue([bountyWith({
       status: 'submitted',
       contributor: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGKCEL9LGAQLHFLQ2GN7SY',
-    }]);
+    })]);
     vi.mocked(window.prompt)
       .mockReturnValueOnce('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF')
       .mockReturnValueOnce('');
@@ -135,15 +145,16 @@ describe('Toast notifications for async bounty actions', () => {
   });
 
   it('shows success toast when bounty is refunded', async () => {
-    vi.mocked(api.listBounties).mockResolvedValue([{
-      ...baseBounty,
+    vi.mocked(api.listBounties).mockResolvedValue([bountyWith({
       status: 'submitted',
       contributor: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGKCEL9LGAQLHFLQ2GN7SY',
-    }]);
+    })]);
     vi.mocked(window.prompt)
       .mockReturnValueOnce('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF')
       .mockReturnValueOnce('');
-    vi.mocked(api.refundBounty).mockResolvedValue(undefined);
+    vi.mocked(api.refundBounty).mockResolvedValue(
+      bountyWith({ status: 'refunded', contributor: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGKCEL9LGAQLHFLQ2GN7SY' }),
+    );
 
     render(<App />);
     await waitFor(() => expect(screen.getByText('Test bounty')).toBeInTheDocument());
@@ -155,11 +166,10 @@ describe('Toast notifications for async bounty actions', () => {
   });
 
   it('shows error toast when refund fails', async () => {
-    vi.mocked(api.listBounties).mockResolvedValue([{
-      ...baseBounty,
+    vi.mocked(api.listBounties).mockResolvedValue([bountyWith({
       status: 'submitted',
       contributor: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGKCEL9LGAQLHFLQ2GN7SY',
-    }]);
+    })]);
     vi.mocked(window.prompt)
       .mockReturnValueOnce('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF')
       .mockReturnValueOnce('');

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -36,6 +36,7 @@ export interface Bounty {
   tokenSymbol: string;
   amount: number;
   labels: GithubLabel[];
+  tags?: string[];
 
   status: BountyStatus;
   createdAt: number;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,15 +1,10 @@
 /// <reference types="vitest" />
 
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
-  test: {
-    environment: "jsdom",
-    setupFiles: "./src/setupTests.ts",
-    globals: true,
-  },
   server: {
     port: 3000,
     proxy: {


### PR DESCRIPTION
## Summary
- show 6 `SkeletonBountyCard` placeholders while the initial bounty fetch is pending
- add `aria-busy=true` to the skeleton list and a retry button for initial load failures
- restore frontend test/build health by fixing existing API/config/type/test blockers uncovered during validation

## Testing
- `node ./node_modules/vitest/vitest.mjs run`
- `npm run build`

Fixes #284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dismissible error alerts with "Try again" button when bounty data fails to load
  * Enhanced loading state with skeleton card visualization during initial load

* **Improvements**
  * Improved error handling and recovery workflow for data loading
  * Refined tag and label filtering for bounty recommendations

* **Testing**
  * Comprehensive unit tests added for core application functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->