### PR TITLE
Add maintainer bounty index

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -5,8 +5,10 @@ mod test;
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short,
-    token::Client as TokenClient, Address, Env, String,
+    token::Client as TokenClient, Address, Env, String, Vec,
 };
+
+const MAX_MAINTAINER_BOUNTIES: u32 = 500;
 
 #[contracttype]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -43,6 +45,7 @@ enum DataKey {
     FeeRecipient,
     Arbiter,
     DisputeWindow,
+    MaintainerIndex(Address),
 }
 
 #[contracttype]
@@ -129,6 +132,7 @@ pub enum ContractError {
     BountyNotFound,
     NotArbiter,
     DisputeWindowNotMet,
+    MaintainerBountyLimitReached,
 }
 
 fn panic_error(error: ContractError) -> ! {
@@ -188,6 +192,16 @@ impl StellarBountyBoardContract {
             panic!("fee recipient not set");
         }
 
+        let maintainer_index_key = DataKey::MaintainerIndex(maintainer.clone());
+        let mut maintainer_bounties: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&maintainer_index_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        if maintainer_bounties.len() >= MAX_MAINTAINER_BOUNTIES {
+            panic_error(ContractError::MaintainerBountyLimitReached);
+        }
+
         let token_client = TokenClient::new(&env, &token);
         let contract_address = env.current_contract_address();
         token_client.transfer(&maintainer, &contract_address, &amount);
@@ -213,12 +227,17 @@ impl StellarBountyBoardContract {
             dispute_raised_at: 0,
         };
 
+        maintainer_bounties.push_back(next_id);
+
         env.storage()
             .persistent()
             .set(&DataKey::NextBountyId, &next_id);
         env.storage()
             .persistent()
             .set(&DataKey::Bounty(next_id), &bounty);
+        env.storage()
+            .persistent()
+            .set(&maintainer_index_key, &maintainer_bounties);
 
         env.events().publish(
             (symbol_short!("Bounty"), symbol_short!("Create")),
@@ -523,6 +542,13 @@ impl StellarBountyBoardContract {
         let mut bounty = read_bounty(&env, bounty_id);
         expire_if_needed(&env, &mut bounty);
         bounty
+    }
+
+    pub fn get_maintainer_bounties(env: Env, maintainer: Address) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MaintainerIndex(maintainer))
+            .unwrap_or_else(|| Vec::new(&env))
     }
 
     pub fn get_next_bounty_id(env: Env) -> u64 {

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -743,6 +743,24 @@ fn test_extend_deadline_earlier() {
 }
 
 #[test]
+fn test_get_maintainer_bounties_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, maintainer, _, _, _, _) = setup_test(&env);
+    let bounties = client.get_maintainer_bounties(&maintainer);
+
+    assert_eq!(bounties.len(), 0);
+}
+
+#[test]
+fn test_get_maintainer_bounties_single() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, maintainer, _, token_id, _, _) = setup_test(&env);
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin.mint(&maintainer, &500);
 
     let bounty_id = client.create_bounty(
         &maintainer,
@@ -751,21 +769,43 @@ fn test_extend_deadline_earlier() {
         &String::from_str(&env, "repo"),
         &1,
         &String::from_str(&env, "title"),
+        &(env.ledger().timestamp() + 1000),
+        &0u32,
+    );
 
-    let bounty_id = client.create_bounty(
-        &maintainer,
-        &token_id,
-        &500,
-        &String::from_str(&env, "repo"),
-        &1,
-        &String::from_str(&env, "title"),
+    let bounties = client.get_maintainer_bounties(&maintainer);
 
-    let bounty_id = client.create_bounty(
-        &maintainer,
-        &token_id,
-        &500,
-        &String::from_str(&env, "repo"),
-        &1,
-        &String::from_str(&env, "title"),
+    assert_eq!(bounties.len(), 1);
+    assert_eq!(bounties.get(0), Some(bounty_id));
+}
 
+#[test]
+fn test_get_maintainer_bounties_multiple_same_maintainer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, maintainer, _, token_id, _, _) = setup_test(&env);
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin.mint(&maintainer, &2000);
+
+    let deadline = env.ledger().timestamp() + 1000;
+    for _ in 0..3u8 {
+        client.create_bounty(
+            &maintainer,
+            &token_id,
+            &500,
+            &String::from_str(&env, "repo"),
+            &1,
+            &String::from_str(&env, "title"),
+            &deadline,
+            &0u32,
+        );
+    }
+
+    let bounties = client.get_maintainer_bounties(&maintainer);
+
+    assert_eq!(bounties.len(), 3);
+    assert_eq!(bounties.get(0), Some(1));
+    assert_eq!(bounties.get(1), Some(2));
+    assert_eq!(bounties.get(2), Some(3));
 }


### PR DESCRIPTION
Closes #227.\n\n## Summary\n- Adds a persistent maintainer-to-bounty-id index updated during bounty creation\n- Adds get_maintainer_bounties so callers can query bounty IDs by maintainer address\n- Caps each maintainer index at 500 entries to prevent unbounded storage growth\n- Adds unit coverage for empty, single, and multiple bounty results\n\n## Testing\n- git diff --check\n- cargo test -q was not run because cargo is not installed in this environment