### PR TITLE
feat: add keep-alive and HTTP/2 via nginx reverse proxy in docker-compose

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,8 +3,12 @@ import { app } from "./app";
 import { logStructured } from "./logger";
 
 const port = Number(process.env.PORT ?? 3001);
+const keepAliveTimeout = Number(process.env.KEEP_ALIVE_TIMEOUT ?? 65000);
+const headersTimeout = Number(process.env.HEADERS_TIMEOUT ?? 66000);
 
-
-app.listen(port, () => {
-  logStructured("info", "server_listen", { port });
+const server = app.listen(port, () => {
+  logStructured("info", "server_listen", { port, keepAliveTimeout, headersTimeout });
 });
+
+server.keepAliveTimeout = keepAliveTimeout;
+server.headersTimeout = headersTimeout;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,13 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     container_name: stellar-bounty-backend
-    ports:
-      - "3001:3001"
+    expose:
+      - "3001"
     environment:
       - NODE_ENV=development
       - PORT=3001
+      - KEEP_ALIVE_TIMEOUT=65000
+      - HEADERS_TIMEOUT=66000
       # Shared cache across replicas (#361); falls back to in-memory if unset.
       - REDIS_URL=redis://redis:6379
     depends_on:
@@ -31,6 +33,26 @@ services:
       timeout: 5s
       retries: 5
       start_period: 20s
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: stellar-bounty-nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/certs:/etc/nginx/certs:ro
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     restart: unless-stopped
 
   redis:
@@ -56,8 +78,9 @@ services:
       - "3000:3000"
     environment:
       - NODE_ENV=development
+      - NEXT_PUBLIC_API_URL=http://nginx
     depends_on:
-      backend:
+      nginx:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:3000 || exit 1"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,66 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    keepalive_timeout 75;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_min_length 1024;
+    gzip_comp_level 5;
+    gzip_proxied any;
+    gzip_vary on;
+
+    upstream backend {
+        server backend:3001;
+        keepalive 32;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+
+        location / {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 60s;
+            proxy_connect_timeout 10s;
+        }
+    }
+
+    server {
+        listen 443 ssl http2;
+        server_name _;
+
+        ssl_certificate     /etc/nginx/certs/server.crt;
+        ssl_certificate_key /etc/nginx/certs/server.key;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+        ssl_session_cache   shared:SSL:10m;
+        ssl_session_timeout 10m;
+
+        location / {
+            proxy_pass http://backend;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_read_timeout 60s;
+            proxy_connect_timeout 10s;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Resolves the TCP handshake overhead caused by HTTP/1.1 without persistent connections by introducing an nginx reverse proxy with HTTP/2 and gzip support.

### Changes

- **`nginx/nginx.conf`** — new nginx config with:
  - HTTP/2 enabled on port 443 (TLS)
  - HTTP/1.1 keepalive upstream pool (`keepalive 32`) to backend
  - gzip compression for `application/json`, `text/plain`, `text/css`, `application/javascript`, and XML types
  - `proxy_pass` to the backend upstream
- **`docker-compose.yml`** — added `nginx` service (nginx:1.27-alpine):
  - Listens on ports 80 and 443
  - Backend now uses `expose` (internal only) instead of publishing port 3001
  - Frontend depends on nginx (healthy) instead of backend directly
  - `NEXT_PUBLIC_API_URL` set to nginx for frontend API calls
  - `KEEP_ALIVE_TIMEOUT=65000` and `HEADERS_TIMEOUT=66000` passed to backend
- **`backend/src/index.ts`** — tuned `server.keepAliveTimeout` and `server.headersTimeout` from env vars (65 s / 66 s) to stay above nginx's 75 s keepalive and avoid premature connection resets

### Acceptance Criteria

- [x] nginx container added with `proxy_pass` to backend
- [x] HTTP/2 enabled in nginx config (port 443 `http2`)
- [x] gzip compression for API responses
- [x] Backend `keepAliveTimeout` and `headersTimeout` tuned

Closes #357
Closes #340
Closes #341
Closes #360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced NGINX reverse proxy with SSL/TLS support for handling HTTP/HTTPS traffic.
  * Made server timeout settings (keep-alive and headers) configurable via environment variables.
  * Updated container orchestration to expose backend through NGINX instead of directly, improving security and infrastructure organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->