### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,2 +1,31 @@
 ---
 name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+A clear and concise description of what you expected to happen.
+
+## Actual Behavior
+What actually happened instead.
+
+## Environment
+- OS: [e.g. Ubuntu 24.04, macOS 15]
+- Browser: [e.g. Chrome 125, Firefox 130]
+- Node version: [e.g. 22.x]
+- Deployment: [e.g. Docker, Railway, local dev]
+
+## Additional Context
+Add any other context, logs, or screenshots about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,19 @@
 ---
 name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+---
 
+## Problem
+A clear description of the problem or limitation this feature would address.
+
+## Proposed Solution
+A clear description of what you want to happen.
+
+## Alternatives Considered
+Any alternative solutions or features you've considered.
+
+## Additional Context
+Add any other context, mockups, or examples about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## What Changed
+Brief description of the changes in this PR.
+
+## Testing Done
+Describe what you tested and how.
+
+## Related Issues
+Closes #[issue_number]
+
+## Checklist
+- [ ] Tests pass locally
+- [ ] Code follows project style
+- [ ] Documentation updated if needed
+- [ ] No unrelated changes


### PR DESCRIPTION
## What Changed
Added GitHub issue templates (bug report, feature request) and PR template under `.github/`.

## Testing Done
- Templates render correctly in GitHub preview
- All required sections present per acceptance criteria

## Related Issues
Closes #330

## Checklist
- [x] Templates follow Contributor Covenant format
- [x] Bug report includes reproduction steps
- [x] Feature request includes problem/solution format
- [x] PR template includes checklist