### PR TITLE
Add JSON body size and parse error safeguards

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -37,8 +37,14 @@ import {
 import { handleGitHubPrEvent } from "./webhooks/githubPrHandler";
 
 const INCOMING_REQUEST_ID = /^[a-zA-Z0-9-]{1,128}$/;
+const JSON_BODY_LIMIT_BYTES = 32 * 1024;
+const JSON_BODY_LIMIT = "32kb";
 
-
+type JsonBodyParserError = Error & {
+  type?: string;
+  status?: number;
+  statusCode?: number;
+};
 
 function resolveRequestId(req: Request): string {
   const raw = req.headers["x-request-id"];
@@ -76,14 +82,33 @@ function requestContextMiddleware(req: Request, res: Response, next: NextFunctio
 export const app = express();
 
 app.use(cors(buildCorsOptions()));
+app.use(requestContextMiddleware);
 
 // Parse JSON bodies; capture raw body for webhook signature verification
 app.use(
   express.json({
+    limit: JSON_BODY_LIMIT,
     verify: captureRawBody,
   }),
 );
-app.use(requestContextMiddleware);
+
+app.use((error: JsonBodyParserError, req: Request, res: Response, next: NextFunction) => {
+  if (error.type === "entity.too.large") {
+    res.status(413).json({
+      error: "Payload too large",
+      maxBytes: JSON_BODY_LIMIT_BYTES,
+      requestId: req.requestId,
+    });
+    return;
+  }
+
+  if (error.type === "entity.parse.failed" || error instanceof SyntaxError) {
+    res.status(400).json({ error: "Invalid JSON", requestId: req.requestId });
+    return;
+  }
+
+  next(error);
+});
 
 // Global read limit (GET only); mutation routes carry a stricter limit (#349).
 app.use(readLimiter);

--- a/backend/src/types/swagger-ui-express.d.ts
+++ b/backend/src/types/swagger-ui-express.d.ts
@@ -1,0 +1,1 @@
+declare module "swagger-ui-express";

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -1,7 +1,6 @@
 import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 
-import { githubPrUrlSchema } from "./prUrl";
 import { isValidStellarAddress } from "../utils";
 
 extendZodWithOpenApi(z);
@@ -10,6 +9,7 @@ extendZodWithOpenApi(z);
 const REPO_REGEX = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
 const TOKEN_REGEX = /^[A-Za-z0-9]{1,12}$/;
 const SOROBAN_ADDRESS_REGEX = /^C[A-Z2-7]{55}$/;
+const XLM_STROOP_SCALE = 10_000_000;
 
 const STELLAR_EXAMPLE = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 const TX_HASH_REGEX = /^[0-9a-fA-F]{64}$/;
@@ -76,7 +76,9 @@ export const createBountySchema = z
       .openapi({ example: "XLM", description: "Stellar token symbol for payout (1–12 alphanumeric chars)." }),
     amount: z.coerce
       .number()
-      .min(1, "Amount must be at least 1 XLM."),
+      .min(1, "Amount must be at least 1 XLM.")
+      .max(10000, "Amount cannot exceed 10000 XLM.")
+      .refine(hasAtMostSevenDecimalPlaces, "Amount must have at most 7 decimal places."),
 
     deadlineDays: z.coerce
       .number()
@@ -119,12 +121,24 @@ export const reserveBountySchema = z
 
 export const GITHUB_PR_URL_REGEX = /^https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/pull\/\d+$/;
 
+function hasAtMostSevenDecimalPlaces(amount: number): boolean {
+  const scaled = amount * XLM_STROOP_SCALE;
+  return Math.abs(scaled - Math.round(scaled)) < 1e-8;
+}
+
 export const submitBountySchema = z
   .object({
     contributor: stellarAccountSchema.openapi({
       description: "Must match the contributor who reserved the bounty.",
     }),
-
+    submissionUrl: z
+      .string()
+      .trim()
+      .url("Submission URL must be a valid URL.")
+      .openapi({
+        example: "https://github.com/owner/repo/pull/99",
+        description: "GitHub pull request URL for the completed bounty work.",
+      }),
     notes: z
       .string()
       .trim()

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -76,6 +76,30 @@ describe("API — bounty lifecycle routes", () => {
     expect(res.body.error).toBeDefined();
   });
 
+  it("POST create with oversized JSON returns structured 413", async () => {
+    const app = await getApp();
+    const res = await request(app)
+      .post("/api/bounties")
+      .send({ ...validCreateBody, summary: "x".repeat(33 * 1024) })
+      .expect(413);
+
+    expect(res.body).toMatchObject({
+      error: "Payload too large",
+      maxBytes: 32768,
+    });
+  });
+
+  it("POST create with malformed JSON returns structured 400", async () => {
+    const app = await getApp();
+    const res = await request(app)
+      .post("/api/bounties")
+      .set("Content-Type", "application/json")
+      .send("{")
+      .expect(400);
+
+    expect(res.body.error).toBe("Invalid JSON");
+  });
+
   it("POST create with amount below 1 XLM returns 400", async () => {
     const app = await getApp();
     const res = await request(app)


### PR DESCRIPTION
## Summary
- Limit Express JSON request bodies to 32kb while preserving raw-body capture for GitHub webhook signatures
- Return structured 413 responses for oversized JSON payloads with `maxBytes: 32768`
- Return structured 400 responses for malformed JSON before route handlers run
- Restore submit URL and XLM amount validation needed for the backend build/API tests to stay green

## Verification
- `npm run build`
- `npx vitest run test/api.test.ts`

Closes #254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced validation for bounty payout amounts, now enforcing a maximum of 7 decimal places.

* **Bug Fixes**
  * Improved error handling for oversized JSON payloads (32KB limit) and malformed JSON submissions. The API now returns structured error messages with request identifiers for better debugging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritik4ever/stellar-bounty-board/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->