### PR TITLE
Validate bounty store path on startup

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,9 +1,11 @@
 import "dotenv/config";
 import { app } from "./app";
 import { logStructured } from "./logger";
+import { validateBountyStorePath } from "./services/bountyStore";
 
 const port = Number(process.env.PORT ?? 3001);
 
+validateBountyStorePath();
 
 app.listen(port, () => {
   logStructured("info", "server_listen", { port });

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -91,7 +91,7 @@ export const logger = pino(
 export type LogFields = Record<string, string | number | boolean | null | undefined>;
 
 export function logStructured(
-  level: "info" | "warn" | "error",
+  level: "info" | "warn" | "error" | "fatal",
   msg: string,
   fields: LogFields = {},
 ): void {

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -87,11 +87,35 @@ interface CreateAuditLogInput {
   metadata?: Record<string, AuditMetadataValue | undefined>;
 }
 
+interface ValidateBountyStorePathOptions {
+  exit?: (code: number) => never;
+}
+
 function getStorePath(): string {
   if (process.env.BOUNTY_STORE_PATH?.trim()) {
     return path.resolve(process.env.BOUNTY_STORE_PATH.trim());
   }
   return path.resolve(__dirname, "../../data/bounties.json");
+}
+
+export function validateBountyStorePath(options: ValidateBountyStorePathOptions = {}): void {
+  const storePath = getStorePath();
+
+  try {
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    const file = fs.openSync(storePath, "a");
+    try {
+      fs.writeSync(file, "");
+    } finally {
+      fs.closeSync(file);
+    }
+  } catch (error) {
+    logStructured("fatal", "bounty_store_path_invalid", {
+      storePath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    (options.exit ?? process.exit)(1);
+  }
 }
 
 function getAuditStorePath(): string {

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -98,20 +98,27 @@ function getStorePath(): string {
   return path.resolve(__dirname, "../../data/bounties.json");
 }
 
+function assertWritableFilePath(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const file = fs.openSync(filePath, "a");
+  try {
+    fs.writeSync(file, "");
+  } finally {
+    fs.closeSync(file);
+  }
+}
+
 export function validateBountyStorePath(options: ValidateBountyStorePathOptions = {}): void {
   const storePath = getStorePath();
+  const auditStorePath = getAuditStorePath();
 
   try {
-    fs.mkdirSync(path.dirname(storePath), { recursive: true });
-    const file = fs.openSync(storePath, "a");
-    try {
-      fs.writeSync(file, "");
-    } finally {
-      fs.closeSync(file);
-    }
+    assertWritableFilePath(storePath);
+    assertWritableFilePath(auditStorePath);
   } catch (error) {
     logStructured("fatal", "bounty_store_path_invalid", {
       storePath,
+      auditStorePath,
       error: error instanceof Error ? error.message : String(error),
     });
     (options.exit ?? process.exit)(1);

--- a/backend/test/bountyStorePathValidation.test.ts
+++ b/backend/test/bountyStorePathValidation.test.ts
@@ -18,6 +18,7 @@ async function loadValidator() {
 
 afterEach(() => {
   delete process.env.BOUNTY_STORE_PATH;
+  delete process.env.BOUNTY_AUDIT_STORE_PATH;
   vi.restoreAllMocks();
 
   for (const root of tempRoots.splice(0)) {
@@ -55,6 +56,22 @@ describe("bounty store path startup validation", () => {
     const blockedParent = path.join(root, "not-a-directory");
     fs.writeFileSync(blockedParent, "blocks nested paths", "utf8");
     process.env.BOUNTY_STORE_PATH = path.join(blockedParent, "bounties.json");
+    const exit = vi.fn((code: number): never => {
+      throw new Error(`exit:${code}`);
+    });
+
+    const { validateBountyStorePath } = await loadValidator();
+
+    expect(() => validateBountyStorePath({ exit })).toThrow("exit:1");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("logs a fatal startup error and exits when the audit store path cannot be written", async () => {
+    const root = makeTempRoot();
+    process.env.BOUNTY_STORE_PATH = path.join(root, "bounties.json");
+    const blockedParent = path.join(root, "not-a-directory");
+    fs.writeFileSync(blockedParent, "blocks nested paths", "utf8");
+    process.env.BOUNTY_AUDIT_STORE_PATH = path.join(blockedParent, "bounties.audit.json");
     const exit = vi.fn((code: number): never => {
       throw new Error(`exit:${code}`);
     });

--- a/backend/test/bountyStorePathValidation.test.ts
+++ b/backend/test/bountyStorePathValidation.test.ts
@@ -1,0 +1,67 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const tempRoots: string[] = [];
+
+function makeTempRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "bounty-store-validation-"));
+  tempRoots.push(root);
+  return root;
+}
+
+async function loadValidator() {
+  vi.resetModules();
+  return import("../src/services/bountyStore");
+}
+
+afterEach(() => {
+  delete process.env.BOUNTY_STORE_PATH;
+  vi.restoreAllMocks();
+
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("bounty store path startup validation", () => {
+  it("accepts an existing writable store path", async () => {
+    const root = makeTempRoot();
+    const storePath = path.join(root, "bounties.json");
+    fs.writeFileSync(storePath, "[]", "utf8");
+    process.env.BOUNTY_STORE_PATH = storePath;
+
+    const { validateBountyStorePath } = await loadValidator();
+
+    expect(() => validateBountyStorePath()).not.toThrow();
+    expect(fs.existsSync(storePath)).toBe(true);
+  });
+
+  it("creates a missing store directory before startup continues", async () => {
+    const root = makeTempRoot();
+    const storePath = path.join(root, "nested", "store", "bounties.json");
+    process.env.BOUNTY_STORE_PATH = storePath;
+
+    const { validateBountyStorePath } = await loadValidator();
+
+    expect(() => validateBountyStorePath()).not.toThrow();
+    expect(fs.existsSync(path.dirname(storePath))).toBe(true);
+    expect(fs.existsSync(storePath)).toBe(true);
+  });
+
+  it("logs a fatal startup error and exits when the path cannot be written", async () => {
+    const root = makeTempRoot();
+    const blockedParent = path.join(root, "not-a-directory");
+    fs.writeFileSync(blockedParent, "blocks nested paths", "utf8");
+    process.env.BOUNTY_STORE_PATH = path.join(blockedParent, "bounties.json");
+    const exit = vi.fn((code: number): never => {
+      throw new Error(`exit:${code}`);
+    });
+
+    const { validateBountyStorePath } = await loadValidator();
+
+    expect(() => validateBountyStorePath({ exit })).toThrow("exit:1");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add startup validation for BOUNTY_STORE_PATH
- create missing store directories before the server starts
- log a fatal error and exit with code 1 when the store path cannot be written

Closes #250.

## Tests
- npm.cmd --prefix backend test -- bountyStorePathValidation.test.ts

## Notes
- npm.cmd --prefix backend run build still fails on existing main-branch TypeScript issues unrelated to this change:
  - missing declaration file for swagger-ui-express
  - submissionUrl type mismatch in src/app.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added startup validation to ensure the data storage location exists and is writable before the server starts.
  * Missing parent directories are now created automatically during validation.
  * Application exits gracefully with an error message when storage path cannot be accessed.

* **Improvements**
  * Logging system now supports fatal-level messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->