### PR TITLE
Virtualize bounty board rendering for large lists

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "stellar-bounty-board-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@tanstack/react-virtual": "^3.13.26",
         "lucide-react": "^1.11.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -27,13 +28,14 @@
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
         "jsdom": "^29.1.1",
-        "storybook": "^8.6.18",
+        "rollup-plugin-visualizer": "^5.12.0",
         "typescript": "^5.6.3",
         "vite": "^5.4.11",
         "vitest": "^4.1.7"
       }
     },
     "..": {
+      "name": "stellar-bounty-board",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -603,6 +605,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -620,6 +623,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -637,6 +641,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -654,6 +659,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -671,6 +677,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -688,6 +695,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -705,6 +713,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -722,6 +731,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -739,6 +749,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -756,6 +767,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -773,6 +785,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -790,6 +803,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -807,6 +821,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -824,6 +839,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -841,6 +857,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -858,6 +875,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -875,6 +893,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -892,6 +911,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -909,6 +929,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -926,6 +947,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -943,6 +965,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -960,6 +983,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -977,6 +1001,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -994,6 +1019,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1011,6 +1037,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1028,6 +1055,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2131,6 +2159,7 @@
       "integrity": "sha512-dRBP2TnX6fGdS0T2mXBHjkS/3Nlu1ra1huovZVFuM67CYMzrhM/3hX/zru1vWSC5rqY93ZaAhjMciPW4pK5mMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/theming": "8.6.18",
         "better-opn": "^3.0.2",
@@ -2163,6 +2192,7 @@
       "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2622,6 +2652,33 @@
         "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.26",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.26.tgz",
+      "integrity": "sha512-DosdgjOxCLahkn0o+ilmZYwEjo1glfMGuRT/j3PQ18yr5XqA8N/BCaL9IJ3B5TRl+nnzyK2IOFgAILwzN3a9xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.16.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.16.0.tgz",
+      "integrity": "sha512-Er2N7q3WOiH6y2JLxsxNX+u2/sLqSsL0bxFgDjuiPiA7vKhZRm+IzcS17vRee3GNXr64UsesA5CAp9yTiIYw9A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -3025,6 +3082,7 @@
       "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -3038,6 +3096,7 @@
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -3074,6 +3133,7 @@
       "integrity": "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "open": "^8.0.4"
       },
@@ -3147,6 +3207,7 @@
       "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -3166,6 +3227,7 @@
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -3180,6 +3242,7 @@
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -3263,6 +3326,90 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/color-convert": {
@@ -3390,6 +3537,7 @@
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -3458,6 +3606,7 @@
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -3507,6 +3656,7 @@
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3534,6 +3684,7 @@
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -3548,6 +3699,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3589,6 +3741,7 @@
       "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -3612,6 +3765,7 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -3688,6 +3842,7 @@
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-callable": "^1.2.7"
       },
@@ -3746,6 +3901,7 @@
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3760,12 +3916,23 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -3791,6 +3958,7 @@
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -3827,6 +3995,7 @@
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3850,6 +4019,7 @@
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -3863,6 +4033,7 @@
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3876,6 +4047,7 @@
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -3927,7 +4099,8 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
@@ -3935,6 +4108,7 @@
       "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -3952,6 +4126,7 @@
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4007,6 +4182,7 @@
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.4",
         "generator-function": "^2.0.0",
@@ -4034,6 +4210,7 @@
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "gopd": "^1.2.0",
@@ -4053,6 +4230,7 @@
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "which-typed-array": "^1.1.16"
       },
@@ -4111,6 +4289,7 @@
       "integrity": "sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -4547,6 +4726,7 @@
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4838,6 +5018,7 @@
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4892,6 +5073,7 @@
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -4986,6 +5168,7 @@
       "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ast-types": "^0.16.1",
         "esprima": "~4.0.0",
@@ -5022,6 +5205,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -5142,6 +5335,47 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.14.0.tgz",
+      "integrity": "sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^8.4.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/rollup/node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5155,6 +5389,7 @@
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -5205,6 +5440,7 @@
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -5276,6 +5512,7 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5314,6 +5551,7 @@
       "integrity": "sha512-p8seiSI6FiVY6P3V0pG+5v7c8pDMehMAFRWEhG5XqIBSQszzOjDnW2rNvm3odoLKfo3V3P6Cs6Hv9ILzymULyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/core": "8.6.18"
       },
@@ -5702,6 +5940,7 @@
       "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -6497,6 +6736,7 @@
       "integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.9",
@@ -6637,6 +6877,7 @@
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -6670,12 +6911,86 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@tanstack/react-virtual": "^3.13.26",
     "lucide-react": "^1.11.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import {
   ArrowUpDown,
 } from "lucide-react";
 import { toast } from 'sonner';
+import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   createBounty,
   exportReleasedPayoutsCsv,
@@ -135,6 +136,9 @@ const boardStatuses: Array<BountyStatus | "all"> = [
 ];
 
 type BountyAction = "reserve" | "submit" | "release" | "refund";
+type BoardRow =
+  | { type: "repo"; repo: string; bounties: Bounty[] }
+  | { type: "bounty"; bounty: Bounty };
 
 function repoOwner(repo: string): string {
   return repo.split("/")[0] ?? repo;
@@ -661,6 +665,35 @@ function App() {
     });
     return groups;
   }, [filteredBounties, repoRoute]);
+
+  const boardRows = useMemo<BoardRow[]>(() => {
+    return Object.entries(groupedBounties).flatMap(([repo, repoBounties]) => [
+      { type: "repo" as const, repo, bounties: repoBounties },
+      ...repoBounties.map((bounty) => ({ type: "bounty" as const, bounty })),
+    ]);
+  }, [groupedBounties]);
+
+  const boardVirtualizerParentRef = useRef<HTMLDivElement | null>(null);
+  const boardVirtualizer = useVirtualizer({
+    count: boardRows.length,
+    getScrollElement: () => boardVirtualizerParentRef.current,
+    getItemKey: (index) => {
+      const row = boardRows[index];
+      return row?.type === "repo" ? `repo:${row.repo}` : `bounty:${row?.bounty.id ?? index}`;
+    },
+    estimateSize: (index) => (boardRows[index]?.type === "repo" ? 142 : 360),
+    overscan: 5,
+    initialRect: { height: 800, width: 0 },
+  });
+  const virtualBoardRows = boardVirtualizer.getVirtualItems();
+  const renderedBoardRows =
+    virtualBoardRows.length > 0
+      ? virtualBoardRows
+      : boardRows.slice(0, Math.min(boardRows.length, 8)).map((row, index) => ({
+          index,
+          key: row.type === "repo" ? `repo:${row.repo}` : `bounty:${row.bounty.id}`,
+          start: index === 0 ? 0 : 142 + (index - 1) * 360,
+        }));
 
   // Derive whether any filter is currently active so EmptyState knows whether
   // to show the "Clear filters" CTA.
@@ -1256,140 +1289,83 @@ function App() {
                     <SkeletonBountyCard key={i} />
                   ))}
                 </div>
-              ) : Object.keys(groupedBounties).length > 0 ? (
-                <div className="board-list">
-                  {Object.entries(groupedBounties).map(([repo, repoBounties]) => (
-                    <div key={repo} className="repo-group">
-                      <div className="repo-group__header">
-                        <h3
-                          className="repo-group__title"
-                          onClick={() => navigate(`/repo/${repo.split('/')[0]}/${repo.split('/')[1]}`)}
-                          role="link"
-                          tabIndex={0}
-                          onKeyDown={(event) => {
-                            if (event.key === "Enter" || event.key === " ") {
-                              event.preventDefault();
-                              navigate(`/repo/${repo.split('/')[0]}/${repo.split('/')[1]}`);
-                            }
-                          }}
+              ) : boardRows.length > 0 ? (
+                <div
+                  className="board-list board-list--virtual"
+                  ref={boardVirtualizerParentRef}
+                  role="list"
+                  aria-label={`Bounty board with ${filteredBounties.length} bounties`}
+                >
+                  <div
+                    className="board-list__virtual-spacer"
+                    style={{ height: `${boardVirtualizer.getTotalSize()}px` }}
+                  >
+                    {renderedBoardRows.map((virtualRow) => {
+                      const row = boardRows[virtualRow.index];
+                      if (!row) return null;
+
+                      return (
+                        <div
+                          className="board-list__virtual-row"
+                          data-index={virtualRow.index}
+                          key={virtualRow.key}
+                          ref={boardVirtualizer.measureElement}
+                          role="listitem"
+                          style={{ transform: `translateY(${virtualRow.start}px)` }}
                         >
-                          {repo}
-                        </h3>
-                        <span className="repo-count">{repoBounties.length} bounties</span>
-                      </div>
-                      <div className="repo-group__metrics">
-                        <div className="repo-metric">
-                          <span className="repo-metric__label">Open</span>
-                          <span className="repo-metric__value">{repoBounties.filter(b => b.status === 'open').length}</span>
-                        </div>
-                        <div className="repo-metric">
-                          <span className="repo-metric__label">Funded</span>
-                          <span className="repo-metric__value">{repoBounties.reduce((sum, b) => sum + b.amount, 0)} XLM</span>
-                        </div>
-                        <div className="repo-metric">
-                          <span className="repo-metric__label">Paid</span>
-                          <span className="repo-metric__value">{repoBounties.filter(b => b.status === 'released').reduce((sum, b) => sum + b.amount, 0)} XLM</span>
-                        </div>
-                      </div>
-                      <div className="repo-group__bounties">
-                        {repoBounties.map((bounty) => (
-                          <article
-                            className="bounty-card"
-                            key={bounty.id}
-                            role="link"
-                            tabIndex={0}
-                            onClick={() => navigate(`/bounties/${encodeURIComponent(bounty.id)}`)}
-                            onKeyDown={(event) => {
-                              if (event.key === "Enter" || event.key === " ") {
-                                event.preventDefault();
-                                navigate(`/bounties/${encodeURIComponent(bounty.id)}`);
-                              }
-                            }}
-                          >
-                            <div className="bounty-card__top">
-                              <div>
-                                <span
-                                  className={`status-pill status-pill--${bounty.status}`}
-                                  title={statusCopy[bounty.status].description}
-                                  aria-label={`${statusCopy[bounty.status].label}: ${statusCopy[bounty.status].description}`}
+                          {row.type === "repo" ? (
+                            <div className="repo-group">
+                              <div className="repo-group__header">
+                                <h3
+                                  className="repo-group__title"
+                                  onClick={() => navigate(`/repo/${row.repo.split('/')[0]}/${row.repo.split('/')[1]}`)}
+                                  role="link"
+                                  tabIndex={0}
+                                  onKeyDown={(event) => {
+                                    if (event.key === "Enter" || event.key === " ") {
+                                      event.preventDefault();
+                                      navigate(`/repo/${row.repo.split('/')[0]}/${row.repo.split('/')[1]}`);
+                                    }
+                                  }}
                                 >
-                                  {statusCopy[bounty.status].label}
-                                </span>
-                                <h3>{bounty.title}</h3>
+                                  {row.repo}
+                                </h3>
+                                <span className="repo-count">{row.bounties.length} bounties</span>
                               </div>
-                              <div className="amount-chip">
-                                {bounty.amount} {bounty.tokenSymbol}
-                              </div>
-                            </div>
-
-                            <p className="bounty-summary">{bounty.summary}</p>
-
-                            <div className="meta-grid">
-                              <div>
-                                <span className="meta-label">Issue</span>
-                                <strong>
-                                  <a
-                                    className="inline-link"
-                                    href={`https://github.com/${bounty.repo}/issues/${bounty.issueNumber}`}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                  >
-                                    {bounty.repo} #{bounty.issueNumber}
-                                  </a>
-                                </strong>
-                              </div>
-                              <div>
-                                <span className="meta-label">Deadline</span>
-                                <strong>{formatRelativeDeadline(bounty.deadlineAt)}</strong>
-                              </div>
-                              <div>
-                                <span className="meta-label">Maintainer</span>
-                                <strong>{shortAddress(bounty.maintainer)}</strong>
-                              </div>
-                              <div>
-                                <span className="meta-label">Contributor</span>
-                                <strong>{bounty.contributor ? shortAddress(bounty.contributor) : "Open"}</strong>
-                              </div>
-                              {bounty.status === "released" && bounty.releasedTxHash && (
-                                <div>
-                                  <span className="meta-label">Release tx</span>
-                                  <strong>{`${bounty.releasedTxHash.slice(0, 10)}...`}</strong>
+                              <div className="repo-group__metrics">
+                                <div className="repo-metric">
+                                  <span className="repo-metric__label">Open</span>
+                                  <span className="repo-metric__value">
+                                    {row.bounties.filter((bounty) => bounty.status === "open").length}
+                                  </span>
                                 </div>
-                              )}
-                              {bounty.status === "refunded" && bounty.refundedTxHash && (
-                                <div>
-                                  <span className="meta-label">Refund tx</span>
-                                  <strong>{`${bounty.refundedTxHash.slice(0, 10)}...`}</strong>
+                                <div className="repo-metric">
+                                  <span className="repo-metric__label">Funded</span>
+                                  <span className="repo-metric__value">
+                                    {row.bounties.reduce((sum, bounty) => sum + bounty.amount, 0)} XLM
+                                  </span>
                                 </div>
-                              )}
+                                <div className="repo-metric">
+                                  <span className="repo-metric__label">Paid</span>
+                                  <span className="repo-metric__value">
+                                    {row.bounties
+                                      .filter((bounty) => bounty.status === "released")
+                                      .reduce((sum, bounty) => sum + bounty.amount, 0)} XLM
+                                  </span>
+                                </div>
+                              </div>
                             </div>
-
-                            <div className="chip-row">
-                              {bounty.labels.map((label) => (
-                                <span className="chip" key={label.name}>
-                                  {label.name}
-                                </span>
-                              ))}
-                            </div>
-
-                            <p className="status-helper">
-                              <strong>{statusCopy[bounty.status].label}:</strong> {statusCopy[bounty.status].description}
-                            </p>
-
-                            {bounty.submissionUrl && (
-                              <a className="submission-link" href={bounty.submissionUrl} target="_blank" rel="noreferrer">
-                                Review submission <ArrowUpRight size={16} />
-                              </a>
-                            )}
-
-                            <div className="action-row">
-                              {(actionCopy[bounty.status] ?? []).map((action) => renderActionButton(bounty, action))}
-                            </div>
-                          </article>
-                        ))}
-                      </div>
-                    </div>
-                  ))}
+                          ) : (
+                            <BountyCard
+                              bounty={row.bounty}
+                              onOpen={handleOpenBounty}
+                              renderActionButton={renderActionButton}
+                            />
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
               ) : (
                 <EmptyState

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -686,13 +686,14 @@ function App() {
     initialRect: { height: 800, width: 0 },
   });
   const virtualBoardRows = boardVirtualizer.getVirtualItems();
+  const getBoardRowSize = (row: BoardRow) => (row.type === "repo" ? 142 : 360);
   const renderedBoardRows =
     virtualBoardRows.length > 0
       ? virtualBoardRows
       : boardRows.slice(0, Math.min(boardRows.length, 8)).map((row, index) => ({
           index,
           key: row.type === "repo" ? `repo:${row.repo}` : `bounty:${row.bounty.id}`,
-          start: index === 0 ? 0 : 142 + (index - 1) * 360,
+          start: boardRows.slice(0, index).reduce((sum, previousRow) => sum + getBoardRowSize(previousRow), 0),
         }));
 
   // Derive whether any filter is currently active so EmptyState knows whether
@@ -1298,6 +1299,7 @@ function App() {
                 >
                   <div
                     className="board-list__virtual-spacer"
+                    role="presentation"
                     style={{ height: `${boardVirtualizer.getTotalSize()}px` }}
                   >
                     {renderedBoardRows.map((virtualRow) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -674,6 +674,7 @@ function App() {
   }, [groupedBounties]);
 
   const boardVirtualizerParentRef = useRef<HTMLDivElement | null>(null);
+  const getBoardRowSize = (row?: BoardRow) => (row?.type === "repo" ? 142 : 360);
   const boardVirtualizer = useVirtualizer({
     count: boardRows.length,
     getScrollElement: () => boardVirtualizerParentRef.current,
@@ -681,12 +682,11 @@ function App() {
       const row = boardRows[index];
       return row?.type === "repo" ? `repo:${row.repo}` : `bounty:${row?.bounty.id ?? index}`;
     },
-    estimateSize: (index) => (boardRows[index]?.type === "repo" ? 142 : 360),
+    estimateSize: (index) => getBoardRowSize(boardRows[index]),
     overscan: 5,
     initialRect: { height: 800, width: 0 },
   });
   const virtualBoardRows = boardVirtualizer.getVirtualItems();
-  const getBoardRowSize = (row: BoardRow) => (row.type === "repo" ? 142 : 360);
   const renderedBoardRows =
     virtualBoardRows.length > 0
       ? virtualBoardRows

--- a/frontend/src/App.virtualization.test.tsx
+++ b/frontend/src/App.virtualization.test.tsx
@@ -75,7 +75,25 @@ beforeEach(() => {
 
     observe(target: Element) {
       const height = target.classList?.contains("board-list--virtual") ? 800 : 360;
-      this.callback([{ target, contentRect: { height, width: 1200 } as DOMRectReadOnly } as ResizeObserverEntry], this);
+      this.callback(
+        [
+          {
+            target,
+            contentRect: {
+              bottom: height,
+              height,
+              left: 0,
+              right: 1200,
+              top: 0,
+              width: 1200,
+              x: 0,
+              y: 0,
+              toJSON: () => ({}),
+            } as DOMRectReadOnly,
+          } as ResizeObserverEntry,
+        ],
+        this,
+      );
     }
 
     unobserve() {}
@@ -114,10 +132,15 @@ describe("virtualized bounty board", () => {
     const board = await screen.findByLabelText("Bounty board with 500 bounties");
     fireEvent.scroll(board, { target: { scrollTop: 0 } });
 
+    const viewportHeight = 800;
+    const estimatedCardHeight = 360;
+    const overscan = 5;
+    const maxMountedCards = Math.ceil(viewportHeight / estimatedCardHeight) + overscan * 2 + 5;
+
     await waitFor(() => {
       const mountedCards = container.querySelectorAll(".bounty-card");
       expect(mountedCards.length).toBeGreaterThan(0);
-      expect(mountedCards.length).toBeLessThan(40);
+      expect(mountedCards.length).toBeLessThanOrEqual(maxMountedCards);
     });
 
     expect(screen.queryAllByText(/^Virtual bounty /)).toHaveLength(container.querySelectorAll(".bounty-card").length);

--- a/frontend/src/App.virtualization.test.tsx
+++ b/frontend/src/App.virtualization.test.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+  Toaster: () => null,
+}));
+
+vi.mock("./api", () => ({
+  createBounty: vi.fn(),
+  exportReleasedPayoutsCsv: vi.fn(),
+  getBounty: vi.fn(),
+  listBounties: vi.fn(),
+  listOpenIssues: vi.fn().mockResolvedValue([]),
+  refundBounty: vi.fn(),
+  releaseBounty: vi.fn(),
+  reserveBounty: vi.fn(),
+  submitBounty: vi.fn(),
+}));
+
+vi.mock("./recommendations", () => ({
+  createDefaultProfile: () => ({
+    preferredTokens: [],
+    skills: [],
+    minReward: 0,
+    maxEstimatedHours: 0,
+  }),
+  generateRecommendations: () => [],
+  updateProfileFromBounties: (profile: unknown) => profile,
+}));
+
+vi.mock("./RecommendedBounties", () => ({
+  default: () => null,
+}));
+
+import * as api from "./api";
+import App from "./App";
+import { Bounty } from "./types";
+
+const makeBounty = (index: number): Bounty => ({
+  id: `BNTY-${index}`,
+  repo: "ritik4ever/stellar-bounty-board",
+  issueNumber: index + 1,
+  title: `Virtual bounty ${index}`,
+  summary: "A performance test bounty",
+  maintainer: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  tokenSymbol: "XLM",
+  amount: 100,
+  labels: [],
+  status: "open",
+  createdAt: 1_700_000_000 + index,
+  deadlineAt: 9_999_999_999,
+  version: 1,
+  events: [],
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(api.listOpenIssues).mockResolvedValue([]);
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+  globalThis.ResizeObserver = class ResizeObserver {
+    private readonly callback: ResizeObserverCallback;
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+    }
+
+    observe(target: Element) {
+      const height = target.classList?.contains("board-list--virtual") ? 800 : 360;
+      this.callback([{ target, contentRect: { height, width: 1200 } as DOMRectReadOnly } as ResizeObserverEntry], this);
+    }
+
+    unobserve() {}
+
+    disconnect() {}
+  };
+
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get() {
+      return this.classList?.contains("board-list--virtual") ? 800 : 0;
+    },
+  });
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getBoundingClientRect(this: HTMLElement) {
+    const height = this.classList?.contains("board-list--virtual") ? 800 : 360;
+    return {
+      bottom: height,
+      height,
+      left: 0,
+      right: 1200,
+      top: 0,
+      width: 1200,
+      x: 0,
+      y: 0,
+      toJSON: () => undefined,
+    };
+  });
+});
+
+describe("virtualized bounty board", () => {
+  it("only mounts the visible bounty cards plus overscan for large lists", async () => {
+    vi.mocked(api.listBounties).mockResolvedValue(Array.from({ length: 500 }, (_, index) => makeBounty(index)));
+
+    const { container } = render(<App />);
+
+    const board = await screen.findByLabelText("Bounty board with 500 bounties");
+    fireEvent.scroll(board, { target: { scrollTop: 0 } });
+
+    await waitFor(() => {
+      const mountedCards = container.querySelectorAll(".bounty-card");
+      expect(mountedCards.length).toBeGreaterThan(0);
+      expect(mountedCards.length).toBeLessThan(40);
+    });
+
+    expect(screen.queryAllByText(/^Virtual bounty /)).toHaveLength(container.querySelectorAll(".bounty-card").length);
+  });
+});

--- a/frontend/src/App.virtualization.test.tsx
+++ b/frontend/src/App.virtualization.test.tsx
@@ -125,7 +125,12 @@ beforeEach(() => {
 
 describe("virtualized bounty board", () => {
   it("only mounts the visible bounty cards plus overscan for large lists", async () => {
-    vi.mocked(api.listBounties).mockResolvedValue(Array.from({ length: 500 }, (_, index) => makeBounty(index)));
+    vi.mocked(api.listBounties).mockResolvedValue(
+      Array.from({ length: 500 }, (_, index) => ({
+        ...makeBounty(index),
+        repo: `ritik4ever/stellar-bounty-board-${Math.floor(index / 50)}`,
+      })),
+    );
 
     const { container } = render(<App />);
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -148,10 +148,19 @@ async function requestBlob(path: string, options: RequestOptions = {}): Promise<
   throw formatRetryError(retryLabel, retryAttempts, message);
 }
 
-
+export async function listBounties(signal?: AbortSignal): Promise<Bounty[]> {
   const body = await requestJson<{ data: Bounty[] }>("/bounties", {
     retry: true,
     retryLabel: "Loading bounties",
+    signal,
+  });
+  return body.data;
+}
+
+export async function getBounty(id: string, signal?: AbortSignal): Promise<Bounty> {
+  const body = await requestJson<{ data: Bounty }>(`/bounties/${encodeURIComponent(id)}`, {
+    retry: true,
+    retryLabel: "Loading bounty",
     signal,
   });
   return body.data;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -349,6 +349,27 @@ textarea {
   gap: 14px;
 }
 
+.board-list--virtual {
+  display: block;
+  max-height: min(78vh, 900px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 6px;
+  scrollbar-gutter: stable;
+}
+
+.board-list__virtual-spacer {
+  position: relative;
+  width: 100%;
+}
+
+.board-list__virtual-row {
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
 .profile-controls label {
   display: grid;
   gap: 8px;

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "composite": true,
     "skipLibCheck": true,
+    "target": "ES2020",
+    "lib": ["ES2020"],
     "module": "ESNext",
     "moduleResolution": "Node",
     "allowSyntheticDefaultImports": true


### PR DESCRIPTION
Closes #360.

## Summary
- Adds `@tanstack/react-virtual` to render only visible bounty-board rows plus overscan instead of mounting every repo/card at once.
- Keeps repo headers and the existing memoized `BountyCard` interactions keyboard-accessible inside the virtual list.
- Adds a focused regression test with 500 bounties to verify the board mounts only a small visible subset.
- Restores missing frontend API exports/config needed by the touched code path so the focused test can run.

## Verification
- `npm --prefix frontend test -- App.virtualization.test.tsx` passes.
- `npm --prefix frontend run build` is still blocked by pre-existing project-wide TypeScript issues unrelated to this change, including duplicate `scoreMatch` exports in `src/recommendations.ts`, `main.tsx` importing a `.tsx` extension without `allowImportingTsExtensions`, legacy `metaTags.test.ts` location typing, and stale `toast.test.tsx` fixture types.

Note: I saw #428, but that approach incrementally renders batches of 50 cards. This PR uses actual viewport virtualization with overscan, matching the issue's visible-row requirement more directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Virtual scrolling for the bounty board for smoother, faster browsing of large lists.
  * New API endpoints to fetch bounty listings and individual bounty details.

* **Tests**
  * Added tests validating virtualized board rendering, measurement, and scroll behavior.

* **Chores**
  * Added virtualization dependency and updated build/config to support the newer JS target.


<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->