### PR TITLE
devops: add wave-5 issues importing script to auto-create from docs/issues/*.md

### DIFF
--- a/scripts/import-wave5-issues.sh
+++ b/scripts/import-wave5-issues.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Import wave-5 issues from docs/issues/*.md
+# Usage: ./scripts/import-wave5-issues.sh
+
+set -e
+
+ISSUES_DIR="docs/issues"
+if [ ! -d "$ISSUES_DIR" ]; then
+  echo "No docs/issues/ directory found. Create markdown files first."
+  exit 1
+fi
+
+for file in "$ISSUES_DIR"/*.md; do
+  title=$(head -1 "$file" | sed 's/^# //')
+  body=$(tail -n +3 "$file")
+  echo "Creating issue: $title"
+  gh issue create --title "$title" --body "$body" 2>/dev/null || echo "Failed to create: $title"
+done
+
+echo "Import complete."


### PR DESCRIPTION
Closes #389

Adds `scripts/import-wave5-issues.sh` that reads markdown files from `docs/issues/` and creates them as GitHub issues automatically.

Devi: `/attempt`

**Wallet:**
- Stellar (USDC): `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`
- BNB (BSC): `0x6851F2cCD4C4EA991734FAA83c027A909f2703f3`