### PR TITLE
Add Stellar Expert links for detail transaction hashes

### DIFF
--- a/frontend/src/BountyDetailPage.test.tsx
+++ b/frontend/src/BountyDetailPage.test.tsx
@@ -102,6 +102,40 @@ describe("BountyDetailPage copy actions", () => {
     expect(print).toHaveBeenCalledOnce();
   });
 
+  it("links release and refund transaction hashes to Stellar Expert", () => {
+    const releasedTxHash =
+      "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    const refundedTxHash =
+      "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+
+    renderDetail({
+      ...bounty,
+      status: "refunded",
+      releasedTxHash,
+      refundedTxHash,
+      releasedAt: 1_700_000_200,
+      refundedAt: 1_700_000_300,
+    });
+
+    const releaseLink = screen.getByRole("link", { name: "abcdef01...23456789" });
+    expect(releaseLink).toHaveAttribute(
+      "href",
+      `https://stellar.expert/explorer/testnet/tx/${releasedTxHash}`,
+    );
+    expect(releaseLink).toHaveAttribute("target", "_blank");
+    expect(releaseLink).toHaveAttribute("rel", "noopener noreferrer");
+    expect(releaseLink).toHaveAttribute("title", releasedTxHash);
+
+    const refundLink = screen.getByRole("link", { name: "12345678...90abcdef" });
+    expect(refundLink).toHaveAttribute(
+      "href",
+      `https://stellar.expert/explorer/testnet/tx/${refundedTxHash}`,
+    );
+    expect(refundLink).toHaveAttribute("target", "_blank");
+    expect(refundLink).toHaveAttribute("rel", "noopener noreferrer");
+    expect(refundLink).toHaveAttribute("title", refundedTxHash);
+  });
+
   it("announces status changes for assistive technology", () => {
     const { rerender } = renderDetail();
     const reservedBounty: Bounty = {

--- a/frontend/src/BountyDetailPage.tsx
+++ b/frontend/src/BountyDetailPage.tsx
@@ -74,6 +74,29 @@ const EVENT_LABELS: Record<string, string> = {
   expired: "Bounty expired",
 };
 
+function stellarExpertTxUrl(hash: string) {
+  return `https://stellar.expert/explorer/testnet/tx/${hash}`;
+}
+
+function formatTxHash(hash: string) {
+  if (hash.length <= 16) return hash;
+  return `${hash.slice(0, 8)}...${hash.slice(-8)}`;
+}
+
+function TransactionHashLink({ hash }: { hash: string }) {
+  return (
+    <a
+      className="inline-link"
+      href={stellarExpertTxUrl(hash)}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={hash}
+    >
+      {formatTxHash(hash)}
+    </a>
+  );
+}
+
 function BountyTimeline({ events, formatTimestamp }: { events: BountyEvent[]; formatTimestamp: (v?: number) => string }) {
   if (!events || events.length === 0) return null;
 
@@ -276,7 +299,7 @@ export default function BountyDetailPage({
                 <div>
                   <span className="meta-label">Release tx</span>
                   <strong className="copy-row">
-                    {bounty.releasedTxHash}
+                    <TransactionHashLink hash={bounty.releasedTxHash} />
                     <CopyIcon text={bounty.releasedTxHash} label="release transaction hash" />
                   </strong>
                 </div>
@@ -285,7 +308,7 @@ export default function BountyDetailPage({
                 <div>
                   <span className="meta-label">Refund tx</span>
                   <strong className="copy-row">
-                    {bounty.refundedTxHash}
+                    <TransactionHashLink hash={bounty.refundedTxHash} />
                     <CopyIcon text={bounty.refundedTxHash} label="refund transaction hash" />
                   </strong>
                 </div>


### PR DESCRIPTION
Closes #382.

## Summary
- Render release and refund transaction hashes as Stellar Expert testnet links on the bounty detail page.
- Keep the copy buttons beside each hash.
- Truncate displayed hashes to the first 8 and last 8 characters while preserving the full hash in the tooltip.

## Validation
- `npm --prefix frontend test -- BountyDetailPage.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release and refund transaction hashes for bounties now display as clickable Stellar Expert explorer links with truncated display text, while maintaining copy-to-clipboard functionality.

* **Tests**
  * Added test to verify transaction hash explorer links render correctly with proper attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->