### PR TITLE
feat: secret-key log redaction, per-route rate limits, Redis cache, token filter (#381, #349, #361, #293)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,25 @@ CORS_ORIGINS=http://localhost:5173
 # [OPTIONAL] Logging level (debug, info, warn, error). Default: info
 LOG_LEVEL=info
 
+# [OPTIONAL] Redis connection string. When set, the bounty list is cached in
+# Redis (5s TTL) so cache is shared across replicas; falls back to an in-memory
+# cache when unset. Example: redis://localhost:6379
+REDIS_URL=
+
+# ------------------------------------------------------------------------------
+# RATE LIMITING (#349)
+# ------------------------------------------------------------------------------
+
+# [OPTIONAL] Sliding window in milliseconds for all rate limiters. Default: 60000
+RATE_LIMIT_WINDOW_MS=60000
+
+# [OPTIONAL] Max GET (read) requests per window per IP. Default: 120
+RATE_LIMIT_READ_MAX=120
+
+# [OPTIONAL] Max mutation requests (reserve/submit/release/refund/create) per
+# window per IP. Default: 10
+RATE_LIMIT_MUTATION_MAX=10
+
 
 # ------------------------------------------------------------------------------
 # RESERVATION EXPIRATION JOB

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 .env
 *.log
+.DS_Store
 backend/data/*.local.json
 contracts/target/
 contracts/.stellar/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -81,6 +81,29 @@ under a specific name, handle, or organisation, please include that preference i
 
 ---
 
+## Logging best practices
+
+The backend logger (`backend/src/logger.ts`, pino) redacts secrets two ways so
+Stellar private keys and credentials never reach log output (#381):
+
+- **Path redaction** masks named fields at any depth: `password`, `secret`,
+  `token`, `apiKey`/`api_key`, `Authorization`, request `authorization` /
+  `cookie` headers, and the Stellar key fields `secretKey`, `privateKey`,
+  `seed`.
+- **Value redaction** scrubs any string matching a Stellar secret seed
+  (`^S[0-9A-Z]{55}$`) wherever it appears — including free-form error messages
+  and nested objects — via a `logMethod` hook, replacing it with
+  `[redacted-secret-key]`.
+
+When adding logging:
+
+- Never log a raw signed transaction, secret seed, or keypair. Log the public
+  key (`G…`) or an opaque identifier instead.
+- Prefer structured fields (`logger.info({ field }, "msg")`) over string
+  interpolation so path redaction can apply.
+- If you introduce a new field name that may carry a secret, add it to the
+  `redact.paths` list in `backend/src/logger.ts`.
+
 ## Automated Security Analysis
 
 This repository runs [GitHub CodeQL](https://codeql.github.com/) on the `javascript` language

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
         "express-rate-limit": "^8.3.1",
+        "ioredis": "^5.4.1",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
         "stellar-bounty-board": "file:..",
@@ -48,7 +49,8 @@
         "@types/express-rate-limit": "^5.1.3",
         "@types/swagger-ui-express": "^4.1.8",
         "@types/yaml": "^1.9.6",
-        "husky": "^9.0.0"
+        "husky": "^9.0.0",
+        "prettier": "^3.8.3"
       }
     },
     "node_modules/@asteasolutions/zod-to-openapi": {
@@ -504,6 +506,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
@@ -1536,6 +1544,15 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -1685,6 +1702,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -1910,6 +1936,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -2314,6 +2341,51 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.0.tgz",
+      "integrity": "sha512-EZBErytyVovD8f6pDfG3Kb37N6Y3lmDA9NNj+4+IP13CzzHGeX+OyeRM2Um13khRzoBSzzL+5lVnCX8V2RLeMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/ip-address": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
@@ -2627,6 +2699,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2851,6 +2924,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/require-addon": {
@@ -3184,6 +3278,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -3488,6 +3588,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3595,6 +3696,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3874,6 +3976,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
     "express-rate-limit": "^8.3.1",
+    "ioredis": "^5.4.1",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "stellar-bounty-board": "file:..",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,6 +9,7 @@ import {
   createBounty,
   listBountyAuditLogs,
   listBounties,
+  listBountiesCached,
   refundBounty,
   releaseBounty,
   reserveBounty,
@@ -28,7 +29,7 @@ import {
   zodErrorMessage,
 } from "./validation/schemas";
 import { logStructured } from "./logger";
-import { limiter } from "./utils";
+import { readLimiter, mutationLimiter } from "./utils";
 import {
   captureRawBody,
   createGitHubWebhookSignatureMiddleware,
@@ -83,6 +84,9 @@ app.use(
   }),
 );
 app.use(requestContextMiddleware);
+
+// Global read limit (GET only); mutation routes carry a stricter limit (#349).
+app.use(readLimiter);
 
 const swaggerDoc = generateOpenApiDocument();
 app.use("/api/docs", swaggerUi.serve, swaggerUi.setup(swaggerDoc));
@@ -154,9 +158,9 @@ app.get("/worker/health", (_req: Request, res: Response) => {
   });
 });
 
-app.get("/api/bounties", (req: Request, res: Response) => {
+app.get("/api/bounties", async (req: Request, res: Response) => {
   const q = typeof req.query.q === "string" ? req.query.q : undefined;
-  res.json({ data: listBounties({ q }) });
+  res.json({ data: await listBountiesCached({ q }) });
 });
 
 app.get("/api/leaderboard", (_req: Request, res: Response) => {
@@ -231,7 +235,7 @@ app.get("/api/bounties/released/export.csv", (req: Request, res: Response) => {
   }
 });
 
-app.post("/api/bounties", limiter, async (req: Request, res: Response) => {
+app.post("/api/bounties", mutationLimiter, async (req: Request, res: Response) => {
   const parsed = createBountySchema.safeParse(req.body);
   if (!parsed.success) {
     jsonError(res, req, 400, zodErrorMessage(parsed.error));
@@ -246,7 +250,7 @@ app.post("/api/bounties", limiter, async (req: Request, res: Response) => {
   }
 });
 
-app.post("/api/bounties/:id/reserve", limiter, async (req: Request, res: Response) => {
+app.post("/api/bounties/:id/reserve", mutationLimiter, async (req: Request, res: Response) => {
   const parsedBody = reserveBountySchema.safeParse(req.body);
   if (!parsedBody.success) {
     jsonError(res, req, 400, zodErrorMessage(parsedBody.error));
@@ -261,7 +265,7 @@ app.post("/api/bounties/:id/reserve", limiter, async (req: Request, res: Respons
   }
 });
 
-app.post("/api/bounties/:id/submit", limiter, async (req: Request, res: Response) => {
+app.post("/api/bounties/:id/submit", mutationLimiter, async (req: Request, res: Response) => {
   const parsedBody = submitBountySchema.safeParse(req.body);
   if (!parsedBody.success) {
     jsonError(res, req, 400, zodErrorMessage(parsedBody.error));
@@ -281,7 +285,7 @@ app.post("/api/bounties/:id/submit", limiter, async (req: Request, res: Response
   }
 });
 
-app.post("/api/bounties/:id/release", limiter, async (req: Request, res: Response) => {
+app.post("/api/bounties/:id/release", mutationLimiter, async (req: Request, res: Response) => {
   const parsedBody = maintainerActionSchema.safeParse(req.body);
   if (!parsedBody.success) {
     jsonError(res, req, 400, zodErrorMessage(parsedBody.error));
@@ -300,7 +304,7 @@ app.post("/api/bounties/:id/release", limiter, async (req: Request, res: Respons
   }
 });
 
-app.post("/api/bounties/:id/refund", limiter, async (req: Request, res: Response) => {
+app.post("/api/bounties/:id/refund", mutationLimiter, async (req: Request, res: Response) => {
   const parsedBody = maintainerActionSchema.safeParse(req.body);
   if (!parsedBody.success) {
     jsonError(res, req, 400, zodErrorMessage(parsedBody.error));

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -3,31 +3,80 @@ import pino from "pino";
 const isDev = process.env.NODE_ENV !== "production";
 
 /**
+ * Matches a Stellar secret seed (StrKey): `S` followed by 55 base32 chars.
+ * Used to scrub secret keys that leak into free-form strings (error messages,
+ * request bodies) where path-based redaction cannot reach them (#381).
+ */
+const STELLAR_SECRET_KEY = /S[0-9A-Z]{55}/g;
+const SECRET_CENSOR = "[redacted-secret-key]";
+
+/** Recursively replace any Stellar secret key found in strings/objects/arrays. */
+export function redactStellarSecrets(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (typeof value === "string") {
+    return value.replace(STELLAR_SECRET_KEY, SECRET_CENSOR);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactStellarSecrets(item, seen));
+  }
+  if (value && typeof value === "object") {
+    if (seen.has(value as object)) {
+      return value;
+    }
+    seen.add(value as object);
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = redactStellarSecrets(val, seen);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
  * Pino logger instance.
  *
  * - Development: pretty-printed, human-readable output via pino-pretty.
  * - Production:  single-line JSON, ready for log aggregators.
  *
- * Sensitive fields (Authorization, cookie, password, secret, token, api_key)
- * are redacted at the serializer level so they never appear in any log output.
+ * Sensitive data is removed two ways:
+ *  - Path redaction (`redact`) masks named fields such as Authorization,
+ *    cookie, password, secret, token, api_key, and Stellar key fields
+ *    (`secretKey` / `privateKey` / `seed`).
+ *  - Value redaction (`hooks.logMethod`) scrubs any Stellar secret key
+ *    (`S...`, 56 chars) that slips into a message string or nested object,
+ *    even when the field name is not in the redact path list (#381).
  */
-export const logger = pino(
-  {
-    level: process.env.LOG_LEVEL ?? "info",
-    redact: {
-      paths: [
-        "req.headers.authorization",
-        "req.headers.cookie",
-        "*.password",
-        "*.secret",
-        "*.token",
-        "*.apiKey",
-        "*.api_key",
-        "*.Authorization",
-      ],
-      censor: "[redacted]",
+/** Base pino options (exported so tests can build an identical logger). */
+export const baseLoggerOptions: pino.LoggerOptions = {
+  level: process.env.LOG_LEVEL ?? "info",
+  redact: {
+    paths: [
+      "req.headers.authorization",
+      "req.headers.cookie",
+      "*.password",
+      "*.secret",
+      "*.token",
+      "*.apiKey",
+      "*.api_key",
+      "*.Authorization",
+      "*.secretKey",
+      "*.privateKey",
+      "*.seed",
+    ],
+    censor: "[redacted]",
+  },
+  hooks: {
+    logMethod(args, method) {
+      // Scrub Stellar secret keys from every argument (merging object + msg)
+      // before pino serializes them.
+      const scrubbed = args.map((arg) => redactStellarSecrets(arg)) as typeof args;
+      return method.apply(this, scrubbed);
     },
   },
+};
+
+export const logger = pino(
+  baseLoggerOptions,
   isDev
     ? pino.transport({
         target: "pino-pretty",

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { sendNotification, type NotificationRecipient } from "./notificationService";
 import { logStructured } from "../logger";
+import { getCache, type CacheAdapter } from "./cache";
 
 export type BountyStatus =
   | "open"
@@ -366,6 +367,47 @@ export function listBounties(options: ListBountiesOptions = {}): BountyRecord[] 
   return sorted;
 }
 
+// ── Cached list for the public board (#361) ──────────────────────────────────
+
+const BOUNTY_LIST_CACHE_KEY = "bounties:list";
+const BOUNTY_LIST_TTL_SECONDS = 5;
+
+/**
+ * Cache-backed variant of {@link listBounties} for the hot `/api/bounties` read
+ * path. The full normalized+sorted list is cached (5s TTL) so it is shared
+ * across replicas via Redis; the cheap `q` filter is applied to the cached list
+ * per request. Writes call {@link invalidateBountyCache}.
+ */
+export async function listBountiesCached(
+  options: ListBountiesOptions = {},
+  cache: CacheAdapter = getCache(),
+): Promise<BountyRecord[]> {
+  let records: BountyRecord[];
+  const cached = await cache.get(BOUNTY_LIST_CACHE_KEY);
+  if (cached) {
+    records = JSON.parse(cached) as BountyRecord[];
+  } else {
+    records = listBounties();
+    await cache.set(BOUNTY_LIST_CACHE_KEY, JSON.stringify(records), BOUNTY_LIST_TTL_SECONDS);
+  }
+
+  const q = options.q?.trim().toLowerCase();
+  if (!q) {
+    return records;
+  }
+  return records.filter(
+    (b) =>
+      b.title.toLowerCase().includes(q) ||
+      b.summary.toLowerCase().includes(q) ||
+      b.labels.some((l) => l.toLowerCase().includes(q)),
+  );
+}
+
+/** Drop the cached bounty list so the next read reflects a mutation (#361). */
+export async function invalidateBountyCache(cache: CacheAdapter = getCache()): Promise<void> {
+  await cache.del(BOUNTY_LIST_CACHE_KEY);
+}
+
 let globalLock: Promise<void> = Promise.resolve();
 
 async function withGlobalLock<T>(fn: () => T | Promise<T>): Promise<T> {
@@ -383,7 +425,7 @@ async function withGlobalLock<T>(fn: () => T | Promise<T>): Promise<T> {
 }
 
 export async function createBounty(input: CreateBountyInput): Promise<BountyRecord> {
-  return withGlobalLock(() => {
+  return withGlobalLock(async () => {
     const records = listBounties();
     const createdAt = nowInSeconds();
     const bounty: BountyRecord = {
@@ -405,6 +447,7 @@ export async function createBounty(input: CreateBountyInput): Promise<BountyReco
     };
 
     writeStore([bounty, ...records]);
+    await invalidateBountyCache();
 
     // Trigger notification on create
     const recipients: NotificationRecipient[] = [{ role: "maintainer", address: input.maintainer }];
@@ -426,7 +469,7 @@ export async function createBounty(input: CreateBountyInput): Promise<BountyReco
 }
 
 export async function reserveBounty(id: string, contributor: string, expectedVersion?: number): Promise<BountyRecord> {
-  return withGlobalLock(() => {
+  return withGlobalLock(async () => {
     const records = listBounties();
     const bounty = findBounty(records, id);
 
@@ -459,6 +502,7 @@ export async function reserveBounty(id: string, contributor: string, expectedVer
         actor: contributor,
       },
     ]);
+    await invalidateBountyCache();
     return persisted;
   });
 }
@@ -469,7 +513,7 @@ export async function submitBounty(
   submissionUrl: string,
   notes?: string,
 ): Promise<BountyRecord> {
-  return withGlobalLock(() => {
+  return withGlobalLock(async () => {
     const records = listBounties();
     const bounty = findBounty(records, id);
 
@@ -505,6 +549,7 @@ export async function submitBounty(
         },
       },
     ]);
+    await invalidateBountyCache();
     return persisted;
   });
 }
@@ -514,7 +559,7 @@ export async function releaseBounty(
   maintainer: string,
   transactionHash?: string,
 ): Promise<BountyRecord> {
-  return withGlobalLock(() => {
+  return withGlobalLock(async () => {
     const records = listBounties();
     const bounty = findBounty(records, id);
 
@@ -548,6 +593,7 @@ export async function releaseBounty(
         },
       },
     ]);
+    await invalidateBountyCache();
     return persisted;
   });
 }
@@ -557,7 +603,7 @@ export async function refundBounty(
   maintainer: string,
   transactionHash?: string,
 ): Promise<BountyRecord> {
-  return withGlobalLock(() => {
+  return withGlobalLock(async () => {
     const records = listBounties();
     const bounty = findBounty(records, id);
 
@@ -594,6 +640,7 @@ export async function refundBounty(
         },
       },
     ]);
+    await invalidateBountyCache();
     return persisted;
   });
 }

--- a/backend/src/services/cache.ts
+++ b/backend/src/services/cache.ts
@@ -1,0 +1,114 @@
+import Redis from "ioredis";
+import { logStructured } from "../logger";
+
+/**
+ * Pluggable cache for production multi-instance deployments (#361).
+ *
+ * A Redis-backed adapter activates when `REDIS_URL` is set so cache is shared
+ * across backend replicas and survives restarts; otherwise an in-memory adapter
+ * is used. All operations are async and never throw — a backend failure must
+ * not take down a request, so cache errors degrade to a miss.
+ */
+export interface CacheAdapter {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ttlSeconds: number): Promise<void>;
+  del(key: string): Promise<void>;
+}
+
+/** Process-local cache with per-key TTL. Lost on restart, not shared. */
+export class InMemoryCache implements CacheAdapter {
+  private readonly store = new Map<string, { value: string; expiresAt: number }>();
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async set(key: string, value: string, ttlSeconds: number): Promise<void> {
+    this.store.set(key, { value, expiresAt: Date.now() + ttlSeconds * 1000 });
+  }
+
+  async del(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  /** Test helper. */
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+/** Redis-backed adapter shared across replicas. Errors degrade to a miss. */
+export class RedisCache implements CacheAdapter {
+  constructor(private readonly client: Redis) {}
+
+  async get(key: string): Promise<string | null> {
+    try {
+      return await this.client.get(key);
+    } catch (error) {
+      logStructured("warn", "redis_get_failed", { key, error: String(error) });
+      return null;
+    }
+  }
+
+  async set(key: string, value: string, ttlSeconds: number): Promise<void> {
+    try {
+      await this.client.set(key, value, "EX", ttlSeconds);
+    } catch (error) {
+      logStructured("warn", "redis_set_failed", { key, error: String(error) });
+    }
+  }
+
+  async del(key: string): Promise<void> {
+    try {
+      await this.client.del(key);
+    } catch (error) {
+      logStructured("warn", "redis_del_failed", { key, error: String(error) });
+    }
+  }
+}
+
+/** No-op adapter (used in tests so caching never affects fixtures). */
+export class NoOpCache implements CacheAdapter {
+  async get(): Promise<string | null> {
+    return null;
+  }
+  async set(): Promise<void> {}
+  async del(): Promise<void> {}
+}
+
+let instance: CacheAdapter | null = null;
+
+/** Singleton cache, chosen from the environment. */
+export function getCache(): CacheAdapter {
+  if (instance) return instance;
+
+  if (process.env.NODE_ENV === "test") {
+    instance = new NoOpCache();
+    return instance;
+  }
+
+  const url = process.env.REDIS_URL?.trim();
+  if (url) {
+    const client = new Redis(url, { maxRetriesPerRequest: 2 });
+    client.on("error", (error: Error) =>
+      logStructured("warn", "redis_connection_error", { error: String(error) }),
+    );
+    instance = new RedisCache(client);
+    logStructured("info", "cache_backend_selected", { backend: "redis" });
+  } else {
+    instance = new InMemoryCache();
+    logStructured("info", "cache_backend_selected", { backend: "memory" });
+  }
+  return instance;
+}
+
+/** Reset the singleton (tests only). */
+export function __resetCacheForTests(): void {
+  instance = null;
+}

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -1,18 +1,54 @@
-import type { RequestHandler } from "express";
+import type { Request, RequestHandler, Response } from "express";
 import { rateLimit } from "express-rate-limit";
 import { StrKey } from "@stellar/stellar-sdk";
 
-/** Bypass strict limits in automated tests so suites can hit POST routes freely. */
-export const limiter: RequestHandler =
-  process.env.NODE_ENV === "test"
-    ? (_req, _res, next) => next()
-    : rateLimit({
-        windowMs: 1 * 60 * 1000,
-        limit: 5,
-        standardHeaders: "draft-8",
-        legacyHeaders: false,
-        ipv6Subnet: 56,
-      });
+/**
+ * Rate limiting (#349).
+ *
+ * Two tiers, both configurable via env:
+ *  - `readLimiter`     — global, GET-only, generous (default 120 req/min/IP).
+ *  - `mutationLimiter` — strict, applied to state-changing routes
+ *    (create / reserve / submit / release / refund) so a single client cannot
+ *    hammer them (default 10 req/min/IP), independent of the read limit.
+ *
+ * Standard `RateLimit-*` headers are returned on every response; 429 responses
+ * additionally carry a `Retry-After` header.
+ */
+const WINDOW_MS = Number(process.env.RATE_LIMIT_WINDOW_MS ?? 60_000);
+const READ_MAX = Number(process.env.RATE_LIMIT_READ_MAX ?? 120);
+const MUTATION_MAX = Number(process.env.RATE_LIMIT_MUTATION_MAX ?? 10);
+
+const isTest = process.env.NODE_ENV === "test";
+
+/** No-op middleware so test suites can hit routes freely. */
+const passthrough: RequestHandler = (_req, _res, next) => next();
+
+function makeLimiter(limit: number, options: { getOnly?: boolean } = {}): RequestHandler {
+  if (isTest) {
+    return passthrough;
+  }
+  return rateLimit({
+    windowMs: WINDOW_MS,
+    limit,
+    standardHeaders: "draft-8",
+    legacyHeaders: false,
+    ipv6Subnet: 56,
+    ...(options.getOnly ? { skip: (req: Request) => req.method !== "GET" } : {}),
+    handler: (_req: Request, res: Response) => {
+      res.setHeader("Retry-After", String(Math.ceil(WINDOW_MS / 1000)));
+      res.status(429).json({ error: "Too many requests. Please retry later." });
+    },
+  });
+}
+
+/** Global read limit (GET only): generous, protects against scraping. */
+export const readLimiter: RequestHandler = makeLimiter(READ_MAX, { getOnly: true });
+
+/** Strict limit for state-changing mutation routes. */
+export const mutationLimiter: RequestHandler = makeLimiter(MUTATION_MAX);
+
+/** @deprecated Use {@link mutationLimiter}. Retained for backward compatibility. */
+export const limiter: RequestHandler = mutationLimiter;
 
 export function isValidStellarAddress(address: string): boolean {
   return StrKey.isValidEd25519PublicKey(address);

--- a/backend/test/cache.test.ts
+++ b/backend/test/cache.test.ts
@@ -1,0 +1,123 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { InMemoryCache, RedisCache, NoOpCache } from "../src/services/cache";
+import { MAINTAINER } from "./fixtures";
+
+describe("InMemoryCache", () => {
+  it("stores and returns a value within its TTL", async () => {
+    const cache = new InMemoryCache();
+    await cache.set("k", "v", 5);
+    expect(await cache.get("k")).toBe("v");
+  });
+
+  it("expires entries after the TTL", async () => {
+    vi.useFakeTimers();
+    try {
+      const cache = new InMemoryCache();
+      await cache.set("k", "v", 5);
+      vi.advanceTimersByTime(5_001);
+      expect(await cache.get("k")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("deletes a key", async () => {
+    const cache = new InMemoryCache();
+    await cache.set("k", "v", 5);
+    await cache.del("k");
+    expect(await cache.get("k")).toBeNull();
+  });
+});
+
+describe("RedisCache", () => {
+  it("delegates get/set/del to the client", async () => {
+    const client = {
+      get: vi.fn().mockResolvedValue("cached"),
+      set: vi.fn().mockResolvedValue("OK"),
+      del: vi.fn().mockResolvedValue(1),
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache = new RedisCache(client as any);
+    expect(await cache.get("k")).toBe("cached");
+    await cache.set("k", "v", 5);
+    expect(client.set).toHaveBeenCalledWith("k", "v", "EX", 5);
+    await cache.del("k");
+    expect(client.del).toHaveBeenCalledWith("k");
+  });
+
+  it("degrades to a miss when the client throws", async () => {
+    const client = {
+      get: vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
+      set: vi.fn(),
+      del: vi.fn(),
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache = new RedisCache(client as any);
+    expect(await cache.get("k")).toBeNull();
+  });
+});
+
+describe("NoOpCache", () => {
+  it("never stores anything", async () => {
+    const cache = new NoOpCache();
+    await cache.set("k", "v", 5);
+    expect(await cache.get("k")).toBeNull();
+  });
+});
+
+describe("listBountiesCached", () => {
+  let storeFile: string;
+
+  beforeEach(() => {
+    storeFile = path.join(os.tmpdir(), `bounty-cache-${randomUUID()}.json`);
+    fs.writeFileSync(storeFile, "[]", "utf8");
+    process.env.BOUNTY_STORE_PATH = storeFile;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.BOUNTY_STORE_PATH;
+    for (const f of [storeFile, storeFile.replace(/\.json$/i, ".audit.json")]) {
+      try {
+        fs.unlinkSync(f);
+      } catch {
+        /* best-effort */
+      }
+    }
+  });
+
+  it("serves a cached list and refreshes only after invalidation", async () => {
+    const { createBounty, listBountiesCached, invalidateBountyCache } = await import(
+      "../src/services/bountyStore"
+    );
+    const { InMemoryCache: Mem } = await import("../src/services/cache");
+    const cache = new Mem();
+
+    const makeInput = (issueNumber: number) => ({
+      repo: "acme/widget",
+      issueNumber,
+      title: `Bounty ${issueNumber} needs a fix in the loading flow`,
+      summary: "A sufficiently long summary describing the task for contributors.",
+      maintainer: MAINTAINER,
+      tokenSymbol: "XLM",
+      amount: 100,
+      deadlineDays: 30,
+      labels: ["help wanted"],
+    });
+
+    await createBounty(makeInput(1));
+    expect((await listBountiesCached({}, cache)).length).toBe(1);
+
+    // A write that bypasses this injected cache leaves the cached value stale.
+    await createBounty(makeInput(2));
+    expect((await listBountiesCached({}, cache)).length).toBe(1);
+
+    // Invalidation forces a refresh from the store.
+    await invalidateBountyCache(cache);
+    expect((await listBountiesCached({}, cache)).length).toBe(2);
+  });
+});

--- a/backend/test/logger.test.ts
+++ b/backend/test/logger.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import pino from "pino";
+import { Keypair } from "@stellar/stellar-sdk";
+import { baseLoggerOptions, redactStellarSecrets } from "../src/logger";
+
+const SECRET = Keypair.random().secret(); // valid Stellar seed: S + 55 base32 chars
+
+describe("redactStellarSecrets", () => {
+  it("redacts a bare secret key string", () => {
+    expect(redactStellarSecrets(SECRET)).toBe("[redacted-secret-key]");
+  });
+
+  it("redacts a secret key embedded in a message", () => {
+    const out = redactStellarSecrets(`signing failed for ${SECRET} on submit`) as string;
+    expect(out).not.toContain(SECRET);
+    expect(out).toContain("[redacted-secret-key]");
+  });
+
+  it("redacts secret keys nested in objects and arrays", () => {
+    const out = redactStellarSecrets({
+      keypair: { secretKey: SECRET },
+      candidates: [SECRET, "not-a-secret"],
+    }) as { keypair: { secretKey: string }; candidates: string[] };
+    expect(out.keypair.secretKey).toBe("[redacted-secret-key]");
+    expect(out.candidates[0]).toBe("[redacted-secret-key]");
+    expect(out.candidates[1]).toBe("not-a-secret");
+  });
+
+  it("leaves non-secret values untouched", () => {
+    expect(redactStellarSecrets("hello world")).toBe("hello world");
+    expect(redactStellarSecrets(42)).toBe(42);
+  });
+});
+
+describe("logger redaction (pino)", () => {
+  function capture(): { lines: string[]; log: pino.Logger } {
+    const lines: string[] = [];
+    const stream = { write: (chunk: string) => void lines.push(chunk) };
+    return { lines, log: pino(baseLoggerOptions, stream) };
+  }
+
+  it("never writes a Stellar secret key to log output (message or fields)", () => {
+    const { lines, log } = capture();
+    log.info({ secretKey: SECRET, nested: { privateKey: SECRET } }, `boom ${SECRET}`);
+    const output = lines.join("");
+    expect(output).not.toContain(SECRET);
+  });
+
+  it("masks named key fields via path redaction", () => {
+    const { lines, log } = capture();
+    // `*.secretKey` matches one level deep, so nest the fields under a key.
+    log.info({ wallet: { secretKey: "plain", privateKey: "plain", seed: "plain" } }, "redact paths");
+    const entry = JSON.parse(lines[0]);
+    expect(entry.wallet.secretKey).toBe("[redacted]");
+    expect(entry.wallet.privateKey).toBe("[redacted]");
+    expect(entry.wallet.seed).toBe("[redacted]");
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,31 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=3001
+      # Shared cache across replicas (#361); falls back to in-memory if unset.
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      redis:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:3001/api/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 20s
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: stellar-bounty-redis
+    ports:
+      - "6379:6379"
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
     restart: unless-stopped
 
   frontend:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,7 +39,7 @@ import SubmissionChecklistModal, { type SubmissionFormData } from "./SubmissionC
 import { BountyRecommendation, ContributorProfile, createDefaultProfile, generateRecommendations, updateProfileFromBounties } from "./recommendations";
 import RecommendedBounties from "./RecommendedBounties";
 import { statusCopy, actionCopy, readInitialFilters, FilterState, statusOptions, statusGlossary, sortOptions } from "./constants";
-import { filterBounties, getRewardBounds, getActiveRewardLabel, getContributorMetrics, getUniqueRepos, getRepoMetrics, sortBounties, debounce, SortOption, SortState, xlmToUsd } from "./utils";
+import { filterBounties, getRewardBounds, getActiveRewardLabel, getContributorMetrics, getUniqueRepos, getUniqueTokenSymbols, getRepoMetrics, sortBounties, debounce, SortOption, SortState, xlmToUsd } from "./utils";
 import { Bounty, CreateBountyPayload, OpenIssue, BountyStatus } from "./types";
 
 import GitHubIssuePreviewCard from "./GitHubIssuePreviewCard";
@@ -322,6 +322,7 @@ function App() {
   const [minReward, setMinReward] = useState(initialFilters.minReward);
   const [maxReward, setMaxReward] = useState(initialFilters.maxReward);
   const [repoFilter, setRepoFilter] = useState(initialFilters.repoFilter);
+  const [tokenFilter, setTokenFilter] = useState(initialFilters.tokenFilter);
   const [sortOption, setSortOption] = useState(initialFilters.sortOption);
   const [sortDirection, setSortDirection] = useState(initialFilters.sortDirection);
   const [pathname, setPathname] = useState(window.location.pathname);
@@ -421,6 +422,10 @@ function App() {
       params.set("repo", repoFilter);
     }
 
+    if (tokenFilter !== "") {
+      params.set("tokenSymbol", tokenFilter);
+    }
+
     if (sortOption !== "newest") {
       params.set("sort", sortOption);
     }
@@ -432,7 +437,7 @@ function App() {
     const nextSearch = params.toString();
     const nextUrl = `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ""}${window.location.hash}`;
     window.history.replaceState(null, "", nextUrl);
-  }, [maxReward, minReward, pathname, debouncedSearchQuery, statusFilter, repoFilter, sortOption, sortDirection]);
+  }, [maxReward, minReward, pathname, debouncedSearchQuery, statusFilter, repoFilter, tokenFilter, sortOption, sortDirection]);
 
   useEffect(() => {
     function handlePopState() {
@@ -446,6 +451,7 @@ function App() {
       setMinReward(filters.minReward);
       setMaxReward(filters.maxReward);
       setRepoFilter(filters.repoFilter);
+      setTokenFilter(filters.tokenFilter);
       setSortOption(filters.sortOption);
       setSortDirection(filters.sortDirection);
     }
@@ -476,6 +482,10 @@ function App() {
     return getUniqueRepos(bounties);
   }, [bounties]);
 
+  const uniqueTokens = useMemo(() => {
+    return getUniqueTokenSymbols(bounties);
+  }, [bounties]);
+
   const rewardBounds = useMemo(() => {
     return getRewardBounds(bounties);
   }, [bounties]);
@@ -499,6 +509,7 @@ function App() {
     setMinReward("");
     setMaxReward("");
     setRepoFilter("");
+    setTokenFilter("");
     setSortOption("newest");
     setSortDirection("desc");
   }
@@ -624,13 +635,14 @@ function App() {
       minReward,
       maxReward,
       repoFilter: effectiveRepoFilter,
+      tokenFilter,
       sortOption,
       sortDirection,
     });
 
     // Apply sorting
     return sortBounties(filtered, { option: sortOption, direction: sortDirection });
-  }, [bounties, debouncedSearchQuery, statusFilter, minReward, maxReward, repoFilter, repoRoute, sortOption, sortDirection]);
+  }, [bounties, debouncedSearchQuery, statusFilter, minReward, maxReward, repoFilter, tokenFilter, repoRoute, sortOption, sortDirection]);
 
   const groupedBounties = useMemo(() => {
     if (repoRoute) {
@@ -1068,6 +1080,25 @@ function App() {
                         {uniqueRepos.map((repo) => (
                           <option key={repo} value={repo}>
                             {repo}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </label>
+
+                  <label className="filter-field">
+                    <span>Token</span>
+                    <div className="input-with-icon">
+                      <Coins size={16} />
+                      <select
+                        aria-label="Filter by token"
+                        value={tokenFilter}
+                        onChange={(event) => setTokenFilter(event.target.value)}
+                      >
+                        <option value="">All Tokens</option>
+                        {uniqueTokens.map((token) => (
+                          <option key={token} value={token}>
+                            {token}
                           </option>
                         ))}
                       </select>

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -62,6 +62,7 @@ export interface FilterState {
   minReward: string;
   maxReward: string;
   repoFilter: string;
+  tokenFilter: string;
   sortOption: SortOption;
   sortDirection: "asc" | "desc";
 }
@@ -74,6 +75,7 @@ export function readInitialFilters(): FilterState {
     minReward: params.get("minReward") ?? "",
     maxReward: params.get("maxReward") ?? "",
     repoFilter: params.get("repo") ?? "",
+    tokenFilter: params.get("tokenSymbol") ?? "",
     sortOption: (params.get("sort") as SortOption) ?? "newest",
     sortDirection: (params.get("direction") as "asc" | "desc") ?? "desc",
   };

--- a/frontend/src/utils.test.ts
+++ b/frontend/src/utils.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { xlmToUsd, resetXlmToUsdCache } from "./utils";
+import { xlmToUsd, resetXlmToUsdCache, filterBounties, getUniqueTokenSymbols } from "./utils";
+import type { FilterState } from "./constants";
+import type { Bounty } from "./types";
 
 describe("xlmToUsd", () => {
   const fetchMock = vi.fn();
@@ -43,5 +45,71 @@ describe("xlmToUsd", () => {
     fetchMock.mockRejectedValue(new Error("network unavailable"));
 
     await expect(xlmToUsd(100)).resolves.toBe("USD unavailable");
+  });
+});
+
+function mockBounty(overrides: Partial<Bounty>): Bounty {
+  return {
+    id: "BNT-0001",
+    repo: "acme/widget",
+    issueNumber: 1,
+    title: "Fix the widget",
+    summary: "A task",
+    maintainer: "GMAINTAINER",
+    tokenSymbol: "XLM",
+    amount: 100,
+    labels: [],
+    status: "open",
+    createdAt: 1,
+    deadlineAt: 2,
+    ...overrides,
+  } as Bounty;
+}
+
+const baseFilters: FilterState = {
+  searchQuery: "",
+  statusFilter: "all",
+  minReward: "",
+  maxReward: "",
+  repoFilter: "",
+  tokenFilter: "",
+  sortOption: "newest",
+  sortDirection: "desc",
+};
+
+const tokenBounties: Bounty[] = [
+  mockBounty({ id: "1", tokenSymbol: "XLM", status: "open" }),
+  mockBounty({ id: "2", tokenSymbol: "USDC", status: "open" }),
+  mockBounty({ id: "3", tokenSymbol: "XLM", status: "released" }),
+  mockBounty({ id: "4", tokenSymbol: "usdc", status: "reserved" }), // lowercase
+];
+
+describe("getUniqueTokenSymbols (#293)", () => {
+  it("returns distinct, uppercased, sorted token symbols", () => {
+    expect(getUniqueTokenSymbols(tokenBounties)).toEqual(["USDC", "XLM"]);
+  });
+
+  it("returns an empty array for no bounties", () => {
+    expect(getUniqueTokenSymbols([])).toEqual([]);
+  });
+});
+
+describe("filterBounties — token filter (#293)", () => {
+  it("filters to a single token (case-insensitive)", () => {
+    const result = filterBounties(tokenBounties, { ...baseFilters, tokenFilter: "USDC" });
+    expect(result.map((b) => b.id).sort()).toEqual(["2", "4"]);
+  });
+
+  it("combines token and status filters with AND logic", () => {
+    const result = filterBounties(tokenBounties, {
+      ...baseFilters,
+      tokenFilter: "XLM",
+      statusFilter: "open",
+    });
+    expect(result.map((b) => b.id)).toEqual(["1"]);
+  });
+
+  it("returns all bounties when the token filter is empty ('All Tokens')", () => {
+    expect(filterBounties(tokenBounties, baseFilters)).toHaveLength(4);
   });
 });

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -19,6 +19,16 @@ export function getUniqueRepos(bounties: Bounty[]): string[] {
   return Array.from(repos).sort();
 }
 
+/** Distinct token symbols across the given bounties, sorted for a stable dropdown (#293). */
+export function getUniqueTokenSymbols(bounties: Bounty[]): string[] {
+  const tokens = new Set(
+    bounties
+      .map((bounty) => bounty.tokenSymbol?.trim().toUpperCase())
+      .filter((symbol): symbol is string => Boolean(symbol)),
+  );
+  return Array.from(tokens).sort();
+}
+
 export function getRepoMetrics(bounties: Bounty[], repo: string) {
   const repoBounties = bounties.filter((bounty) => bounty.repo === repo);
   const openBounties = repoBounties.filter((bounty) => bounty.status === "open");
@@ -50,6 +60,14 @@ export function filterBounties(bounties: Bounty[], filters: FilterState): Bounty
 
     // Repo filter
     if (filters.repoFilter.trim() !== "" && bounty.repo !== filters.repoFilter) {
+      return false;
+    }
+
+    // Token filter (AND with status/other filters) (#293)
+    if (
+      filters.tokenFilter.trim() !== "" &&
+      bounty.tokenSymbol?.toUpperCase() !== filters.tokenFilter.toUpperCase()
+    ) {
       return false;
     }
 


### PR DESCRIPTION
Implements four assigned issues in a single PR.

## #381 — `pino` log redaction for Stellar private keys
`backend/src/logger.ts` now removes secrets two ways:
- **Path redaction** adds `*.secretKey`, `*.privateKey`, `*.seed` to the existing redact paths.
- **Value redaction** — a `logMethod` hook scrubs any string matching a Stellar secret seed (`^S[0-9A-Z]{55}$`) wherever it appears, including free-form **error messages** and nested objects, replacing it with `[redacted-secret-key]` (path redaction alone can't reach those).
- Unit tests (`backend/test/logger.test.ts`) verify a generated secret is redacted from message + fields and that named key fields are masked.
- Documented in `SECURITY.md` → "Logging best practices".

## #349 — per-endpoint rate-limit tightening
`backend/src/utils.ts` exposes two limiters wired in `app.ts`:
- **Read** (GET only): 120 req/min/IP (`RATE_LIMIT_READ_MAX`).
- **Mutation** (`create` / `reserve` / `submit` / `release` / `refund`): 10 req/min/IP (`RATE_LIMIT_MUTATION_MAX`), independent of the read limit.
- Standard `RateLimit-*` headers on every response; **`Retry-After`** on 429; window configurable via `RATE_LIMIT_WINDOW_MS`. All documented in `.env.example`. (Limiters stay no-op under `NODE_ENV=test`, matching the existing convention.)

## #361 — optional Redis caching layer
- New `backend/src/services/cache.ts`: a `CacheAdapter` with `InMemoryCache`, `RedisCache` (ioredis), and `NoOpCache`. `getCache()` selects **Redis when `REDIS_URL` is set**, else in-memory; Redis errors degrade to a cache miss.
- `bountyStore.listBountiesCached()` caches the bounty list with a **5s TTL**; every write (`create`/`reserve`/`submit`/`release`/`refund`) calls `invalidateBountyCache()` (`DEL`). The `/api/bounties` route uses it.
- `docker-compose.yml` gains a `redis:7-alpine` service with a `redis-cli ping` health check, wired to the backend via `REDIS_URL`.
- Tests (`backend/test/cache.test.ts`) cover TTL/get/set/del, Redis delegation + error degradation, and cache→invalidate behavior.

## #293 — token symbol filter dropdown
- `getUniqueTokenSymbols()` derives distinct, uppercased, sorted symbols from the fetched bounties; the dropdown renders them with an **"All Tokens"** reset option.
- Selecting a token sets the `?tokenSymbol=` URL param (synced like the existing repo filter) and AND-combines with the status filter in `filterBounties`.
- Vitest tests (`frontend/src/utils.test.ts`) mock a bounty list and assert the option set + AND-filter + reset behavior.

## Test plan
- [x] `backend`: `npm test` → my new tests pass (logger 6/6, cache 7/7); no regressions (the only failing tests are pre-existing — see below).
- [x] `frontend`: token-filter tests pass (8/8); `constants.ts` / `utils.ts` / `App.tsx` are clean under `tsc --noEmit`.

## Pre-existing issues (out of scope, not caused by this PR)
Verified against clean `main`:
- **Backend** `tsc` fails on two pre-existing errors unrelated to these issues: missing `@types/swagger-ui-express`, and a `submissionUrl` type mismatch in the submit route. Vitest still runs (esbuild). Pre-existing failing tests: `expiry`/`reservationExpirationJob` expiry logic, the Stellar auth-middleware 401 case, two `api.test` create-validation cases, and an empty `test/utils.test.ts`.
- **Frontend** `tsc` is red on `main`: `src/api.ts` has a corrupted `listBounties` (its function-declaration line was lost, leaving an orphaned body — `TS1128`), which masks further pre-existing type errors in `recommendations.ts`, `main.tsx`, `RecommendedBounties.tsx`, etc. I left `api.ts` untouched to keep this PR focused; my changed files type-check cleanly on their own.

Closes #381
Closes #361
Closes #349
Closes #293


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token filter to the bounties board.
  * Implemented caching for bounty lists with in-memory fallback for improved performance.
  * Introduced separate configurable rate limits for read and write operations.

* **Documentation**
  * Added security logging best practices guidance.

* **Chores**
  * Updated development environment to include Redis support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->