### PR TITLE
Handle malformed reservation timestamps

### DIFF
--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -285,8 +285,10 @@ function normalizeRecords(records: BountyRecord[]): BountyRecord[] {
     // Check for expired reservation (timeout without submission)
     if (
       record.status === "reserved" &&
-      record.reservedAt &&
-      record.reservationTimeoutSeconds &&
+      typeof record.reservedAt === "number" &&
+      Number.isFinite(record.reservedAt) &&
+      typeof record.reservationTimeoutSeconds === "number" &&
+      Number.isFinite(record.reservationTimeoutSeconds) &&
       now > record.reservedAt + record.reservationTimeoutSeconds
     ) {
       changed = true;

--- a/backend/src/services/reservationExpirationJob.ts
+++ b/backend/src/services/reservationExpirationJob.ts
@@ -73,13 +73,16 @@ export function expireStaleReservations(ttlSeconds?: number): ExpirationResult {
       (typeof b.reservedAt !== "number" || !Number.isFinite(b.reservedAt)),
   );
 
-  for (const bounty of malformed) {
+  if (malformed.length > 0) {
     logger.warn(
       {
-        bountyId: bounty.id,
-        reservedAt: bounty.reservedAt,
+        malformedCount: malformed.length,
+        bounties: malformed.map((bounty) => ({
+          bountyId: bounty.id,
+          reservedAt: bounty.reservedAt,
+        })),
       },
-      "[ExpirationJob] Skipping reserved bounty with malformed reservedAt",
+      "[ExpirationJob] Skipping reserved bounties with malformed reservedAt",
     );
   }
 

--- a/backend/src/services/reservationExpirationJob.ts
+++ b/backend/src/services/reservationExpirationJob.ts
@@ -67,10 +67,27 @@ export function expireStaleReservations(ttlSeconds?: number): ExpirationResult {
   const checkedAt = nowSeconds;
 
   const bounties = listBounties();
+  const malformed = bounties.filter(
+    (b) =>
+      b.status === "reserved" &&
+      (typeof b.reservedAt !== "number" || !Number.isFinite(b.reservedAt)),
+  );
+
+  for (const bounty of malformed) {
+    logger.warn(
+      {
+        bountyId: bounty.id,
+        reservedAt: bounty.reservedAt,
+      },
+      "[ExpirationJob] Skipping reserved bounty with malformed reservedAt",
+    );
+  }
+
   const stale = bounties.filter(
     (b): b is BountyRecord & { reservedAt: number; contributor: string } =>
       b.status === "reserved" &&
       typeof b.reservedAt === "number" &&
+      Number.isFinite(b.reservedAt) &&
       nowSeconds - b.reservedAt > effectiveTtl,
   );
 

--- a/backend/test/reservationExpirationJob.test.ts
+++ b/backend/test/reservationExpirationJob.test.ts
@@ -69,13 +69,13 @@ function makeReservedBounty(reservedSecondsAgo: number) {
 describe("expireStaleReservations", () => {
   it("does not expire a fresh reservation (reserved 1 day ago, TTL 7 days)", async () => {
     const store = await loadStore();
-    const bounty = store.createBounty({
+    const bounty = await store.createBounty({
       repo: "test/repo", issueNumber: 1, title: "Fresh bounty",
       summary: "Summary long enough for validation purposes here.",
       maintainer: MAINTAINER, tokenSymbol: "XLM", amount: 50,
       deadlineDays: 30, labels: [],
     });
-    store.reserveBounty(bounty.id, CONTRIBUTOR);
+    await store.reserveBounty(bounty.id, CONTRIBUTOR);
 
     const { expireStaleReservations } = await loadJob();
     const result = expireStaleReservations(7 * 24 * 60 * 60);
@@ -140,6 +140,44 @@ describe("expireStaleReservations", () => {
     expect(freshUpdated.status).toBe("reserved");
   });
 
+  it("warns for malformed reservedAt records and continues expiring valid reservations", async () => {
+    const stale1 = makeReservedBounty(8 * 24 * 60 * 60);
+    const stale2 = makeReservedBounty(10 * 24 * 60 * 60);
+    const corrupt = {
+      ...makeReservedBounty(9 * 24 * 60 * 60),
+      reservedAt: "not-a-timestamp" as unknown as number,
+    };
+    fs.writeFileSync(storeFile, JSON.stringify([stale1, corrupt, stale2], null, 2));
+
+    const { logger } = await import("../src/logger");
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    const { expireStaleReservations } = await loadJob();
+    const result = expireStaleReservations(7 * 24 * 60 * 60);
+
+    expect(result.expiredCount).toBe(2);
+    expect(result.expiredBountyIds).toContain(stale1.id);
+    expect(result.expiredBountyIds).toContain(stale2.id);
+    expect(result.expiredBountyIds).not.toContain(corrupt.id);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bountyId: corrupt.id,
+        reservedAt: "not-a-timestamp",
+      }),
+      "[ExpirationJob] Skipping reserved bounty with malformed reservedAt",
+    );
+
+    const raw = JSON.parse(fs.readFileSync(storeFile, "utf8"));
+    const stale1Updated = raw.find((b: { id: string }) => b.id === stale1.id);
+    const stale2Updated = raw.find((b: { id: string }) => b.id === stale2.id);
+    const corruptUpdated = raw.find((b: { id: string }) => b.id === corrupt.id);
+    expect(stale1Updated.status).toBe("open");
+    expect(stale2Updated.status).toBe("open");
+    expect(corruptUpdated.status).toBe("reserved");
+    expect(corruptUpdated.reservedAt).toBe("not-a-timestamp");
+
+    warnSpy.mockRestore();
+  });
+
   it("respects RESERVATION_TTL_DAYS env var", async () => {
     process.env.RESERVATION_TTL_DAYS = "3";
     const stale = makeReservedBounty(4 * 24 * 60 * 60); // 4 days > 3 day TTL
@@ -155,14 +193,14 @@ describe("expireStaleReservations", () => {
 
   it("does not touch submitted bounties", async () => {
     const store = await loadStore();
-    const bounty = store.createBounty({
+    const bounty = await store.createBounty({
       repo: "test/repo", issueNumber: 2, title: "Submitted bounty",
       summary: "Summary long enough for validation purposes here.",
       maintainer: MAINTAINER, tokenSymbol: "XLM", amount: 50,
       deadlineDays: 30, labels: [],
     });
-    store.reserveBounty(bounty.id, CONTRIBUTOR);
-    store.submitBounty(bounty.id, CONTRIBUTOR, "https://github.com/pr/1");
+    await store.reserveBounty(bounty.id, CONTRIBUTOR);
+    await store.submitBounty(bounty.id, CONTRIBUTOR, "https://github.com/pr/1");
 
     const { expireStaleReservations } = await loadJob();
     const result = expireStaleReservations(0); // TTL 0 would expire anything reserved

--- a/backend/test/reservationExpirationJob.test.ts
+++ b/backend/test/reservationExpirationJob.test.ts
@@ -160,10 +160,15 @@ describe("expireStaleReservations", () => {
     expect(result.expiredBountyIds).not.toContain(corrupt.id);
     expect(warnSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        bountyId: corrupt.id,
-        reservedAt: "not-a-timestamp",
+        malformedCount: 1,
+        bounties: expect.arrayContaining([
+          expect.objectContaining({
+            bountyId: corrupt.id,
+            reservedAt: "not-a-timestamp",
+          }),
+        ]),
       }),
-      "[ExpirationJob] Skipping reserved bounty with malformed reservedAt",
+      "[ExpirationJob] Skipping reserved bounties with malformed reservedAt",
     );
 
     const raw = JSON.parse(fs.readFileSync(storeFile, "utf8"));


### PR DESCRIPTION
## Summary
- skip reserved bounties with malformed `reservedAt` values instead of letting them participate in expiration logic
- log the skipped bounty ID and bad timestamp so maintainers can inspect corrupted records
- add a regression test that proves valid stale reservations still expire when one reserved record is malformed

Closes #275

## Tests
- npm --prefix backend test -- reservationExpirationJob.test.ts

## Notes
- `npm --prefix backend run build` currently fails on unrelated existing TypeScript issues in `src/app.ts` / missing `swagger-ui-express` type declarations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reservation expiration validation to properly identify and skip invalid data entries, while logging warnings for system monitoring and preventing incorrect processing.

* **Tests**
  * Added test coverage for handling malformed reservation data during the expiration process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->