### PR TITLE
docs: add OpenAPI spec coverage for dispute and resolution endpoints

### DIFF
--- a/docs/openapi-dispute-endpoints.md
+++ b/docs/openapi-dispute-endpoints.md
@@ -1,0 +1,86 @@
+# OpenAPI Spec — Dispute & Resolution Endpoints
+
+## POST /api/disputes
+
+Create a new dispute for a bounty.
+
+\`\`\`yaml
+/api/disputes:
+  post:
+    summary: Create a dispute
+    tags: [Disputes]
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              bountyId:
+                type: string
+              reason:
+                type: string
+              evidence:
+                type: array
+                items:
+                  type: string
+    responses:
+      201:
+        description: Dispute created
+      400:
+        description: Invalid input
+\`\`\`
+
+## GET /api/disputes/:id
+
+Get dispute details.
+
+\`\`\`yaml
+/api/disputes/{id}:
+  get:
+    summary: Get dispute details
+    tags: [Disputes]
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    responses:
+      200:
+        description: Dispute details
+      404:
+        description: Dispute not found
+\`\`\`
+
+## POST /api/disputes/:id/resolve
+
+Resolve a dispute (milestone or maintainer only).
+
+\`\`\`yaml
+/api/disputes/{id}/resolve:
+  post:
+    summary: Resolve a dispute
+    tags: [Disputes]
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              resolution:
+                type: string
+                enum: [in_favor_of_creator, in_favor_of_submitter, split]
+              notes:
+                type: string
+    responses:
+      200:
+        description: Dispute resolved
+\`\`\`


### PR DESCRIPTION
Closes #340

Adds YAML OpenAPI spec snippets for dispute creation, retrieval, and resolution endpoints in `docs/openapi-dispute-endpoints.md`.

**Wallet:**
- Stellar (USDC): `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`
- BNB (BSC): `0x6851F2cCD4C4EA991734FAA83c027A909f2703f3`