### PR TITLE
feat(api): Cache open issues feed

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -18,7 +18,7 @@ import {
   getGlobalMetrics,
   getLeaderboard,
 } from "./services/bountyStore";
-import { listOpenIssues } from "./services/openIssues";
+import { getOpenIssuesFeedStatus, listOpenIssues } from "./services/openIssues";
 import {
   bountyIdSchema,
   createBountySchema,
@@ -143,6 +143,15 @@ app.get("/api/health", (_req: Request, res: Response) => {
     service: "stellar-bounty-board-backend",
     status: "ok",
     timestamp: new Date().toISOString(),
+  });
+});
+
+app.get("/api/health/deep", (_req: Request, res: Response) => {
+  res.json({
+    service: "stellar-bounty-board-backend",
+    status: "ok",
+    timestamp: new Date().toISOString(),
+    openIssuesFeed: getOpenIssuesFeedStatus(),
   });
 });
 
@@ -340,8 +349,14 @@ app.post(
   },
 );
 
-app.get("/api/open-issues", (_req: Request, res: Response) => {
-  res.json({ data: listOpenIssues() });
+app.get("/api/open-issues", async (req: Request, res: Response) => {
+  try {
+    const feed = await listOpenIssues();
+    res.setHeader("Cache-Control", "max-age=600");
+    res.json({ data: feed.issues });
+  } catch (error) {
+    sendError(res, req, error, 500);
+  }
 });
 
 

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -77,6 +77,27 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/api/health/deep",
+  tags: ["System"],
+  summary: "Deep health check",
+  description:
+    "Returns service health plus the current open-issues feed status, including whether the feed is using stale data " +
+    "after GitHub rate limiting.",
+  responses: {
+    200: jsonResponse(
+      "Service and dependency status.",
+      z.object({
+        service: z.string(),
+        status: z.literal("ok"),
+        timestamp: z.string(),
+        openIssuesFeed: z.enum(["up", "rate-limited", "stale"]),
+      }),
+    ),
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/api/bounties",
   tags: ["Bounties"],
   summary: "List all bounties",
@@ -216,7 +237,8 @@ registry.registerPath({
   tags: ["Open Issues"],
   summary: "List open feature requests",
   description:
-    "Returns a curated static list of open feature requests and contribution opportunities for the Stellar Bounty Board project itself.",
+    "Returns contribution opportunities from the GitHub issue tracker. Responses are cached for 10 minutes and " +
+    "stale cached data is served when GitHub rate limits are encountered.",
   responses: {
     200: jsonResponse("Array of open issues.", z.object({ data: z.array(openIssueSchema) })),
   },

--- a/backend/src/services/openIssues.ts
+++ b/backend/src/services/openIssues.ts
@@ -6,7 +6,74 @@ export interface OpenIssue {
   impact: "starter" | "core" | "advanced";
 }
 
-const openIssues: OpenIssue[] = [
+export type OpenIssuesFeedStatus = "up" | "rate-limited" | "stale";
+
+export interface OpenIssuesFeedResult {
+  issues: OpenIssue[];
+  status: OpenIssuesFeedStatus;
+}
+
+interface GitHubIssue {
+  number?: unknown;
+  title?: unknown;
+  body?: unknown;
+  labels?: unknown[];
+  pull_request?: unknown;
+}
+
+interface CacheEntry {
+  issues: OpenIssue[];
+  fetchedAt: number;
+}
+
+class LruCache<K, V> {
+  private readonly entries = new Map<K, V>();
+
+  constructor(private readonly maxEntries: number) {}
+
+  get(key: K): V | undefined {
+    const value = this.entries.get(key);
+    if (value === undefined) {
+      return undefined;
+    }
+    this.entries.delete(key);
+    this.entries.set(key, value);
+    return value;
+  }
+
+  peek(key: K): V | undefined {
+    return this.entries.get(key);
+  }
+
+  set(key: K, value: V): void {
+    if (this.entries.has(key)) {
+      this.entries.delete(key);
+    }
+    this.entries.set(key, value);
+
+    if (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest !== undefined) {
+        this.entries.delete(oldest);
+      }
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}
+
+const OPEN_ISSUES_CACHE_KEY = "github-open-issues";
+export const OPEN_ISSUES_CACHE_TTL_MS = 10 * 60 * 1000;
+const GITHUB_OPEN_ISSUES_URL =
+  "https://api.github.com/repos/ritik4ever/stellar-bounty-board/issues" +
+  "?state=open&labels=Stellar%20Wave&per_page=20";
+
+const openIssuesCache = new LruCache<string, CacheEntry>(1);
+let lastFeedStatus: OpenIssuesFeedStatus = "up";
+
+const fallbackOpenIssues: OpenIssue[] = [
   {
     id: "SBB-101",
     title: "Add Freighter wallet signing for maintainer-only release and refund actions",
@@ -41,7 +108,172 @@ const openIssues: OpenIssue[] = [
   },
 ];
 
-export function listOpenIssues(): OpenIssue[] {
-  return openIssues;
+function extractLabelNames(labels: unknown[] | undefined): string[] {
+  if (!Array.isArray(labels)) {
+    return [];
+  }
+  return labels
+    .map((label) => {
+      if (typeof label === "string") {
+        return label;
+      }
+      if (
+        label &&
+        typeof label === "object" &&
+        "name" in label &&
+        typeof (label as { name?: unknown }).name === "string"
+      ) {
+        return (label as { name: string }).name;
+      }
+      return undefined;
+    })
+    .filter((label): label is string => Boolean(label));
+}
+
+function inferImpact(labels: string[]): OpenIssue["impact"] {
+  const normalized = labels.map((label) => label.toLowerCase());
+  if (normalized.includes("good first issue") || normalized.includes("documentation")) {
+    return "starter";
+  }
+  if (
+    normalized.some((label) =>
+      ["security", "devops", "performance", "smart contract"].includes(label),
+    )
+  ) {
+    return "advanced";
+  }
+  return "core";
+}
+
+function summarizeIssue(body: unknown): string {
+  if (typeof body !== "string") {
+    return "Open contribution opportunity from the GitHub issue tracker.";
+  }
+
+  const summary = body
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^#+\s*/, "").replace(/^[-*]\s*/, "").trim())
+    .find((line) => line.length > 0);
+
+  if (!summary) {
+    return "Open contribution opportunity from the GitHub issue tracker.";
+  }
+
+  return summary.length > 180 ? `${summary.slice(0, 177)}...` : summary;
+}
+
+function toOpenIssue(issue: GitHubIssue): OpenIssue | null {
+  if (issue.pull_request) {
+    return null;
+  }
+  if (typeof issue.number !== "number" || typeof issue.title !== "string") {
+    return null;
+  }
+
+  const labels = extractLabelNames(issue.labels);
+  return {
+    id: `#${issue.number}`,
+    title: issue.title,
+    labels,
+    summary: summarizeIssue(issue.body),
+    impact: inferImpact(labels),
+  };
+}
+
+function cacheIsFresh(entry: CacheEntry, now = Date.now()): boolean {
+  return now - entry.fetchedAt < OPEN_ISSUES_CACHE_TTL_MS;
+}
+
+function readFreshCache(): OpenIssuesFeedResult | null {
+  const cached = openIssuesCache.get(OPEN_ISSUES_CACHE_KEY);
+  if (cached && cacheIsFresh(cached)) {
+    lastFeedStatus = "up";
+    return { issues: cached.issues, status: "up" };
+  }
+  return null;
+}
+
+function readStaleCache(status: OpenIssuesFeedStatus): OpenIssuesFeedResult | null {
+  const stale = openIssuesCache.peek(OPEN_ISSUES_CACHE_KEY);
+  if (!stale) {
+    return null;
+  }
+  lastFeedStatus = status;
+  return { issues: stale.issues, status };
+}
+
+function githubRequestHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "stellar-bounty-board-open-issues-feed",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  return headers;
+}
+
+function isRateLimited(response: Response): boolean {
+  return response.status === 403 || response.headers.get("X-RateLimit-Remaining") === "0";
+}
+
+export async function listOpenIssues(): Promise<OpenIssuesFeedResult> {
+  const fresh = readFreshCache();
+  if (fresh) {
+    return fresh;
+  }
+
+  try {
+    const response = await fetch(GITHUB_OPEN_ISSUES_URL, {
+      headers: githubRequestHeaders(),
+    });
+
+    if (isRateLimited(response)) {
+      const stale = readStaleCache("rate-limited");
+      if (stale) {
+        return stale;
+      }
+      lastFeedStatus = "rate-limited";
+      return { issues: fallbackOpenIssues, status: "rate-limited" };
+    }
+
+    if (!response.ok) {
+      throw new Error(`GitHub open issues request failed with HTTP ${response.status}`);
+    }
+
+    const payload = (await response.json()) as unknown;
+    const issues = Array.isArray(payload)
+      ? payload
+          .map((issue) => toOpenIssue(issue as GitHubIssue))
+          .filter((issue): issue is OpenIssue => issue !== null)
+      : [];
+
+    const nextIssues = issues.length > 0 ? issues : fallbackOpenIssues;
+    openIssuesCache.set(OPEN_ISSUES_CACHE_KEY, {
+      issues: nextIssues,
+      fetchedAt: Date.now(),
+    });
+    lastFeedStatus = "up";
+    return { issues: nextIssues, status: "up" };
+  } catch {
+    const stale = readStaleCache("stale");
+    if (stale) {
+      return stale;
+    }
+    lastFeedStatus = "stale";
+    return { issues: fallbackOpenIssues, status: "stale" };
+  }
+}
+
+export function getOpenIssuesFeedStatus(): OpenIssuesFeedStatus {
+  return lastFeedStatus;
+}
+
+export function resetOpenIssuesCacheForTests(): void {
+  openIssuesCache.clear();
+  lastFeedStatus = "up";
 }
 

--- a/backend/test/openIssuesCache.test.ts
+++ b/backend/test/openIssuesCache.test.ts
@@ -1,0 +1,109 @@
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const githubIssue = {
+  number: 365,
+  title: "Add open issues caching",
+  body: "Cache the GitHub API response for 10 minutes.\n\nMore detail follows.",
+  labels: [{ name: "performance" }, { name: "api" }],
+};
+
+function mockGitHubResponse(body: unknown, init: ResponseInit = {}) {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json", ...init.headers },
+      ...init,
+    }),
+  );
+}
+
+describe("open issues GitHub feed cache", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    delete process.env.GITHUB_TOKEN;
+  });
+
+  it("caches GitHub API responses and sets a public max-age", async () => {
+    const fetchMock = vi.fn(() => mockGitHubResponse([githubIssue]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { app } = await import("../src/app");
+
+    const first = await request(app).get("/api/open-issues").expect(200);
+    const second = await request(app).get("/api/open-issues").expect(200);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(first.headers["cache-control"]).toBe("max-age=600");
+    expect(second.headers["cache-control"]).toBe("max-age=600");
+    expect(second.body.data).toEqual(first.body.data);
+    expect(first.body.data[0]).toMatchObject({
+      id: "#365",
+      title: "Add open issues caching",
+      labels: ["performance", "api"],
+    });
+  });
+
+  it("uses GITHUB_TOKEN for authenticated GitHub requests", async () => {
+    process.env.GITHUB_TOKEN = "ghp_test_token";
+    const fetchMock = vi.fn(() => mockGitHubResponse([githubIssue]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { app } = await import("../src/app");
+
+    await request(app).get("/api/open-issues").expect(200);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer ghp_test_token",
+        }),
+      }),
+    );
+  });
+
+  it("serves stale cached issues on GitHub rate limits", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-28T00:00:00.000Z"));
+
+    const staleIssue = { ...githubIssue, title: "Cached issue" };
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => mockGitHubResponse([staleIssue]))
+      .mockImplementationOnce(() =>
+        mockGitHubResponse(
+          { message: "API rate limit exceeded" },
+          {
+            status: 403,
+            headers: {
+              "Content-Type": "application/json",
+              "X-RateLimit-Remaining": "0",
+            },
+          },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { app } = await import("../src/app");
+
+    await request(app).get("/api/open-issues").expect(200);
+    vi.setSystemTime(new Date("2026-05-28T00:11:00.000Z"));
+
+    const rateLimited = await request(app).get("/api/open-issues").expect(200);
+    const health = await request(app).get("/api/health/deep").expect(200);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(rateLimited.body.data[0]).toMatchObject({
+      id: "#365",
+      title: "Cached issue",
+    });
+    expect(health.body.openIssuesFeed).toBe("rate-limited");
+  });
+});


### PR DESCRIPTION
Adds a cached GitHub-backed open-issues feed so `/api/open-issues` no longer hits the GitHub API on every request. The feed now caches successful responses for 10 minutes, includes optional `GITHUB_TOKEN` authentication, and falls back to stale cached data when GitHub returns a rate-limit response.

**Deep Health Status**

`GET /api/health/deep` now reports `openIssuesFeed` as `up`, `rate-limited`, or `stale`, making the feed degradation visible without failing the frontend.

**Validation**

- `node node_modules/vitest/vitest.mjs run test/openIssuesCache.test.ts` -> 3/3 passed
- `git diff --check` -> passed
- `node node_modules/vitest/vitest.mjs run test/api.test.ts test/openIssuesCache.test.ts` -> new cache tests passed; existing current-main amount validation tests still fail on `10001 XLM` and `>7 decimal places`
- `node node_modules/typescript/bin/tsc -p tsconfig.json --noEmit` -> existing current-main failures remain for missing `@types/swagger-ui-express` and `submitBountySchema.submissionUrl`

Closes #365