### PR TITLE
ci: add Playwright e2e test workflow against docker-compose stack

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -1,0 +1,83 @@
+name: Playwright E2E
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  e2e:
+    name: Playwright E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Start full stack with docker-compose
+        run: docker compose up -d --build
+        env:
+          NODE_ENV: test
+
+      - name: Wait for backend health check
+        run: |
+          echo "Waiting for backend to be healthy..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3001/api/health; then
+              echo "Backend is up."
+              break
+            fi
+            echo "Attempt $i/30 — retrying in 5s..."
+            sleep 5
+          done
+          curl -sf http://localhost:3001/api/health || (echo "Backend never became healthy" && exit 1)
+
+      - name: Wait for frontend health check
+        run: |
+          echo "Waiting for frontend to be healthy..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000; then
+              echo "Frontend is up."
+              break
+            fi
+            echo "Attempt $i/30 — retrying in 5s..."
+            sleep 5
+          done
+          curl -sf http://localhost:3000 || (echo "Frontend never became healthy" && exit 1)
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright e2e tests
+        run: npx playwright test --reporter=html
+        env:
+          BASE_URL: http://localhost:3000
+          API_URL: http://localhost:3001
+
+      - name: Upload Playwright HTML report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Tear down docker-compose stack
+        if: always()
+        run: docker compose down -v


### PR DESCRIPTION
## Summary

Full-stack regressions were only caught manually. This PR adds a **GitHub Actions workflow** (`.github/workflows/playwright-e2e.yml`) that spins up the complete backend + frontend stack via `docker compose` and runs Playwright tests against it in headless Chromium on every PR and push to `main`.

## How it works

1. **Stack startup** — `docker compose up -d --build` starts backend (`:3001`) and frontend (`:3000`)
2. **Health-check polling** — shell loops hit `/api/health` and the frontend root until both respond (30 × 5 s attempts), failing fast if they never come up
3. **Playwright run** — `npx playwright test --reporter=html` runs all e2e specs against the live stack
4. **Artifact upload** — the full HTML report is uploaded on failure (7-day retention) so CI failures are debuggable without local reproduction
5. **Cleanup** — `docker compose down -v` always runs, even on failure, to free runner resources

## Acceptance criteria met

- [x] Workflow starts backend + frontend with `docker compose` and health-check waits
- [x] Playwright tests run against the composed stack in headless Chromium
- [x] HTML report uploaded as artifact on failure
- [x] Workflow runs on PR and push to `main` — acts as required status check for merges

## Closes

Closes #328
Closes #329
Closes #291
Closes #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Automated end-to-end testing now verifies application functionality on every code change to ensure consistent quality and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->