### PR TITLE
Cap bounty amount validation

### DIFF
--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -76,7 +76,15 @@ export const createBountySchema = z
       .openapi({ example: "XLM", description: "Stellar token symbol for payout (1–12 alphanumeric chars)." }),
     amount: z.coerce
       .number()
-      .min(1, "Amount must be at least 1 XLM."),
+      .min(1, "Amount must be at least 1 XLM.")
+      .max(1_000_000, "Amount must not exceed 1,000,000 tokens.")
+      .refine((amount) => Number.isInteger(amount * 10_000_000), {
+        message: "Amount must have at most 7 decimal places.",
+      })
+      .openapi({
+        example: 100,
+        description: "Bounty amount. Must be between 1 and 1,000,000 tokens with at most 7 decimal places.",
+      }),
 
     deadlineDays: z.coerce
       .number()

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -85,13 +85,13 @@ describe("API — bounty lifecycle routes", () => {
     expect(res.body.error).toMatch(/at least 1 XLM/i);
   });
 
-  it("POST create with amount above 10000 XLM returns 400", async () => {
+  it("POST create with amount above 1,000,000 tokens returns 400", async () => {
     const app = await getApp();
     const res = await request(app)
       .post("/api/bounties")
-      .send({ ...validCreateBody, amount: 10001 })
+      .send({ ...validCreateBody, amount: 1_000_001 })
       .expect(400);
-    expect(res.body.error).toMatch(/exceed 10000 XLM/i);
+    expect(res.body.error).toMatch(/exceed 1,000,000 tokens/i);
   });
 
   it("POST create with more than 7 decimal places returns 400", async () => {
@@ -128,6 +128,15 @@ describe("API — bounty lifecycle routes", () => {
       .send({ ...validCreateBody, amount: 10000 })
       .expect(201);
     expect(res.body.data.amount).toBe(10000);
+  });
+
+  it("POST create with 1,000,000 tokens succeeds", async () => {
+    const app = await getApp();
+    const res = await request(app)
+      .post("/api/bounties")
+      .send({ ...validCreateBody, amount: 1_000_000 })
+      .expect(201);
+    expect(res.body.data.amount).toBe(1_000_000);
   });
 
   it("reserve → submit → release flow via HTTP", async () => {


### PR DESCRIPTION
Closes #347.

## Summary
- Cap bounty creation amounts at 1,000,000 tokens in the Zod request schema.
- Keep the existing lower bound and enforce at most 7 decimal places.
- Update API coverage for the maximum boundary and over-limit rejection.

## Validation
- `npm --prefix backend test -- api.test.ts`