### PR TITLE
feat: add GET /api/bounties/by-issue lookup endpoint (Fixes #258)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -18,6 +18,7 @@ import {
   getMaintainerMetrics,
   getGlobalMetrics,
   getLeaderboard,
+  findBountyByIssue,
 } from "./services/bountyStore";
 import { listOpenIssues } from "./services/openIssues";
 import {
@@ -353,6 +354,37 @@ app.get("/api/bounties/:id/events", (req: Request, res: Response) => {
   try {
     const events = getBountyEvents(parseId(req.params.id));
     res.json({ data: events });
+  } catch (error) {
+    sendError(res, req, error);
+  }
+});
+
+app.get("/api/bounties/by-issue", (req: Request, res: Response) => {
+  try {
+    const repo = typeof req.query.repo === "string" ? req.query.repo.trim() : undefined;
+    const issueRaw = typeof req.query.issue === "string" ? req.query.issue.trim() : undefined;
+
+    if (!repo) {
+      jsonError(res, req, 400, "repo query parameter is required.");
+      return;
+    }
+    if (!issueRaw) {
+      jsonError(res, req, 400, "issue query parameter is required.");
+      return;
+    }
+
+    const issueNumber = Number(issueRaw);
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+      jsonError(res, req, 400, "issue must be a positive integer.");
+      return;
+    }
+
+    const bounty = findBountyByIssue(repo, issueNumber);
+    if (!bounty) {
+      jsonError(res, req, 404, "No bounty found for the given repo and issue number.");
+      return;
+    }
+    res.json({ data: bounty });
   } catch (error) {
     sendError(res, req, error);
   }

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -252,6 +252,34 @@ registry.registerPath({
 // ---------------------------------------------------------------------------
 // Generator
 // ---------------------------------------------------------------------------
+registry.registerPath({
+  method: "get",
+  path: "/api/bounties/by-issue",
+  tags: ["Bounties"],
+  summary: "Look up a bounty by GitHub repo and issue number",
+  description:
+    "Returns the bounty attached to a specific GitHub issue. " +
+    "Use this when you have a repo (owner/repo) and issue number and need to check " +
+    "whether a bounty exists for it. Returns 404 if no bounty is found.",
+  request: {
+    query: z.object({
+      repo: z.string().trim().min(1).openapi({
+        example: "owner/repo",
+        description: "GitHub repository in owner/repo format.",
+      }),
+      issue: z.string().trim().min(1).openapi({
+        example: "42",
+        description: "GitHub issue number (positive integer).",
+      }),
+    }),
+  },
+  responses: {
+    200: bountyDataResponse("Bounty found for the given repo and issue."),
+    400: errorResponse("Missing or invalid query parameters."),
+    404: errorResponse("No bounty found for the given repo and issue number."),
+  },
+});
+
 export function generateOpenApiDocument() {
   const generator = new OpenApiGeneratorV31(registry.definitions);
   return generator.generateDocument({

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -267,8 +267,8 @@ registry.registerPath({
         example: "owner/repo",
         description: "GitHub repository in owner/repo format.",
       }),
-      issue: z.string().trim().min(1).openapi({
-        example: "42",
+      issue: z.coerce.number().int().positive().openapi({
+        example: 42,
         description: "GitHub issue number (positive integer).",
       }),
     }),

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -677,6 +677,13 @@ export function listBountyAuditLogs(
   };
 }
 
+export function findBountyByIssue(repo: string, issueNumber: number): BountyRecord | undefined {
+  const records = listBounties();
+  return records.find(
+    (b) => b.repo.toLowerCase() === repo.toLowerCase() && b.issueNumber === issueNumber,
+  );
+}
+
 export function getBountyEvents(bountyId: string): BountyEvent[] {
   const records = listBounties();
   const bounty = records.find((b) => b.id === bountyId);

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -297,6 +297,74 @@ describe("API — bounty lifecycle routes", () => {
   });
 });
 
+describe("GET /api/bounties/by-issue", () => {
+  it("returns bounty when found by repo and issue number", async () => {
+    const app = await getApp();
+    const { body: created } = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+
+    const res = await request(app)
+      .get("/api/bounties/by-issue")
+      .query({ repo: validCreateBody.repo, issue: validCreateBody.issueNumber })
+      .expect(200);
+
+    expect(res.body.data.id).toBe(created.data.id);
+    expect(res.body.data.repo).toBe(validCreateBody.repo);
+    expect(res.body.data.issueNumber).toBe(validCreateBody.issueNumber);
+  });
+
+  it("returns 404 when no bounty matches", async () => {
+    const app = await getApp();
+    const res = await request(app)
+      .get("/api/bounties/by-issue")
+      .query({ repo: "owner/nonexistent", issue: 999 })
+      .expect(404);
+
+    expect(res.body.error).toMatch(/no bounty found/i);
+  });
+
+  it("returns 400 when repo param is missing", async () => {
+    const app = await getApp();
+    const res = await request(app)
+      .get("/api/bounties/by-issue")
+      .query({ issue: 42 })
+      .expect(400);
+
+    expect(res.body.error).toMatch(/repo/i);
+  });
+
+  it("returns 400 when issue param is missing", async () => {
+    const app = await getApp();
+    const res = await request(app)
+      .get("/api/bounties/by-issue")
+      .query({ repo: "owner/repo" })
+      .expect(400);
+
+    expect(res.body.error).toMatch(/issue/i);
+  });
+
+  it("returns 400 when issue is not a positive integer", async () => {
+    const app = await getApp();
+    const res = await request(app)
+      .get("/api/bounties/by-issue")
+      .query({ repo: "owner/repo", issue: "abc" })
+      .expect(400);
+
+    expect(res.body.error).toMatch(/positive integer/i);
+  });
+
+  it("matches repo case-insensitively", async () => {
+    const app = await getApp();
+    await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+
+    const res = await request(app)
+      .get("/api/bounties/by-issue")
+      .query({ repo: "OWNER/REPO-NAME", issue: validCreateBody.issueNumber })
+      .expect(200);
+
+    expect(res.body.data.repo).toBe(validCreateBody.repo);
+  });
+});
+
 describe("GET /api/leaderboard", () => {
   it("returns empty array when no bounties exist", async () => {
     const app = await getApp();

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -352,6 +352,24 @@ describe("GET /api/bounties/by-issue", () => {
     expect(res.body.error).toMatch(/positive integer/i);
   });
 
+  it("returns 400 when issue is zero or negative", async () => {
+    const app = await getApp();
+
+    const zeroRes = await request(app)
+      .get("/api/bounties/by-issue")
+      .query({ repo: "owner/repo", issue: 0 })
+      .expect(400);
+
+    expect(zeroRes.body.error).toMatch(/positive/i);
+
+    const negativeRes = await request(app)
+      .get("/api/bounties/by-issue")
+      .query({ repo: "owner/repo", issue: -1 })
+      .expect(400);
+
+    expect(negativeRes.body.error).toMatch(/positive/i);
+  });
+
   it("matches repo case-insensitively", async () => {
     const app = await getApp();
     await request(app).post("/api/bounties").send(validCreateBody).expect(201);


### PR DESCRIPTION
## Summary

Adds a new `GET /api/bounties/by-issue?repo=owner/repo&issue=123` endpoint that lets the frontend look up whether a GitHub issue already has a bounty, without fetching the entire bounty list.

## Changes

- **`bountyStore.ts`**: Added `findBountyByIssue(repo, issueNumber)` — case-insensitive repo match
- **`app.ts`**: New route `GET /api/bounties/by-issue` with full query param validation
- **`openapi.ts`**: Documented the endpoint in the OpenAPI spec
- **`api.test.ts`**: 6 new tests covering all acceptance criteria

## Acceptance Criteria

- [x] Returns the `Bounty` object if found, `404` if not
- [x] Both `repo` and `issue` params required — missing params return 400
- [x] Documented in OpenAPI spec
- [x] Unit test covers: found, not found, missing params
- [x] Case-insensitive repo matching

## Test Results

All 6 new tests pass.

Closes #258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve bounties by repository and issue number, with parameter validation and appropriate error handling for missing or invalid inputs.

* **Tests**
  * Added test coverage for the new bounty lookup endpoint, including successful retrievals, error cases, and case-insensitive repository matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->