### PR TITLE
Add stable lazy-loaded bounty avatar fallback

### DIFF
--- a/frontend/src/BountyDetailPage.test.tsx
+++ b/frontend/src/BountyDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -100,6 +100,47 @@ describe("BountyDetailPage copy actions", () => {
     await userEvent.click(screen.getByRole("button", { name: /print \/ export pdf/i }));
 
     expect(print).toHaveBeenCalledOnce();
+  });
+
+  it("renders the repository avatar with stable lazy-loading image attributes", () => {
+    render(
+      <BountyDetailPage
+        {...detailProps()}
+        avatarUrl="https://github.com/ritik4ever.png?size=72"
+      />,
+    );
+
+    const avatar = screen.getByRole("img", { name: "ritik4ever" });
+
+    expect(avatar).toHaveAttribute("src", "https://github.com/ritik4ever.png?size=56");
+    expect(avatar).toHaveAttribute(
+      "srcset",
+      "https://github.com/ritik4ever.png?size=56 56w, https://github.com/ritik4ever.png?size=112 112w",
+    );
+    expect(avatar).toHaveAttribute("sizes", "56px");
+    expect(avatar).toHaveAttribute("loading", "lazy");
+    expect(avatar).toHaveAttribute("decoding", "async");
+    expect(avatar).toHaveAttribute("width", "56");
+    expect(avatar).toHaveAttribute("height", "56");
+  });
+
+  it("shows a placeholder avatar when the repository avatar fails to load", () => {
+    render(
+      <BountyDetailPage
+        {...detailProps()}
+        avatarUrl="https://github.com/ritik4ever.png?size=72"
+      />,
+    );
+
+    fireEvent.error(screen.getByRole("img", { name: "ritik4ever" }));
+
+    expect(screen.getByRole("img", { name: "ritik4ever avatar placeholder" })).toHaveTextContent("RI");
+  });
+
+  it("shows a placeholder avatar when no repository avatar URL is available", () => {
+    renderDetail();
+
+    expect(screen.getByRole("img", { name: "ritik4ever avatar placeholder" })).toHaveTextContent("RI");
   });
 
   it("announces status changes for assistive technology", () => {

--- a/frontend/src/BountyDetailPage.test.tsx
+++ b/frontend/src/BountyDetailPage.test.tsx
@@ -143,6 +143,15 @@ describe("BountyDetailPage copy actions", () => {
     expect(screen.getByRole("img", { name: "ritik4ever avatar placeholder" })).toHaveTextContent("RI");
   });
 
+  it("reserves stable space for the async USD amount", () => {
+    const { container } = renderDetail();
+
+    const usdAmount = container.querySelector(".usd-amount");
+
+    expect(usdAmount).toBeInTheDocument();
+    expect(usdAmount).toHaveAttribute("aria-hidden", "true");
+  });
+
   it("announces status changes for assistive technology", () => {
     const { rerender } = renderDetail();
     const reservedBounty: Bounty = {

--- a/frontend/src/BountyDetailPage.tsx
+++ b/frontend/src/BountyDetailPage.tsx
@@ -74,6 +74,16 @@ const EVENT_LABELS: Record<string, string> = {
   expired: "Bounty expired",
 };
 
+function avatarUrlForSize(source: string, size: number) {
+  try {
+    const url = new URL(source);
+    url.searchParams.set("size", String(size));
+    return url.toString();
+  } catch {
+    return source;
+  }
+}
+
 function BountyTimeline({ events, formatTimestamp }: { events: BountyEvent[]; formatTimestamp: (v?: number) => string }) {
   if (!events || events.length === 0) return null;
 
@@ -119,6 +129,15 @@ export default function BountyDetailPage({
   formatTimestamp,
 }: Props) {
   const statusAnnouncement = useBountyStatusAnnouncement(bounty, statusCopy);
+  const [avatarFailed, setAvatarFailed] = useState(false);
+  const avatarSrc = avatarUrl ? avatarUrlForSize(avatarUrl, 56) : "";
+  const avatarSrcSet = avatarUrl
+    ? `${avatarUrlForSize(avatarUrl, 56)} 56w, ${avatarUrlForSize(avatarUrl, 112)} 112w`
+    : undefined;
+
+  useEffect(() => {
+    setAvatarFailed(false);
+  }, [avatarUrl]);
 
   // Update social meta tags when bounty data changes
   useEffect(() => {
@@ -178,13 +197,27 @@ export default function BountyDetailPage({
         ) : (
           <div className="bounty-detail__content">
             <div className="bounty-detail__hero">
-              {avatarUrl && (
+              {avatarUrl && !avatarFailed ? (
                 <img
                   className="repo-avatar"
-                  src={avatarUrl}
+                  src={avatarSrc}
+                  srcSet={avatarSrcSet}
+                  sizes="56px"
                   alt={owner}
                   loading="lazy"
+                  decoding="async"
+                  width={56}
+                  height={56}
+                  onError={() => setAvatarFailed(true)}
                 />
+              ) : (
+                <div
+                  className="repo-avatar repo-avatar--placeholder"
+                  role="img"
+                  aria-label={owner ? `${owner} avatar placeholder` : "Repository avatar placeholder"}
+                >
+                  <span aria-hidden="true">{owner.slice(0, 2).toUpperCase() || "GH"}</span>
+                </div>
               )}
               <div>
                 <span

--- a/frontend/src/UsdAmount.tsx
+++ b/frontend/src/UsdAmount.tsx
@@ -18,7 +18,12 @@ export default function UsdAmount({ amount }: UsdAmountProps) {
     };
   }, [amount]);
 
-  if (!usdValue) return null;
-
-  return <span className="usd-amount">({usdValue})</span>;
+  return (
+    <span
+      className="usd-amount"
+      aria-hidden={!usdValue ? "true" : undefined}
+    >
+      {usdValue ? `(${usdValue})` : ""}
+    </span>
+  );
 }

--- a/frontend/src/imageAttributes.test.ts
+++ b/frontend/src/imageAttributes.test.ts
@@ -1,0 +1,81 @@
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+type ImageViolation = {
+  file: string;
+  missing: string[];
+  tag: string;
+};
+
+const sourceFiles = import.meta.glob("./**/*.{ts,tsx}", {
+  eager: true,
+  import: "default",
+  query: "?raw",
+}) as Record<string, string>;
+
+function jsxAttributeValue(attribute: ts.JsxAttribute) {
+  const initializer = attribute.initializer;
+
+  if (!initializer) return true;
+  if (ts.isStringLiteral(initializer)) return initializer.text;
+  if (ts.isJsxExpression(initializer) && initializer.expression && ts.isStringLiteral(initializer.expression)) {
+    return initializer.expression.text;
+  }
+
+  return true;
+}
+
+function collectImageViolations(fileName: string, source: string) {
+  const parsed = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const violations: ImageViolation[] = [];
+
+  function inspectAttributes(attributes: ts.JsxAttributes, node: ts.Node) {
+    const props = new Map<string, string | true>();
+
+    for (const prop of attributes.properties) {
+      if (ts.isJsxAttribute(prop)) {
+        props.set(prop.name.text, jsxAttributeValue(prop));
+      }
+    }
+
+    const missing = [
+      props.get("loading") === "lazy" ? null : 'loading="lazy"',
+      props.get("decoding") === "async" ? null : 'decoding="async"',
+      props.has("width") ? null : "width",
+      props.has("height") ? null : "height",
+    ].filter((value): value is string => Boolean(value));
+
+    if (missing.length > 0) {
+      violations.push({
+        file: fileName,
+        missing,
+        tag: node.getText(parsed),
+      });
+    }
+  }
+
+  function visit(node: ts.Node) {
+    if (ts.isJsxSelfClosingElement(node) && node.tagName.getText(parsed) === "img") {
+      inspectAttributes(node.attributes, node);
+    }
+
+    if (ts.isJsxOpeningElement(node) && node.tagName.getText(parsed) === "img") {
+      inspectAttributes(node.attributes, node);
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(parsed);
+  return violations;
+}
+
+describe("app image tags", () => {
+  it("keeps every JSX img lazy, async decoded, and size-constrained", () => {
+    const violations = Object.entries(sourceFiles).flatMap(([fileName, source]) =>
+      collectImageViolations(fileName, source),
+    );
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;600&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;600&display=optional");
 
 :root {
   color-scheme: light;
@@ -1093,10 +1093,13 @@ select {
 }
 
 .usd-amount {
+  display: inline-block;
+  min-width: 14ch;
   font-size: 0.75rem;
   opacity: 0.65;
   font-family: "IBM Plex Mono", monospace;
   font-weight: 400;
+  text-align: left;
 }
 
 .status-pill {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -792,9 +792,21 @@ select {
 .repo-avatar {
   width: 56px;
   height: 56px;
+  flex: 0 0 56px;
   border-radius: 18px;
   border: 1px solid rgba(54, 63, 59, 0.12);
   background: rgba(255, 255, 255, 0.9);
+  object-fit: cover;
+}
+
+.repo-avatar--placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #e6f4ee, #f7d9c8);
+  color: #174337;
+  font-weight: 800;
+  letter-spacing: 0;
 }
 
 .meta-grid--detail {


### PR DESCRIPTION
## Summary
Fixes #363.

Updates the bounty detail repository avatar so it has stable image-loading attributes and a fallback placeholder when the image cannot load. I also ran an official Lighthouse pass after the first fix, found the remaining CLS was caused by late webfont/USD-label layout movement, and included the extra layout reservations needed for the bounty detail route to hit CLS 0.

## What changed
- Keeps repository avatar loading lazy.
- Adds `srcSet`/`sizes` for 56px and 112px avatar variants.
- Adds `decoding="async"`.
- Adds explicit `width` and `height` attributes.
- Keeps avatar layout stable with fixed CSS sizing and `object-fit: cover`.
- Shows a placeholder avatar when the image URL is missing or the image fails to load.
- Reserves stable space for the async USD amount so the amount chip does not expand after render.
- Changes Google font loading to `display=optional` to avoid late webfont swap layout shift.
- Adds regression tests for image attributes, dimensions, broken/missing avatar fallback, the reserved USD slot, and app-wide JSX `<img>` attribute coverage.

## Due diligence
- Verified the only JSX `<img>` currently in `frontend/src` is the bounty detail repository avatar.
- Added `frontend/src/imageAttributes.test.ts`, which parses app TSX source and fails if any JSX `<img>` lacks `loading="lazy"`, `decoding="async"`, `width`, or `height`.
- Ran official Lighthouse 13.3.0 against a temporary isolated Vite route rendering `BountyDetailPage` with the repo CSS. The route was local-only and is not committed.
- The first Lighthouse run after the image fix still reported CLS around 0.111. Trace inspection showed the remaining layout shift came from webfont swap and the async USD amount label, not from the avatar image. This PR includes the targeted fixes for those remaining shifts.
- Re-ran Lighthouse for both a normal avatar URL and a broken avatar URL after the follow-up fix. Both produced CLS 0.

## Verification
Ran:

```powershell
npm --prefix frontend test -- src/BountyDetailPage.test.tsx src/imageAttributes.test.ts
git diff --check
rg -n "<img" frontend/src -S
```

Result:

```text
BountyDetailPage.test.tsx + imageAttributes.test.ts: 2 files passed, 10 tests passed
git diff --check: no whitespace errors
static image audit: only frontend/src\BountyDetailPage.tsx contains a JSX <img>
```

Official Lighthouse 13.3.0 loaded-avatar command:

```powershell
npx --yes lighthouse@latest http://127.0.0.1:5178/cls-check/ --only-categories=performance --output=json --output-path=lighthouse-performance-fontoptional-loaded.json --chrome-flags="--headless=new --no-sandbox --disable-gpu" --quiet
```

Loaded-avatar CLS result:

```text
cumulative-layout-shift numericValue: 0
cumulative-layout-shift displayValue: 0
cumulative-layout-shift score: 1
```

Official Lighthouse 13.3.0 broken-avatar command:

```powershell
npx --yes lighthouse@latest "http://127.0.0.1:5178/cls-check/?mode=broken" --only-categories=performance --output=json --output-path=lighthouse-performance-fontoptional-broken.json --chrome-flags="--headless=new --no-sandbox --disable-gpu" --quiet
```

Broken-avatar CLS result:

```text
cumulative-layout-shift numericValue: 0
cumulative-layout-shift displayValue: 0
cumulative-layout-shift score: 1
```

## Notes
- Scope is kept to the bounty detail image surface currently present in `frontend/src`, plus the two layout reservations needed for Lighthouse CLS 0 on that same surface.
- No generated files, Lighthouse JSON reports, or temporary test route files are included in this PR.
- Broader frontend checks currently fail on existing baseline issues outside this patch:
  - `npm --prefix frontend run build` fails first at `src/api.ts(158,1)` with `TS1128: Declaration or statement expected`.
  - `npm --prefix frontend test` has unrelated recommendation/toast/dark-mode failures.
- AI-assisted implementation: yes, reviewed and verified locally.
