### PR TITLE
docs: add Mermaid state machine diagram for BountyStatus transitions

### DIFF
--- a/docs/bounty-status-machine.md
+++ b/docs/bounty-status-machine.md
@@ -1,0 +1,35 @@
+# Bounty Status State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Open
+    Open --> Assigned: /attempt
+    Assigned --> InProgress: Work started
+    InProgress --> Submitted: PR created
+    Submitted --> InReview: /approve
+    InReview --> Approved: Review passed
+    InReview --> ChangesRequested: Review failed
+    ChangesRequested --> Submitted: Updated
+    Approved --> Completed: Payment released
+    Approved --> Disputed: Dispute raised
+    Disputed --> Resolved: Resolution
+    Completed --> [*]
+    Open --> Cancelled: Cancelled
+    Assigned --> Open: Unassigned
+    Resolved --> [*]
+```
+
+## Status Descriptions
+
+| Status | Description |
+|--------|-------------|
+| Open | Bounty available for claiming |
+| Assigned | Contributor claimed via /attempt |
+| InProgress | Work in progress |
+| Submitted | PR submitted for review |
+| InReview | Maintainer is reviewing |
+| Approved | Submission approved |
+| Completed | Payment sent, done |
+| Disputed | Conflict raised |
+| Resolved | Dispute resolved |
+| Cancelled | Bounty cancelled |


### PR DESCRIPTION
Closes #338

Adds a Mermaid state diagram visualizing all BountyStatus transitions from Open through Completed, including dispute handling.

**Wallet:**
- Stellar (USDC): `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`
- BNB (BSC): `0x6851F2cCD4C4EA991734FAA83c027A909f2703f3`