### PR TITLE
feat: add pagination to GET /api/bounties/:id/events (Fixes #249)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -15,6 +15,7 @@ import {
   reserveBounty,
   submitBounty,
   getBountyEvents,
+  getBountyEventsPaginated,
   getMaintainerMetrics,
   getGlobalMetrics,
   getLeaderboard,
@@ -351,8 +352,10 @@ app.get("/api/open-issues", (_req: Request, res: Response) => {
 
 app.get("/api/bounties/:id/events", (req: Request, res: Response) => {
   try {
-    const events = getBountyEvents(parseId(req.params.id));
-    res.json({ data: events });
+    const page = parsePaginationValue(req.query.page, "page", 1, 1);
+    const pageSize = parsePaginationValue(req.query.pageSize, "pageSize", 20, 1, 50);
+    const result = getBountyEventsPaginated(parseId(req.params.id), { page, pageSize });
+    res.json(result);
   } catch (error) {
     sendError(res, req, error);
   }
@@ -367,7 +370,10 @@ app.get("/api/bounties/:id", (req: Request, res: Response) => {
       jsonError(res, req, 404, "Bounty not found.");
       return;
     }
-    res.json({ data: bounty });
+    // Only include the last 10 events for backward compat; full list via /events endpoint
+    const events = bounty.events ?? [];
+    const recentEvents = events.length <= 10 ? events : events.slice(-10);
+    res.json({ data: { ...bounty, events: recentEvents } });
   } catch (error) {
     sendError(res, req, error, 400);
   }

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -686,6 +686,32 @@ export function getBountyEvents(bountyId: string): BountyEvent[] {
   return bounty.events ?? [];
 }
 
+export interface PaginatedEvents {
+  data: BountyEvent[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export function getBountyEventsPaginated(
+  bountyId: string,
+  options: { page?: number; pageSize?: number } = {},
+): PaginatedEvents {
+  const { page = 1, pageSize = 20 } = options;
+  const records = listBounties();
+  const bounty = records.find((b) => b.id === bountyId);
+  if (!bounty) {
+    throw new Error(`Bounty ${bountyId} not found.`);
+  }
+
+  const allEvents = [...(bounty.events ?? [])].sort((a, b) => b.timestamp - a.timestamp);
+  const total = allEvents.length;
+  const start = (page - 1) * pageSize;
+  const data = allEvents.slice(start, start + pageSize);
+
+  return { data, total, page, pageSize };
+}
+
 export interface MaintainerMetrics {
   totalBounties: number;
   openCount: number;

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -297,6 +297,78 @@ describe("API — bounty lifecycle routes", () => {
   });
 });
 
+describe("GET /api/bounties/:id/events (paginated)", () => {
+  it("returns paginated events with default params", async () => {
+    const app = await getApp();
+    const { body: created } = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+    const id = created.data.id as string;
+
+    // Reserve to generate a second event
+    await request(app).post(`/api/bounties/${id}/reserve`).send({ contributor: CONTRIBUTOR }).expect(200);
+
+    const res = await request(app).get(`/api/bounties/${id}/events`).expect(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.total).toBe(2);
+    expect(res.body.page).toBe(1);
+    expect(res.body.pageSize).toBe(20);
+  });
+
+  it("events are ordered by timestamp descending", async () => {
+    const app = await getApp();
+    const { body: created } = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+    const id = created.data.id as string;
+
+    await request(app).post(`/api/bounties/${id}/reserve`).send({ contributor: CONTRIBUTOR }).expect(200);
+    await request(app)
+      .post(`/api/bounties/${id}/submit`)
+      .send({ contributor: CONTRIBUTOR, submissionUrl: "https://github.com/owner/repo/pull/1" })
+      .expect(200);
+
+    const res = await request(app).get(`/api/bounties/${id}/events`).expect(200);
+    const timestamps = res.body.data.map((e: { timestamp: number }) => e.timestamp);
+    for (let i = 1; i < timestamps.length; i++) {
+      expect(timestamps[i - 1]).toBeGreaterThanOrEqual(timestamps[i]);
+    }
+  });
+
+  it("supports page and pageSize params", async () => {
+    const app = await getApp();
+    const { body: created } = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+    const id = created.data.id as string;
+
+    await request(app).post(`/api/bounties/${id}/reserve`).send({ contributor: CONTRIBUTOR }).expect(200);
+    await request(app)
+      .post(`/api/bounties/${id}/submit`)
+      .send({ contributor: CONTRIBUTOR, submissionUrl: "https://github.com/owner/repo/pull/1" })
+      .expect(200);
+
+    const page1 = await request(app).get(`/api/bounties/${id}/events`).query({ page: 1, pageSize: 1 }).expect(200);
+    expect(page1.body.data).toHaveLength(1);
+    expect(page1.body.total).toBe(3);
+    expect(page1.body.page).toBe(1);
+    expect(page1.body.pageSize).toBe(1);
+
+    const page2 = await request(app).get(`/api/bounties/${id}/events`).query({ page: 2, pageSize: 1 }).expect(200);
+    expect(page2.body.data).toHaveLength(1);
+    expect(page2.body.page).toBe(2);
+  });
+
+  it("returns 400 for pageSize above 50", async () => {
+    const app = await getApp();
+    const { body: created } = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+    const id = created.data.id as string;
+
+    const res = await request(app).get(`/api/bounties/${id}/events`).query({ pageSize: 51 }).expect(400);
+    expect(res.body.error).toMatch(/pageSize/i);
+  });
+
+  it("returns 400 for unknown bounty id", async () => {
+    const app = await getApp();
+    const res = await request(app).get("/api/bounties/BNT-9999/events").expect(400);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+});
+
 describe("GET /api/leaderboard", () => {
   it("returns empty array when no bounties exist", async () => {
     const app = await getApp();


### PR DESCRIPTION
## Summary

Extracts the bounty events endpoint into a dedicated paginated `GET /api/bounties/:id/events` so bounties with many lifecycle events don't inflate the payload unnecessarily.

## Changes

- **`bountyStore.ts`**: Added `getBountyEventsPaginated()` returning `{ data, total, page, pageSize }`
- **`app.ts`**: Updated `GET /api/bounties/:id/events` to support `?page` and `?pageSize` (max 50) query params
- **`app.ts`**: Full bounty response (`GET /api/bounties/:id`) retains only the last 10 events for backward compat
- **`api.test.ts`**: 5 new tests covering all acceptance criteria

## Acceptance Criteria

- [x] Returns `{ data: BountyEvent[], total, page, pageSize }`
- [x] Events ordered by `timestamp` descending by default
- [x] Supports `?page` and `?pageSize` (max 50)
- [x] Existing full bounty response retains the last 10 events for backward compat

## Test Results

All 5 new tests pass.

Closes #249