### PR TITLE
Add gzip compression for large API responses

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.3.4",
         "@stellar/stellar-sdk": "^15.0.1",
+        "compression": "^1.8.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
@@ -22,6 +23,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@types/compression": "^1.8.1",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/node": "^22.10.2",
@@ -984,6 +986,17 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -1571,6 +1584,45 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -2560,6 +2612,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^7.3.4",
     "@stellar/stellar-sdk": "^15.0.1",
+    "compression": "^1.8.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
@@ -26,6 +27,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/compression": "^1.8.1",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/node": "^22.10.2",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,4 +1,5 @@
 import cors from "cors";
+import compression from "compression";
 import express, { Request, Response, NextFunction } from "express";
 import { randomUUID } from "node:crypto";
 import swaggerUi from "swagger-ui-express";
@@ -74,6 +75,7 @@ function requestContextMiddleware(req: Request, res: Response, next: NextFunctio
 
 export const app = express();
 
+app.use(compression({ threshold: 1024 }));
 app.use(cors(buildCorsOptions()));
 
 // Parse JSON bodies; capture raw body for webhook signature verification

--- a/backend/test/compression.test.ts
+++ b/backend/test/compression.test.ts
@@ -1,0 +1,98 @@
+import http from "node:http";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { validCreateBody } from "./fixtures";
+
+let storeFile: string;
+
+beforeEach(() => {
+  storeFile = path.join(os.tmpdir(), `bounty-compression-${randomUUID()}.json`);
+  fs.writeFileSync(storeFile, "[]", "utf8");
+  process.env.BOUNTY_STORE_PATH = storeFile;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete process.env.BOUNTY_STORE_PATH;
+  for (const file of [storeFile, storeFile.replace(/\.json$/i, ".audit.json")]) {
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+});
+
+async function getApp() {
+  const { app } = await import("../src/app");
+  return app;
+}
+
+function listen(app: http.RequestListener): Promise<http.Server> {
+  return new Promise((resolve) => {
+    const server = http.createServer(app);
+    server.listen(0, () => resolve(server));
+  });
+}
+
+function close(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function gzipRequest(port: number): Promise<http.IncomingMessage> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        port,
+        path: "/api/bounties",
+        headers: {
+          "Accept-Encoding": "gzip",
+        },
+      },
+      (res) => {
+        res.resume();
+        res.on("end", () => resolve(res));
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("response compression", () => {
+  it("gzip-compresses API responses larger than 1KB", async () => {
+    const app = await getApp();
+
+    for (let i = 0; i < 20; i += 1) {
+      await request(app)
+        .post("/api/bounties")
+        .send({
+          ...validCreateBody,
+          issueNumber: 10_000 + i,
+        })
+        .expect(201);
+    }
+
+    const uncompressed = await request(app).get("/api/bounties").expect(200);
+    expect(Buffer.byteLength(uncompressed.text)).toBeGreaterThan(1024);
+
+    const server = await listen(app);
+    try {
+      const address = server.address();
+      if (typeof address !== "object" || address === null) {
+        throw new Error("Expected server to listen on a TCP port");
+      }
+
+      const res = await gzipRequest(address.port);
+      expect(res.headers["content-encoding"]).toBe("gzip");
+    } finally {
+      await close(server);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add Express `compression` middleware near the top of the backend stack with a 1KB threshold
- add the runtime dependency plus TypeScript types
- add an HTTP regression test proving large `/api/bounties` responses return `Content-Encoding: gzip`

## Validation
- `node node_modules/vitest/vitest.mjs run test/compression.test.ts`
- raw HTTP smoke: `Accept-Encoding: gzip` returned `Content-Encoding: gzip`
- bytes transferred: identity 21,241 bytes -> gzip 738 bytes, 96.5% smaller
- `git diff --check`

Closes #356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP response compression now enabled to reduce bandwidth usage and improve load times for API responses.

* **Tests**
  * Added integration tests to verify compression functionality for responses exceeding the size threshold.

* **Chores**
  * Updated dependencies to support compression middleware functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->