### PR TITLE
Configure weekly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,1 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directories:
+      - "/backend"
+      - "/frontend"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
+  - package-ecosystem: "cargo"
+    directory: "/contracts"
+    schedule:
+      interval: "weekly"
+    groups:
+      cargo-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Summary
- Configured Dependabot weekly dependency updates for backend, frontend, and contracts.

Issue
- Closes #321

Changes
- Added npm weekly updates for `/backend` and `/frontend` using the `directories` option.
- Added Cargo weekly updates for `/contracts`.
- Grouped minor and patch updates into one group for npm and one group for Cargo.

Validation
- `git diff --check` passed.
- `npx --yes prettier --check .github/dependabot.yml` passed.

Notes
- No dependency install, test, or build was needed because this only updates Dependabot configuration.
- Reopened from a fresh branch after correcting the local Git author identity.