### PR TITLE
Add GET /api/bounties filtering by maintainer address

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -160,7 +160,8 @@ app.get("/worker/health", (_req: Request, res: Response) => {
 
 app.get("/api/bounties", async (req: Request, res: Response) => {
   const q = typeof req.query.q === "string" ? req.query.q : undefined;
-  res.json({ data: await listBountiesCached({ q }) });
+  const maintainer = typeof req.query.maintainer === "string" ? req.query.maintainer : undefined;
+  res.json({ data: await listBountiesCached({ q, maintainer }) });
 });
 
 app.get("/api/leaderboard", (_req: Request, res: Response) => {

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -348,6 +348,8 @@ function persistUpdated(records: BountyRecord[], updated: BountyRecord): BountyR
 export interface ListBountiesOptions {
   /** Case-insensitive substring filter applied to title, summary, and labels. */
   q?: string;
+  /** Filter by maintainer Stellar address (exact match). */
+  maintainer?: string;
 }
 
 export function listBounties(options: ListBountiesOptions = {}): BountyRecord[] {
@@ -362,6 +364,11 @@ export function listBounties(options: ListBountiesOptions = {}): BountyRecord[] 
         b.summary.toLowerCase().includes(q) ||
         b.labels.some((l) => l.toLowerCase().includes(q)),
     );
+  }
+
+  if (options.maintainer?.trim()) {
+    const addr = options.maintainer.trim();
+    sorted = sorted.filter((b) => b.maintainer === addr);
   }
 
   return sorted;
@@ -392,15 +399,23 @@ export async function listBountiesCached(
   }
 
   const q = options.q?.trim().toLowerCase();
-  if (!q) {
-    return records;
+  let filtered = records;
+
+  if (q) {
+    filtered = filtered.filter(
+      (b) =>
+        b.title.toLowerCase().includes(q) ||
+        b.summary.toLowerCase().includes(q) ||
+        b.labels.some((l) => l.toLowerCase().includes(q)),
+    );
   }
-  return records.filter(
-    (b) =>
-      b.title.toLowerCase().includes(q) ||
-      b.summary.toLowerCase().includes(q) ||
-      b.labels.some((l) => l.toLowerCase().includes(q)),
-  );
+
+  if (options.maintainer?.trim()) {
+    const addr = options.maintainer.trim();
+    filtered = filtered.filter((b) => b.maintainer === addr);
+  }
+
+  return filtered;
 }
 
 /** Drop the cached bounty list so the next read reflects a mutation (#361). */


### PR DESCRIPTION
Closes #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added maintainer filtering to the bounties API. Users can now filter bounties by maintainer using an optional query parameter with an exact-match Stellar address.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->