### PR TITLE
feat(frontend): add urgency-based expiration status badge color coding

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,7 +39,7 @@ import SubmissionChecklistModal, { type SubmissionFormData } from "./SubmissionC
 import { BountyRecommendation, ContributorProfile, createDefaultProfile, generateRecommendations, updateProfileFromBounties } from "./recommendations";
 import RecommendedBounties from "./RecommendedBounties";
 import { statusCopy, actionCopy, readInitialFilters, FilterState, statusOptions, statusGlossary, sortOptions } from "./constants";
-import { filterBounties, getRewardBounds, getActiveRewardLabel, getContributorMetrics, getUniqueRepos, getUniqueTokenSymbols, getRepoMetrics, sortBounties, debounce, SortOption, SortState, xlmToUsd } from "./utils";
+import { filterBounties, getRewardBounds, getActiveRewardLabel, getContributorMetrics, getUniqueRepos, getUniqueTokenSymbols, getRepoMetrics, sortBounties, debounce, SortOption, SortState, xlmToUsd, getUrgencyClass } from "./utils";
 import { Bounty, CreateBountyPayload, OpenIssue, BountyStatus } from "./types";
 
 import GitHubIssuePreviewCard from "./GitHubIssuePreviewCard";
@@ -227,7 +227,7 @@ const BountyCard = memo(function BountyCard({ bounty, onOpen, renderActionButton
       <div className="bounty-card__top">
         <div>
           <span
-            className={`status-pill status-pill--${bounty.status}`}
+            className={`status-pill status-pill--${bounty.status} status-pill--${getUrgencyClass(bounty)}`}
             title={statusCopy[bounty.status].description}
             aria-label={`${statusCopy[bounty.status].label}: ${statusCopy[bounty.status].description}`}
           >

--- a/frontend/src/BountyDetailPage.tsx
+++ b/frontend/src/BountyDetailPage.tsx
@@ -6,6 +6,7 @@ import CopyIcon from "./CopyIcons";
 import UsdAmount from "./UsdAmount";
 import type { Bounty, BountyEvent, BountyStatus } from "./types";
 import { updateSocialMetaTags } from "./metaTags";
+import { getUrgencyClass } from "./utils";
 
 type BountyAction = "reserve" | "submit" | "release" | "refund";
 
@@ -188,7 +189,7 @@ export default function BountyDetailPage({
               )}
               <div>
                 <span
-                  className={`status-pill status-pill--${bounty.status}`}
+                  className={`status-pill status-pill--${bounty.status} status-pill--${getUrgencyClass(bounty)}`}
                   title={statusCopy[bounty.status].description}
                 >
                   {statusCopy[bounty.status].label}

--- a/frontend/src/RecommendedBounties.tsx
+++ b/frontend/src/RecommendedBounties.tsx
@@ -3,6 +3,7 @@ import { ArrowUpRight, Star, TrendingUp } from "lucide-react";
 import { BountyRecommendation } from "./recommendations";
 import { statusCopy } from "./constants";
 import UsdAmount from "./UsdAmount";
+import { getUrgencyClass } from "./utils";
 
 interface RecommendedBountiesProps {
   recommendations: BountyRecommendation[];
@@ -59,7 +60,7 @@ function BountyRecommendationCard({ recommendation }: { recommendation: BountyRe
       <div className="bounty-card__top">
         <div>
           <span
-            className={`status-pill status-pill--${bounty.status}`}
+            className={`status-pill status-pill--${bounty.status} status-pill--${getUrgencyClass(bounty)}`}
             title={statusCopy[bounty.status].description}
             aria-label={`${statusCopy[bounty.status].label}: ${statusCopy[bounty.status].description}`}
           >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1118,6 +1118,32 @@ select {
   color: #8b4035;
 }
 
+/* Urgency-based color overrides for open/reserved bounties */
+.status-pill--urgency-plenty {
+  background: var(--mint-soft);
+  color: #0d4736;
+}
+
+.status-pill--urgency-warning {
+  background: #fff3cd;
+  color: #856404;
+}
+
+.status-pill--urgency-urgent {
+  background: #f8d7da;
+  color: #842029;
+}
+
+.status-pill--urgency-ended {
+  background: #e2e3e5;
+  color: #41464b;
+}
+
+.status-pill--urgency-disputed {
+  background: #cfe2ff;
+  color: #084298;
+}
+
 .amount-chip {
   background: var(--ink);
   color: #fff7ef;

--- a/frontend/src/urgency.test.ts
+++ b/frontend/src/urgency.test.ts
@@ -82,6 +82,16 @@ describe("getUrgencyLevel", () => {
     expect(getUrgencyLevel(bounty, NOW)).toBe("urgent");
   });
 
+  it("returns 'warning' for reserved bounty with >7 days remaining", () => {
+    const bounty = makeBounty({
+      status: "reserved",
+      deadlineAt: NOW + 10 * 24 * 60 * 60, // 10 days left
+    });
+    // "plenty" (green) is reserved for "open" bounties only;
+    // "reserved" bounties always show at least "warning" to indicate active assignment.
+    expect(getUrgencyLevel(bounty, NOW)).toBe("warning");
+  });
+
   it("returns 'ended' for expired bounty", () => {
     const bounty = makeBounty({ status: "expired" });
     expect(getUrgencyLevel(bounty, NOW)).toBe("ended");

--- a/frontend/src/urgency.test.ts
+++ b/frontend/src/urgency.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { getUrgencyLevel, getUrgencyClass, UrgencyLevel } from "./utils";
+import type { Bounty } from "./types";
+
+/** Create a minimal bounty stub for testing urgency levels. */
+function makeBounty(overrides: Partial<Bounty> = {}): Bounty {
+  return {
+    id: "test-1",
+    repo: "owner/repo",
+    issueNumber: 1,
+    title: "Test Bounty",
+    summary: "A test bounty",
+    maintainer: "G" + "A".repeat(55),
+    tokenSymbol: "XLM",
+    amount: 10,
+    labels: [],
+    status: "open",
+    createdAt: 1000,
+    deadlineAt: 1000 + 30 * 24 * 60 * 60, // 30 days from epoch
+    version: 1,
+    events: [],
+    ...overrides,
+  };
+}
+
+describe("getUrgencyLevel", () => {
+  const NOW = 1000 + 15 * 24 * 60 * 60; // 15 days after createdAt
+
+  it("returns 'plenty' for open bounty with >7 days remaining", () => {
+    const bounty = makeBounty({
+      status: "open",
+      deadlineAt: NOW + 10 * 24 * 60 * 60, // 10 days left
+    });
+    expect(getUrgencyLevel(bounty, NOW)).toBe("plenty");
+  });
+
+  it("returns 'warning' for open bounty with 1–7 days remaining", () => {
+    const bounty = makeBounty({
+      status: "open",
+      deadlineAt: NOW + 3 * 24 * 60 * 60, // 3 days left
+    });
+    expect(getUrgencyLevel(bounty, NOW)).toBe("warning");
+  });
+
+  it("returns 'warning' for open bounty with exactly 7 days remaining", () => {
+    const bounty = makeBounty({
+      status: "open",
+      deadlineAt: NOW + 7 * 24 * 60 * 60,
+    });
+    expect(getUrgencyLevel(bounty, NOW)).toBe("warning");
+  });
+
+  it("returns 'urgent' for open bounty with <24 hours remaining", () => {
+    const bounty = makeBounty({
+      status: "open",
+      deadlineAt: NOW + 12 * 60 * 60, // 12 hours left
+    });
+    expect(getUrgencyLevel(bounty, NOW)).toBe("urgent");
+  });
+
+  it("returns 'warning' for open bounty with exactly 24 hours remaining", () => {
+    const bounty = makeBounty({
+      status: "open",
+      deadlineAt: NOW + 24 * 60 * 60,
+    });
+    expect(getUrgencyLevel(bounty, NOW)).toBe("warning");
+  });
+
+  it("returns 'warning' for reserved bounty with 1–7 days remaining", () => {
+    const bounty = makeBounty({
+      status: "reserved",
+      deadlineAt: NOW + 5 * 24 * 60 * 60,
+    });
+    expect(getUrgencyLevel(bounty, NOW)).toBe("warning");
+  });
+
+  it("returns 'urgent' for reserved bounty with <24 hours remaining", () => {
+    const bounty = makeBounty({
+      status: "reserved",
+      deadlineAt: NOW + 2 * 60 * 60, // 2 hours left
+    });
+    expect(getUrgencyLevel(bounty, NOW)).toBe("urgent");
+  });
+
+  it("returns 'ended' for expired bounty", () => {
+    const bounty = makeBounty({ status: "expired" });
+    expect(getUrgencyLevel(bounty, NOW)).toBe("ended");
+  });
+
+  it("returns 'ended' for released bounty", () => {
+    const bounty = makeBounty({ status: "released" });
+    expect(getUrgencyLevel(bounty, NOW)).toBe("ended");
+  });
+
+  it("returns 'ended' for refunded bounty", () => {
+    const bounty = makeBounty({ status: "refunded" });
+    expect(getUrgencyLevel(bounty, NOW)).toBe("ended");
+  });
+
+  it("returns 'ended' for open bounty past deadline", () => {
+    const bounty = makeBounty({
+      status: "open",
+      deadlineAt: NOW - 3600, // 1 hour ago
+    });
+    expect(getUrgencyLevel(bounty, NOW)).toBe("ended");
+  });
+
+  it("returns 'plenty' for submitted bounty (not open/reserved)", () => {
+    const bounty = makeBounty({
+      status: "submitted",
+      deadlineAt: NOW + 3600,
+    });
+    expect(getUrgencyLevel(bounty, NOW)).toBe("plenty");
+  });
+
+  it("returns 'disputed' for disputed status", () => {
+    const bounty = makeBounty({
+      status: "open" as BountyStatus,
+      deadlineAt: NOW + 3600,
+    });
+    // Simulate disputed by casting
+    (bounty as any).status = "disputed";
+    expect(getUrgencyLevel(bounty, NOW)).toBe("disputed");
+  });
+});
+
+describe("getUrgencyClass", () => {
+  const NOW = 1000 + 15 * 24 * 60 * 60;
+
+  it("returns urgency-plenty for plenty level", () => {
+    const bounty = makeBounty({
+      status: "open",
+      deadlineAt: NOW + 10 * 24 * 60 * 60,
+    });
+    expect(getUrgencyClass(bounty, NOW)).toBe("urgency-plenty");
+  });
+
+  it("returns urgency-warning for warning level", () => {
+    const bounty = makeBounty({
+      status: "open",
+      deadlineAt: NOW + 3 * 24 * 60 * 60,
+    });
+    expect(getUrgencyClass(bounty, NOW)).toBe("urgency-warning");
+  });
+
+  it("returns urgency-urgent for urgent level", () => {
+    const bounty = makeBounty({
+      status: "open",
+      deadlineAt: NOW + 12 * 60 * 60,
+    });
+    expect(getUrgencyClass(bounty, NOW)).toBe("urgency-urgent");
+  });
+
+  it("returns urgency-ended for ended level", () => {
+    const bounty = makeBounty({ status: "expired" });
+    expect(getUrgencyClass(bounty, NOW)).toBe("urgency-ended");
+  });
+});
+
+// Re-export for type checking
+type BountyStatus = "open" | "reserved" | "submitted" | "released" | "refunded" | "expired";

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -6,8 +6,8 @@ export type UrgencyLevel = "plenty" | "warning" | "urgent" | "ended" | "disputed
 /**
  * Determine the urgency level of a bounty based on its status and time remaining.
  *
- * - Green (`plenty`): open with >7 days remaining
- * - Yellow (`warning`): open or reserved with 1–7 days remaining
+ * - Green (`plenty`): open only, with >7 days remaining
+ * - Yellow (`warning`): open or reserved with 1–7 days; reserved with >7 days
  * - Red (`urgent`): open or reserved with <24 hours remaining
  * - Grey (`ended`): expired, released, or refunded
  * - Blue (`disputed`): disputed status
@@ -44,6 +44,12 @@ export function getUrgencyLevel(bounty: Bounty, nowSeconds?: number): UrgencyLev
   const daysRemaining = secondsRemaining / (24 * 60 * 60);
 
   if (daysRemaining <= 7) {
+    return "warning";
+  }
+
+  // Only "open" bounties qualify for "plenty" (green).
+  // "reserved" bounties always show at least "warning" to indicate active assignment.
+  if (bounty.status === "reserved") {
     return "warning";
   }
 

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,6 +1,62 @@
 import { Bounty, BountyStatus } from "./types";
 import { FilterState } from "./constants";
 
+export type UrgencyLevel = "plenty" | "warning" | "urgent" | "ended" | "disputed";
+
+/**
+ * Determine the urgency level of a bounty based on its status and time remaining.
+ *
+ * - Green (`plenty`): open with >7 days remaining
+ * - Yellow (`warning`): open or reserved with 1–7 days remaining
+ * - Red (`urgent`): open or reserved with <24 hours remaining
+ * - Grey (`ended`): expired, released, or refunded
+ * - Blue (`disputed`): disputed status
+ */
+export function getUrgencyLevel(bounty: Bounty, nowSeconds?: number): UrgencyLevel {
+  const now = nowSeconds ?? Math.floor(Date.now() / 1000);
+
+  if (bounty.status === "expired" || bounty.status === "released" || bounty.status === "refunded") {
+    return "ended";
+  }
+
+  // "disputed" is not in the current BountyStatus union but is handled
+  // defensively for forward-compatibility.
+  if ((bounty.status as string) === "disputed") {
+    return "disputed";
+  }
+
+  if (bounty.status !== "open" && bounty.status !== "reserved") {
+    return "plenty";
+  }
+
+  const secondsRemaining = bounty.deadlineAt - now;
+
+  if (secondsRemaining <= 0) {
+    return "ended";
+  }
+
+  const hoursRemaining = secondsRemaining / 3600;
+
+  if (hoursRemaining < 24) {
+    return "urgent";
+  }
+
+  const daysRemaining = secondsRemaining / (24 * 60 * 60);
+
+  if (daysRemaining <= 7) {
+    return "warning";
+  }
+
+  return "plenty";
+}
+
+/**
+ * Returns the CSS modifier class suffix for the given urgency level.
+ * Use with `status-pill--urgency-${modifier}`.
+ */
+export function getUrgencyClass(bounty: Bounty, nowSeconds?: number): string {
+  return `urgency-${getUrgencyLevel(bounty, nowSeconds)}`;
+}
 
 // Simple debounce function for search
 export function debounce<T extends (...args: any[]) => any>(


### PR DESCRIPTION
## Summary

Adds time-aware color coding to the status badge on BountyCard, BountyDetailPage, and RecommendedBounties.

### Urgency Levels

| Level | Color | Condition |
|-------|-------|-----------|
| **Plenty** | Green | Open with >7 days remaining |
| **Warning** | Yellow | Open or reserved with 1-7 days remaining |
| **Urgent** | Red | Open or reserved with <24 hours remaining |
| **Ended** | Grey | Expired, released, refunded, or past deadline |
| **Disputed** | Blue | Disputed status (forward-compatible) |

### Changes

- **utils.ts** — add `getUrgencyLevel()` and `getUrgencyClass()` helpers with full JSDoc
- **index.css** — add 5 urgency-based CSS modifier classes
- **App.tsx** — apply urgency class to BountyCard status pill
- **BountyDetailPage.tsx** — apply urgency class to detail page status pill
- **RecommendedBounties.tsx** — apply urgency class to recommendation cards
- **urgency.test.ts** — Vitest coverage for all urgency levels and edge cases

### Accessibility

Color is never the only indicator — the text label (e.g. "Open", "Reserved") is always shown alongside the color, satisfying the accessibility requirement.

Closes #376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounty status pills now include urgency-based visual modifiers, making time-sensitive bounties easier to identify.

* **Style**
  * Added CSS variants for urgency levels to give distinct colors/appearance for each urgency state.

* **Tests**
  * Added tests covering urgency determination and the mapping to visual classes to ensure consistent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->