### PR TITLE
feat: paginate bounties API

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -10,6 +10,7 @@ import {
   listBountyAuditLogs,
   listBounties,
   listBountiesCached,
+  listBountiesPage,
   refundBounty,
   releaseBounty,
   reserveBounty,
@@ -159,8 +160,16 @@ app.get("/worker/health", (_req: Request, res: Response) => {
 });
 
 app.get("/api/bounties", async (req: Request, res: Response) => {
-  const q = typeof req.query.q === "string" ? req.query.q : undefined;
-  res.json({ data: await listBountiesCached({ q }) });
+  try {
+    const q = typeof req.query.q === "string" ? req.query.q : undefined;
+    const page = parsePaginationValue(req.query.page, "page", 1, 1);
+    const pageSize = parsePaginationValue(req.query.pageSize, "pageSize", 20, 1, 100);
+    const payload = await listBountiesPage({ q, page, pageSize });
+    res.setHeader("X-Total-Count", String(payload.total));
+    res.json(payload);
+  } catch (error) {
+    sendError(res, req, error);
+  }
 });
 
 app.get("/api/leaderboard", (_req: Request, res: Response) => {

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -350,6 +350,14 @@ export interface ListBountiesOptions {
   q?: string;
 }
 
+export interface PaginatedBounties {
+  data: BountyRecord[];
+  total: number;
+  page: number;
+  pageSize: number;
+  hasMore: boolean;
+}
+
 export function listBounties(options: ListBountiesOptions = {}): BountyRecord[] {
   const records = normalizeRecords(readStore());
   let sorted = [...records].sort((a, b) => b.createdAt - a.createdAt);
@@ -785,4 +793,24 @@ export function getLeaderboard(limit = 10): LeaderboardEntry[] {
   return Array.from(entries.values())
     .sort((a, b) => b.totalXlm - a.totalXlm || b.bountiesCompleted - a.bountiesCompleted)
     .slice(0, limit);
+}
+
+export async function listBountiesPage(
+  options: ListBountiesOptions & { page?: number; pageSize?: number } = {},
+  cache: CacheAdapter = getCache(),
+): Promise<PaginatedBounties> {
+  const page = options.page ?? 1;
+  const pageSize = options.pageSize ?? 20;
+  const records = await listBountiesCached({ q: options.q }, cache);
+  const total = records.length;
+  const offset = (page - 1) * pageSize;
+  const data = records.slice(offset, offset + pageSize);
+
+  return {
+    data,
+    total,
+    page,
+    pageSize,
+    hasMore: offset + pageSize < total,
+  };
 }

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -43,10 +43,35 @@ describe("API — health and listing", () => {
     expect(res.body.service).toContain("bounty-board");
   });
 
-  it("GET /api/bounties returns data array", async () => {
+  it("GET /api/bounties returns a paginated data array", async () => {
     const app = await getApp();
     const res = await request(app).get("/api/bounties").expect(200);
     expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body).toMatchObject({ total: 0, page: 1, pageSize: 20, hasMore: false });
+    expect(res.headers["x-total-count"]).toBe("0");
+  });
+
+  it("GET /api/bounties paginates results and validates pageSize", async () => {
+    const app = await getApp();
+    for (let i = 0; i < 3; i += 1) {
+      await request(app)
+        .post("/api/bounties")
+        .send({ ...validCreateBody, issueNumber: validCreateBody.issueNumber + i })
+        .expect(201);
+    }
+
+    const first = await request(app).get("/api/bounties").query({ page: 1, pageSize: 2 }).expect(200);
+    expect(first.body.data).toHaveLength(2);
+    expect(first.body.total).toBe(3);
+    expect(first.body.hasMore).toBe(true);
+    expect(first.headers["x-total-count"]).toBe("3");
+
+    const second = await request(app).get("/api/bounties").query({ page: 2, pageSize: 2 }).expect(200);
+    expect(second.body.data).toHaveLength(1);
+    expect(second.body.hasMore).toBe(false);
+
+    const invalid = await request(app).get("/api/bounties").query({ pageSize: 101 }).expect(400);
+    expect(invalid.body.error).toMatch(/pageSize/i);
   });
 
   it("GET /api/open-issues returns data", async () => {


### PR DESCRIPTION
## Summary
- adds server-side pagination to `GET /api/bounties` via `page` and `pageSize` query params
- returns `{ data, total, page, pageSize, hasMore }` plus `X-Total-Count`
- caps `pageSize` at 100 and returns 400 for oversized values
- adds integration coverage for pagination metadata and invalid page size

Closes #248.

## Validation
- `git diff --check` ✅
- `npm --prefix backend test -- --run test/api.test.ts --reporter=dot` → 25 passed, 2 failed

The 2 failing tests are existing amount validation failures unrelated to pagination:
- `POST create with amount above 10000 XLM returns 400` currently gets 201
- `POST create with more than 7 decimal places returns 400` currently gets 201

I kept this PR scoped to pagination only.
