### PR TITLE
feat(seo): Add robots.txt, dynamic sitemap.xml, canonical links and Stellar Expert tx links

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -142,6 +142,56 @@ function sendError(res: Response, req: Request, error: unknown, statusCode = 400
   jsonError(res, req, statusCode, message);
 }
 
+// ─── SEO: robots.txt (issue #373) ────────────────────────────────────────────
+// Allow all user agents to crawl bounty pages; disallow admin/internal paths.
+app.get("/robots.txt", (_req: Request, res: Response) => {
+  const FRONTEND_URL = process.env.FRONTEND_URL ?? "https://stellar-bounty-board.vercel.app";
+  res.type("text/plain").send(
+    [
+      "User-agent: *",
+      "Allow: /",
+      "Disallow: /api/",
+      "Disallow: /admin/",
+      "",
+      `Sitemap: ${FRONTEND_URL}/sitemap.xml`,
+    ].join("\n")
+  );
+});
+
+// ─── SEO: dynamic sitemap.xml (issue #373) ───────────────────────────────────
+// Lists every released/open bounty with its canonical URL so search engines
+// can efficiently discover and index individual bounty pages.
+app.get("/sitemap.xml", (_req: Request, res: Response) => {
+  const FRONTEND_URL = process.env.FRONTEND_URL ?? "https://stellar-bounty-board.vercel.app";
+  const allBounties = listBounties();
+  const indexable = allBounties.filter(
+    (b) => b.status === "open" || b.status === "released"
+  );
+
+  const urlset = indexable
+    .map((b) => {
+      const lastmod = b.releasedAt ?? b.createdAt ?? new Date().toISOString();
+      return [
+        "  <url>",
+        `    <loc>${FRONTEND_URL}/bounties/${b.id}</loc>`,
+        `    <lastmod>${new Date(lastmod).toISOString().split("T")[0]}</lastmod>`,
+        "    <changefreq>weekly</changefreq>",
+        "    <priority>0.7</priority>",
+        "  </url>",
+      ].join("\n");
+    })
+    .join("\n");
+
+  const xml = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    urlset,
+    "</urlset>",
+  ].join("\n");
+
+  res.type("application/xml").send(xml);
+});
+
 app.get("/api/health", (_req: Request, res: Response) => {
   res.json({
     service: "stellar-bounty-board-backend",

--- a/frontend/src/BountyDetailPage.tsx
+++ b/frontend/src/BountyDetailPage.tsx
@@ -130,6 +130,21 @@ export default function BountyDetailPage({
     };
   }, [bounty]);
 
+  // Issue #373: inject canonical <link> so search engines index the stable URL
+  useEffect(() => {
+    if (!bounty) return;
+    let canonical = document.querySelector<HTMLLinkElement>("link[rel='canonical']");
+    if (!canonical) {
+      canonical = document.createElement("link");
+      canonical.rel = "canonical";
+      document.head.appendChild(canonical);
+    }
+    canonical.href = `${window.location.origin}/bounties/${bounty.id}`;
+    return () => {
+      if (canonical) canonical.href = "";
+    };
+  }, [bounty]);
+
   function handlePrint() {
     window.print();
   }
@@ -276,7 +291,17 @@ export default function BountyDetailPage({
                 <div>
                   <span className="meta-label">Release tx</span>
                   <strong className="copy-row">
-                    {bounty.releasedTxHash}
+                    {/* Issue #382: clickable Stellar Expert deep link */}
+                    <a
+                      className="inline-link"
+                      href={`https://stellar.expert/explorer/testnet/tx/${bounty.releasedTxHash}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      title="View on Stellar Expert"
+                    >
+                      {bounty.releasedTxHash.slice(0, 8)}…{bounty.releasedTxHash.slice(-6)}
+                      <ArrowUpRight size={12} aria-hidden="true" />
+                    </a>
                     <CopyIcon text={bounty.releasedTxHash} label="release transaction hash" />
                   </strong>
                 </div>
@@ -285,7 +310,17 @@ export default function BountyDetailPage({
                 <div>
                   <span className="meta-label">Refund tx</span>
                   <strong className="copy-row">
-                    {bounty.refundedTxHash}
+                    {/* Issue #382: clickable Stellar Expert deep link */}
+                    <a
+                      className="inline-link"
+                      href={`https://stellar.expert/explorer/testnet/tx/${bounty.refundedTxHash}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      title="View on Stellar Expert"
+                    >
+                      {bounty.refundedTxHash.slice(0, 8)}…{bounty.refundedTxHash.slice(-6)}
+                      <ArrowUpRight size={12} aria-hidden="true" />
+                    </a>
                     <CopyIcon text={bounty.refundedTxHash} label="refund transaction hash" />
                   </strong>
                 </div>


### PR DESCRIPTION
## Summary

Adds full SEO infrastructure for the bounty board: `robots.txt`, dynamic `sitemap.xml`, canonical URL injection, and clickable Stellar Expert transaction hash links.

## Changes

### `backend/src/app.ts`
- **`GET /robots.txt`** — Allows all user agents to crawl bounty pages; blocks `/api/` and `/admin/`. References the sitemap URL via the `FRONTEND_URL` env var.
- **`GET /sitemap.xml`** — Dynamically generated from the live bounty list. Includes every `open` and `released` bounty with its canonical URL, `lastmod` date, `changefreq`, and `priority`.

### `frontend/src/BountyDetailPage.tsx`
- **Canonical link injection** — `useEffect` inserts/updates `<link rel='canonical' href='/bounties/:id'>` in the document head whenever the bounty changes, and clears it on unmount.
- **Stellar Expert deep links (issue #382)** — `releasedTxHash` and `refundedTxHash` are now rendered as clickable `<a>` tags pointing to `https://stellar.expert/explorer/testnet/tx/<hash>` with truncated display text and an `ArrowUpRight` icon.

## Acceptance Criteria (issue #373)
- [x] `robots.txt` served at `/robots.txt` allowing all user agents on bounty pages
- [x] `sitemap.xml` generated dynamically from the bounty API
- [x] Each released/open bounty has a canonical URL in the sitemap
- [x] Canonical `<link>` added to `BountyDetailPage`

Closes #373
Closes #335
Closes #382
Closes #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `robots.txt` and `sitemap.xml` endpoints for improved search engine indexing.
  * Implemented canonical link tags for better SEO and duplicate page detection.
  * Made transaction hashes clickable with direct links to Stellar Expert, displaying truncated hashes with external link icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->