### PR TITLE
Add amount range filters to bounty list API

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -124,6 +124,23 @@ function parsePaginationValue(
   return parsed;
 }
 
+function parseAmountFilter(raw: unknown, field: string): number | undefined {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`${field} must be a number.`);
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${field} must be a number.`);
+  }
+
+  return parsed;
+}
+
 function jsonError(res: Response, req: Request, statusCode: number, message: string) {
   res.status(statusCode).json({ error: message, requestId: req.requestId });
 }
@@ -159,8 +176,14 @@ app.get("/worker/health", (_req: Request, res: Response) => {
 });
 
 app.get("/api/bounties", async (req: Request, res: Response) => {
-  const q = typeof req.query.q === "string" ? req.query.q : undefined;
-  res.json({ data: await listBountiesCached({ q }) });
+  try {
+    const q = typeof req.query.q === "string" ? req.query.q : undefined;
+    const minAmount = parseAmountFilter(req.query.minAmount, "minAmount");
+    const maxAmount = parseAmountFilter(req.query.maxAmount, "maxAmount");
+    res.json({ data: await listBountiesCached({ q, minAmount, maxAmount }) });
+  } catch (error) {
+    sendError(res, req, error);
+  }
 });
 
 app.get("/api/leaderboard", (_req: Request, res: Response) => {

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -348,6 +348,10 @@ function persistUpdated(records: BountyRecord[], updated: BountyRecord): BountyR
 export interface ListBountiesOptions {
   /** Case-insensitive substring filter applied to title, summary, and labels. */
   q?: string;
+  /** Minimum bounty amount, inclusive. */
+  minAmount?: number;
+  /** Maximum bounty amount, inclusive. */
+  maxAmount?: number;
 }
 
 export function listBounties(options: ListBountiesOptions = {}): BountyRecord[] {
@@ -362,6 +366,14 @@ export function listBounties(options: ListBountiesOptions = {}): BountyRecord[] 
         b.summary.toLowerCase().includes(q) ||
         b.labels.some((l) => l.toLowerCase().includes(q)),
     );
+  }
+
+  if (options.minAmount !== undefined) {
+    sorted = sorted.filter((b) => b.amount >= options.minAmount!);
+  }
+
+  if (options.maxAmount !== undefined) {
+    sorted = sorted.filter((b) => b.amount <= options.maxAmount!);
   }
 
   return sorted;
@@ -391,16 +403,27 @@ export async function listBountiesCached(
     await cache.set(BOUNTY_LIST_CACHE_KEY, JSON.stringify(records), BOUNTY_LIST_TTL_SECONDS);
   }
 
+  let filtered = records;
+
   const q = options.q?.trim().toLowerCase();
-  if (!q) {
-    return records;
+  if (q) {
+    filtered = filtered.filter(
+      (b) =>
+        b.title.toLowerCase().includes(q) ||
+        b.summary.toLowerCase().includes(q) ||
+        b.labels.some((l) => l.toLowerCase().includes(q)),
+    );
   }
-  return records.filter(
-    (b) =>
-      b.title.toLowerCase().includes(q) ||
-      b.summary.toLowerCase().includes(q) ||
-      b.labels.some((l) => l.toLowerCase().includes(q)),
-  );
+
+  if (options.minAmount !== undefined) {
+    filtered = filtered.filter((b) => b.amount >= options.minAmount!);
+  }
+
+  if (options.maxAmount !== undefined) {
+    filtered = filtered.filter((b) => b.amount <= options.maxAmount!);
+  }
+
+  return filtered;
 }
 
 /** Drop the cached bounty list so the next read reflects a mutation (#361). */

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -112,6 +112,32 @@ describe("API — bounty lifecycle routes", () => {
     expect(res.body.data.id).toMatch(/^BNT-\d{4}$/);
   });
 
+  it("GET /api/bounties filters by amount range", async () => {
+    const app = await getApp();
+
+    await request(app).post("/api/bounties").send({ ...validCreateBody, amount: 75, title: "Small bounty" }).expect(201);
+    await request(app).post("/api/bounties").send({ ...validCreateBody, amount: 250, title: "Target bounty" }).expect(201);
+    await request(app).post("/api/bounties").send({ ...validCreateBody, amount: 750, title: "Large bounty" }).expect(201);
+
+    const minOnly = await request(app).get("/api/bounties?minAmount=250").expect(200);
+    expect(minOnly.body.data.map((b: { amount: number }) => b.amount)).toEqual(expect.arrayContaining([250, 750]));
+    expect(minOnly.body.data.some((b: { amount: number }) => b.amount === 75)).toBe(false);
+
+    const maxOnly = await request(app).get("/api/bounties?maxAmount=250").expect(200);
+    expect(maxOnly.body.data.map((b: { amount: number }) => b.amount)).toEqual(expect.arrayContaining([75, 250]));
+    expect(maxOnly.body.data.some((b: { amount: number }) => b.amount === 750)).toBe(false);
+
+    const combined = await request(app).get("/api/bounties?minAmount=100&maxAmount=500").expect(200);
+    expect(combined.body.data.map((b: { amount: number }) => b.amount)).toEqual([250]);
+  });
+
+  it("GET /api/bounties returns 400 for non-numeric amount filters", async () => {
+    const app = await getApp();
+
+    const res = await request(app).get("/api/bounties?minAmount=abc").expect(400);
+    expect(res.body.error).toMatch(/minAmount must be a number/i);
+  });
+
   it("POST create with 1 XLM succeeds", async () => {
     const app = await getApp();
     const res = await request(app)


### PR DESCRIPTION
Closes #262.\n\nAdds minAmount/maxAmount query params to GET /api/bounties with inclusive filtering and 400 responses for non-numeric values. Includes integration coverage for min only, max only, combined range, and invalid input.\n\nNote: local test command could not run because dependencies are not installed in the fresh clone (vitest: not found).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The bounties endpoint now supports filtering by price range using `minAmount` and `maxAmount` query parameters, allowing users to narrow results within their budget.

* **Bug Fixes**
  * Enhanced validation and error handling for numeric filter parameters with improved error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->