### PR TITLE
devops: add frontend Vitest coverage threshold enforcement

### DIFF
--- a/frontend/vite.config.d.ts
+++ b/frontend/vite.config.d.ts
@@ -1,2 +1,3 @@
 declare const _default: import("vite").UserConfig;
 export default _default;
+// Adding coverage threshold

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      thresholds: {
+        statements: 80,
+        branches: 70,
+        functions: 80,
+        lines: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
Closes #380

Adds Vitest coverage configuration with 80% threshold enforcement for statements, functions, and lines.

**Wallet:**
- Stellar (USDC): `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`
- BNB (BSC): `0x6851F2cCD4C4EA991734FAA83c027A909f2703f3`