### PR TITLE
fix: add Content-Security-Policy meta tag to frontend build (#351)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ See [docs/deployment.md](docs/deployment.md) for step-by-step instructions to de
 
 For detailed architecture diagrams and data flow documentation, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
+For integrating GitHub webhooks — including the HMAC-SHA256 algorithm, Node.js and Python verification examples, timing-safe comparison guidance, and troubleshooting — see [docs/webhook-signatures.md](docs/webhook-signatures.md).
+
 ## Contract Event Indexer Worker
 
 The backend includes an isolated worker for indexing Soroban contract events. See [backend/worker/README.md](backend/worker/README.md) for details on running and extending the indexer.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,37 @@
 # Security Policy
 
+## Content Security Policy (CSP)
+
+The frontend build injects a `Content-Security-Policy-Report-Only` meta tag via `frontend/vite.config.ts`.
+
+### Current policy
+
+```
+default-src 'self';
+connect-src 'self' https://rpc-futurenet.stellar.org https://api.github.com;
+script-src  'self';
+style-src   'self' 'unsafe-inline';
+img-src     'self' data: blob:;
+font-src    'self';
+object-src  'none';
+base-uri    'self';
+form-action 'self';
+```
+
+### Report-only mode
+
+The policy is currently deployed in **report-only mode** (`Content-Security-Policy-Report-Only`).
+Violations are logged to the browser console but do **not** block any functionality.
+Once no violations are observed in staging, the meta tag should be upgraded to
+`Content-Security-Policy` to enforce the policy.
+
+### Updating the policy
+
+Edit the `cspDirectives` array in `frontend/vite.config.ts` → `cspPlugin()`.
+After any change, verify there are no new console violations before promoting to production.
+
+---
+
 ## Supported Versions
 
 Only the latest version of the Stellar Bounty Board is currently supported with security updates.

--- a/docs/webhook-signatures.md
+++ b/docs/webhook-signatures.md
@@ -2,6 +2,114 @@
 
 Use the backend webhook signature utility whenever a third-party service sends data into the API. This keeps webhook routes reusable and prevents unauthenticated traffic from reaching integration logic.
 
+---
+
+## Algorithm: HMAC-SHA256
+
+Every webhook request is authenticated using **HMAC-SHA256** (Hash-based Message Authentication Code with SHA-256).
+
+The sender (GitHub) computes:
+```
+signature = "sha256=" + HMAC_SHA256(key=WEBHOOK_SECRET, message=RAW_REQUEST_BODY)
+```
+
+The receiver (this backend) independently computes the same signature from the raw body and the shared secret, then compares both values in **constant time** to prevent timing attacks.
+
+> ⚠️ **Timing-safe comparison is mandatory.**  
+> A naïve string comparison (`===`) short-circuits on the first mismatched character, leaking information about how many characters match.  
+> Always use `crypto.timingSafeEqual()` (Node.js) or `hmac.compare_digest()` (Python) — both are used in the examples below and in the backend implementation.
+
+---
+
+## Example: Node.js (built-in `crypto`)
+
+```js
+const crypto = require("crypto");
+
+/**
+ * Verify a GitHub-style HMAC-SHA256 webhook signature.
+ * @param {string} secret   - Shared webhook secret
+ * @param {string} payload  - Raw request body (string, not parsed JSON)
+ * @param {string} header   - Value of X-Hub-Signature-256 header, e.g. "sha256=abc123..."
+ * @returns {boolean}
+ */
+function verifyGitHubSignature(secret, payload, header) {
+  if (!header || !header.startsWith("sha256=")) return false;
+
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(payload, "utf8")
+    .digest("hex");
+
+  const received = header.slice("sha256=".length);
+
+  // Timing-safe comparison — never use === here
+  return crypto.timingSafeEqual(
+    Buffer.from(expected, "hex"),
+    Buffer.from(received, "hex")
+  );
+}
+
+// Express usage
+app.post("/api/webhooks/github", express.raw({ type: "application/json" }), (req, res) => {
+  const sig = req.headers["x-hub-signature-256"];
+  if (!verifyGitHubSignature(process.env.GITHUB_WEBHOOK_SECRET, req.body.toString("utf8"), sig)) {
+    return res.status(401).json({ error: "Invalid signature" });
+  }
+  res.json({ status: "ok" });
+});
+```
+
+---
+
+## Example: Python (`hmac` + `hashlib`)
+
+```python
+import hmac
+import hashlib
+
+def verify_github_signature(secret: str, payload: bytes, header: str) -> bool:
+    """
+    Verify a GitHub-style HMAC-SHA256 webhook signature.
+
+    :param secret:  Shared webhook secret (plain string)
+    :param payload: Raw request body as bytes
+    :param header:  Value of X-Hub-Signature-256 header, e.g. "sha256=abc123..."
+    :returns:       True if the signature is valid, False otherwise
+    """
+    if not header or not header.startswith("sha256="):
+        return False
+
+    expected = hmac.new(
+        key=secret.encode("utf-8"),
+        msg=payload,
+        digestmod=hashlib.sha256,
+    ).hexdigest()
+
+    received = header[len("sha256="):]
+
+    # Timing-safe comparison — never use == here
+    return hmac.compare_digest(expected, received)
+
+
+# Flask usage
+from flask import Flask, request, abort
+app = Flask(__name__)
+
+@app.post("/api/webhooks/github")
+def github_webhook():
+    sig = request.headers.get("X-Hub-Signature-256", "")
+    if not verify_github_signature(
+        secret=os.environ["GITHUB_WEBHOOK_SECRET"],
+        payload=request.get_data(),
+        header=sig,
+    ):
+        abort(401)
+    return {"status": "ok"}
+```
+
+---
+
 ## What exists today
 
 - `backend/src/webhooks/signatureVerification.ts` provides a generic HMAC signature verifier.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,6 +47,7 @@ import UsdAmount from "./UsdAmount";
 
 import SkeletonBountyCard from "./SkeletonBountyCard";
 import EmptyState from "./EmptyState";
+import { ShortcutsHelpOverlay } from "./ShortcutsHelpOverlay";
 
 // Lazy-load BountyDetailPage — it is only rendered on /bounties/:id routes,
 // so deferring it keeps the initial board bundle smaller.
@@ -312,6 +313,7 @@ function App() {
   const [submitting, setSubmitting] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showShortcutsOverlay, setShowShortcutsOverlay] = useState(false);
 
   const [searchQuery, setSearchQuery] = useState(initialFilters.searchQuery);
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(initialFilters.searchQuery);
@@ -463,6 +465,57 @@ function App() {
     window.addEventListener("popstate", handlePopState);
     return () => window.removeEventListener("popstate", handlePopState);
   }, []);
+
+  // ─── Keyboard shortcut handler ───────────────────────────────────────────
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    function handleGlobalKeyDown(event: KeyboardEvent) {
+      // Never intercept shortcuts while typing inside a form element
+      const target = event.target as HTMLElement;
+      const tag = target.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      const statusMap: Record<string, "all" | BountyStatus> = {
+        "1": "all",
+        "2": "open",
+        "3": "reserved",
+        "4": "submitted",
+        "5": "released",
+      };
+
+      switch (event.key) {
+        case "?":
+          event.preventDefault();
+          setShowShortcutsOverlay((prev) => !prev);
+          break;
+        case "/":
+          event.preventDefault();
+          searchInputRef.current?.focus();
+          break;
+        case "1":
+        case "2":
+        case "3":
+        case "4":
+        case "5":
+          setStatusFilter(statusMap[event.key] as "all" | BountyStatus);
+          break;
+        default:
+          break;
+      }
+    }
+
+    window.addEventListener("keydown", handleGlobalKeyDown);
+    return () => window.removeEventListener("keydown", handleGlobalKeyDown);
+  }, []);
+  // ─────────────────────────────────────────────────────────────────────────
 
   function navigate(nextPath: string) {
     if (nextPath === window.location.pathname) return;
@@ -1113,9 +1166,11 @@ function App() {
                     <div className="input-with-icon">
                       <Search size={16} />
                       <input
+                        ref={searchInputRef}
                         value={searchQuery}
                         onChange={(event) => setSearchQuery(event.target.value)}
                         placeholder="Search repo, title, labels, status"
+                        aria-keyshortcuts="/"
                       />
                     </div>
                   </label>
@@ -1606,6 +1661,11 @@ function App() {
               }}
             />
           )}
+
+          <ShortcutsHelpOverlay
+            isOpen={showShortcutsOverlay}
+            onClose={() => setShowShortcutsOverlay(false)}
+          />
         </div>
     );
 }

--- a/frontend/src/ShortcutsHelpOverlay.test.tsx
+++ b/frontend/src/ShortcutsHelpOverlay.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ShortcutsHelpOverlay } from "./ShortcutsHelpOverlay";
+
+describe("ShortcutsHelpOverlay", () => {
+  it("renders nothing when isOpen is false", () => {
+    render(<ShortcutsHelpOverlay isOpen={false} onClose={vi.fn()} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("renders the overlay when isOpen is true", () => {
+    render(<ShortcutsHelpOverlay isOpen={true} onClose={vi.fn()} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(
+      screen.getByText("Keyboard shortcuts"),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onClose when Escape is pressed", () => {
+    const onClose = vi.fn();
+    render(<ShortcutsHelpOverlay isOpen={true} onClose={onClose} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the close button is clicked", () => {
+    const onClose = vi.fn();
+    render(<ShortcutsHelpOverlay isOpen={true} onClose={onClose} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /close keyboard shortcuts overlay/i }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the backdrop is clicked", () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <ShortcutsHelpOverlay isOpen={true} onClose={onClose} />,
+    );
+    // The backdrop is the outermost div (presentation role)
+    const backdrop = container.firstElementChild as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call onClose when clicking inside the dialog card", () => {
+    const onClose = vi.fn();
+    render(<ShortcutsHelpOverlay isOpen={true} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("dialog"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("lists the ? and / keyboard shortcuts", () => {
+    render(<ShortcutsHelpOverlay isOpen={true} onClose={vi.fn()} />);
+    expect(screen.getByText("Open / close this help overlay")).toBeInTheDocument();
+    expect(screen.getByText("Focus the search bar")).toBeInTheDocument();
+  });
+
+  it("lists status filter shortcuts 1-5", () => {
+    render(<ShortcutsHelpOverlay isOpen={true} onClose={vi.fn()} />);
+    expect(screen.getByText(/status filter to "All"/i)).toBeInTheDocument();
+    expect(screen.getByText(/status filter to "Open"/i)).toBeInTheDocument();
+    expect(screen.getByText(/status filter to "Released"/i)).toBeInTheDocument();
+  });
+
+  it("has correct ARIA attributes for accessibility", () => {
+    render(<ShortcutsHelpOverlay isOpen={true} onClose={vi.fn()} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby");
+  });
+});

--- a/frontend/src/ShortcutsHelpOverlay.tsx
+++ b/frontend/src/ShortcutsHelpOverlay.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useId, useRef } from "react";
+import { X } from "lucide-react";
+
+interface Shortcut {
+  keys: string[];
+  description: string;
+}
+
+const SHORTCUTS: Shortcut[] = [
+  { keys: ["?"], description: "Open / close this help overlay" },
+  { keys: ["/"], description: "Focus the search bar" },
+  { keys: ["1"], description: 'Set status filter to "All"' },
+  { keys: ["2"], description: 'Set status filter to "Open"' },
+  { keys: ["3"], description: 'Set status filter to "Reserved"' },
+  { keys: ["4"], description: 'Set status filter to "Submitted"' },
+  { keys: ["5"], description: 'Set status filter to "Released"' },
+  { keys: ["Esc"], description: "Close this overlay / go back from bounty detail" },
+];
+
+interface ShortcutsHelpOverlayProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Modal overlay listing keyboard shortcuts for the bounty board.
+ * - Closes on Escape or backdrop click.
+ * - Traps focus inside while open.
+ * - Opened by pressing `?` anywhere (wired up in App.tsx).
+ */
+export function ShortcutsHelpOverlay({ isOpen, onClose }: ShortcutsHelpOverlayProps) {
+  const titleId = useId();
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // Focus the close button when the overlay opens so keyboard users can act immediately
+  useEffect(() => {
+    if (isOpen) {
+      closeButtonRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  // Trap focus within the overlay
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const overlay = overlayRef.current;
+      if (!overlay) return;
+
+      const focusable = overlay.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault();
+          last?.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          event.preventDefault();
+          first?.focus();
+        }
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
+      role="presentation"
+      onClick={onClose}
+    >
+      <div
+        ref={overlayRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="w-full max-w-md card"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h2 id={titleId} className="text-lg font-semibold text-white">
+            Keyboard shortcuts
+          </h2>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="ghost-button p-1"
+            onClick={onClose}
+            aria-label="Close keyboard shortcuts overlay"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <table className="mt-4 w-full text-sm border-collapse">
+          <thead className="sr-only">
+            <tr>
+              <th>Key</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/10">
+            {SHORTCUTS.map(({ keys, description }) => (
+              <tr key={description}>
+                <td className="py-2 pr-4 align-middle whitespace-nowrap">
+                  {keys.map((key) => (
+                    <kbd
+                      key={key}
+                      className="inline-flex items-center justify-center rounded border border-white/20 bg-white/10 px-1.5 py-0.5 font-mono text-xs text-gray-200 shadow-sm"
+                    >
+                      {key}
+                    </kbd>
+                  ))}
+                </td>
+                <td className="py-2 text-gray-300">{description}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <p className="mt-4 text-xs text-gray-500">
+          Shortcuts are disabled when typing inside an input or textarea.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,10 +3,40 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { visualizer } from "rollup-plugin-visualizer";
+import type { Plugin } from "vite";
+
+// ─── Content-Security-Policy plugin (issue #351) ──────────────────────────────
+// Injects a CSP meta tag into index.html at build time.
+// Report-only mode is used first so violations are logged to the browser console
+// without blocking any existing functionality.  Upgrade to enforcement
+// (Content-Security-Policy) once no violations are observed in staging.
+function cspPlugin(): Plugin {
+  const cspDirectives = [
+    "default-src 'self'",
+    "connect-src 'self' https://rpc-futurenet.stellar.org https://api.github.com",
+    "script-src 'self'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob:",
+    "font-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ].join("; ");
+
+  return {
+    name: "vite-plugin-csp",
+    transformIndexHtml(html) {
+      // Inject report-only CSP so violations are visible in the browser console
+      const reportOnlyMeta = `<meta http-equiv="Content-Security-Policy-Report-Only" content="${cspDirectives}">`;
+      return html.replace(/(<head[^>]*>)/i, `$1\n    ${reportOnlyMeta}`);
+    },
+  };
+}
 
 export default defineConfig(({ mode }) => ({
   plugins: [
     react(),
+    cspPlugin(),
     // Only generate the bundle report when running `npm run build:analyze`
     ...(mode === "analyze"
       ? [


### PR DESCRIPTION
## Summary
Closes #351
Closes #371
Closes #311
Closes #343

## What this PR does (issue #351)
The frontend was served with no CSP, leaving XSS a direct path to the DOM and wallet state.

**`frontend/vite.config.ts`**
- Added `cspPlugin()` — a lightweight inline Vite plugin using `transformIndexHtml` to inject a `Content-Security-Policy-Report-Only` meta tag into every built HTML page
- Policy: `default-src 'self'; connect-src 'self' https://rpc-futurenet.stellar.org https://api.github.com; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'`
- **Report-only mode first** — violations log to browser console without blocking existing functionality; upgrade to enforcement once staging shows zero violations

**`SECURITY.md`**
- Documented full CSP directive set, report-only rationale, and the upgrade path to enforcement mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content Security Policy (CSP) framework has been implemented. The CSP operates in report-only mode, where policy violations are logged to the browser console but do not block page functionality.

* **Documentation**
  * Security policy documentation has been updated to include CSP configuration details and guidelines for policy maintenance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->