### PR TITLE
Add arbiter address configuration to backend env and API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ CORS_ORIGINS=http://localhost:5173
 # [OPTIONAL] Logging level (debug, info, warn, error). Default: info
 LOG_LEVEL=info
 
+# [OPTIONAL] Stellar public address of the arbiter used for dispute
+# resolution. When set, the health endpoint exposes it.
+# Example: GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+ARBITER_ADDRESS=
+
 # [OPTIONAL] Redis connection string. When set, the bounty list is cached in
 # Redis (5s TTL) so cache is shared across replicas; falls back to an in-memory
 # cache when unset. Example: redis://localhost:6379

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -142,11 +142,14 @@ function sendError(res: Response, req: Request, error: unknown, statusCode = 400
   jsonError(res, req, statusCode, message);
 }
 
+const ARBITER_ADDRESS = process.env.ARBITER_ADDRESS?.trim() || undefined;
+
 app.get("/api/health", (_req: Request, res: Response) => {
   res.json({
     service: "stellar-bounty-board-backend",
     status: "ok",
     timestamp: new Date().toISOString(),
+    ...(ARBITER_ADDRESS ? { arbiterAddress: ARBITER_ADDRESS } : {}),
   });
 });
 


### PR DESCRIPTION
Closes #225

Adds ARBITER_ADDRESS to .env.example and reads it in app.ts.
The /api/health endpoint exposes it when configured.