### PR TITLE
feat: add response gzip compression to Express (#356)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -406,3 +406,6 @@ app.get("/api/leaderboard", (req: Request, res: Response) => {
     sendError(res, req, error);
   }
 });
+
+import compression from 'compression';
+app.use(compression());

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -77,6 +77,9 @@ export const app = express();
 
 app.use(cors(buildCorsOptions()));
 
+// Compression before routes — must be early to intercept responses
+app.use(compression());
+
 // Parse JSON bodies; capture raw body for webhook signature verification
 app.use(
   express.json({
@@ -407,5 +410,3 @@ app.get("/api/leaderboard", (req: Request, res: Response) => {
   }
 });
 
-import compression from 'compression';
-app.use(compression());


### PR DESCRIPTION
Adds compression middleware for gzip/brotli response compression.\n\nCloses #356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled HTTP response compression to reduce payload sizes and improve perceived load times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->