### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,2 +1,37 @@
 ---
 name: Bug report
+about: Report a reproducible problem in Stellar Bounty Board
+title: "bug: "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+Briefly describe the bug and the affected area.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+What should have happened?
+
+## Actual behavior
+
+What happened instead?
+
+## Environment
+
+- Browser and version:
+- Operating system:
+- Frontend URL or local port:
+- Backend URL or local port:
+- Wallet or network, if relevant:
+
+## Additional context
+
+Add screenshots, logs, or links that help explain the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,29 @@
 ---
 name: Feature request
+about: Suggest an improvement or new capability
+title: "feat: "
+labels: enhancement
+assignees: ""
+---
 
+## Problem
+
+What user or maintainer problem should this solve?
+
+## Proposed solution
+
+Describe the change you would like to see.
+
+## Alternatives considered
+
+List any simpler or different approaches you considered.
+
+## Acceptance criteria
+
+- [ ]
+- [ ]
+- [ ]
+
+## Additional context
+
+Add mockups, examples, related issues, or implementation notes.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## What changed
+
+-
+
+## Why
+
+Explain the issue or user need this PR addresses.
+
+## Related issues
+
+Closes #
+
+## Testing done
+
+- [ ] Not run; reason:
+- [ ] Unit tests
+- [ ] Build
+- [ ] Manual smoke test
+
+## Checklist
+
+- [ ] Scope is focused on one issue
+- [ ] Documentation updated, if needed
+- [ ] Tests added or updated, if behavior changed
+- [ ] No debug logs or unrelated refactors included
+- [ ] Screenshots or recordings attached for UI changes


### PR DESCRIPTION
## Summary
- expand the bug report template with description, reproduction steps, expected vs actual behavior, and environment fields
- expand the feature request template with problem, proposed solution, alternatives, and acceptance criteria
- add a pull request template covering changes, testing, related issues, and review checklist

Closes #330.

## Tests
- Not run; GitHub template documentation-only change.