### PR TITLE
feat(auth): require Stellar signature on POST /api/bounties

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -34,6 +34,7 @@ import {
   captureRawBody,
   createGitHubWebhookSignatureMiddleware,
 } from "./webhooks/signatureVerification";
+import { createBountyCreationSignatureMiddleware, createStellarSignatureAuthMiddleware } from "./middleware/auth";
 import { handleGitHubPrEvent } from "./webhooks/githubPrHandler";
 
 const INCOMING_REQUEST_ID = /^[a-zA-Z0-9-]{1,128}$/;
@@ -285,7 +286,7 @@ app.get("/api/bounties/released/export.csv", (req: Request, res: Response) => {
   }
 });
 
-app.post("/api/bounties", mutationLimiter, async (req: Request, res: Response) => {
+app.post("/api/bounties", mutationLimiter, createBountyCreationSignatureMiddleware(), async (req: Request, res: Response) => {
   const parsed = createBountySchema.safeParse(req.body);
   if (!parsed.success) {
     jsonError(res, req, 400, zodErrorMessage(parsed.error));
@@ -335,7 +336,7 @@ app.post("/api/bounties/:id/submit", mutationLimiter, async (req: Request, res: 
   }
 });
 
-app.post("/api/bounties/:id/release", mutationLimiter, async (req: Request, res: Response) => {
+app.post("/api/bounties/:id/release", mutationLimiter, createStellarSignatureAuthMiddleware(), async (req: Request, res: Response) => {
   const parsedBody = maintainerActionSchema.safeParse(req.body);
   if (!parsedBody.success) {
     jsonError(res, req, 400, zodErrorMessage(parsedBody.error));
@@ -354,7 +355,7 @@ app.post("/api/bounties/:id/release", mutationLimiter, async (req: Request, res:
   }
 });
 
-app.post("/api/bounties/:id/refund", mutationLimiter, async (req: Request, res: Response) => {
+app.post("/api/bounties/:id/refund", mutationLimiter, createStellarSignatureAuthMiddleware(), async (req: Request, res: Response) => {
   const parsedBody = maintainerActionSchema.safeParse(req.body);
   if (!parsedBody.success) {
     jsonError(res, req, 400, zodErrorMessage(parsedBody.error));

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -72,6 +72,42 @@ function verifyStellarSignature(publicKey: string, payload: Buffer, signatureHea
   return false;
 }
 
+export function createBountyCreationSignatureMiddleware(): RequestHandler {
+  return (req, res, next) => {
+    if (process.env.NODE_ENV === "test") {
+      next();
+      return;
+    }
+
+    const signatureHeader = normalizeHeaderValue(req.header(HEADER_SIGNATURE));
+    if (!signatureHeader) {
+      res.status(401).json({ error: `Missing ${HEADER_SIGNATURE} header.` });
+      return;
+    }
+
+    const body = req.body ?? {};
+    const { repo, issueNumber, amount, tokenSymbol, deadlineDays, maintainer } = body;
+
+    if (!maintainer || typeof maintainer !== "string") {
+      res.status(401).json({ error: "Missing maintainer field required for signature verification." });
+      return;
+    }
+
+    // Canonical payload the client must sign: { repo, issueNumber, amount, tokenSymbol, deadline }
+    const canonicalPayload = Buffer.from(
+      JSON.stringify({ repo, issueNumber, amount, tokenSymbol, deadline: deadlineDays }),
+      "utf8",
+    );
+
+    if (!verifyStellarSignature(maintainer, canonicalPayload, signatureHeader)) {
+      res.status(401).json({ error: "Invalid Stellar signature. Signer public key must match maintainer address." });
+      return;
+    }
+
+    next();
+  };
+}
+
 export function createStellarSignatureAuthMiddleware(): RequestHandler {
   return (req, res, next) => {
     if (process.env.NODE_ENV === "test") {

--- a/backend/test/authMiddleware.test.ts
+++ b/backend/test/authMiddleware.test.ts
@@ -10,6 +10,8 @@ let storeFile: string;
 const signingKeypair = Keypair.random();
 const validMaintainerPublicKey = signingKeypair.publicKey();
 
+const mismatchedKeypair = Keypair.random();
+
 beforeEach(() => {
   storeFile = path.join(os.tmpdir(), `bounty-auth-${randomUUID()}.json`);
   fs.writeFileSync(storeFile, "[]", "utf8");
@@ -41,27 +43,91 @@ async function getApp() {
   return app;
 }
 
-function signJsonPayload(payload: unknown): string {
+function signPayload(keypair: Keypair, payload: unknown): string {
   const message = Buffer.from(JSON.stringify(payload), "utf8");
-  const signature = signingKeypair.sign(message);
-  return signature.toString("base64");
+  return keypair.sign(message).toString("base64");
 }
 
-describe("Stellar auth middleware", () => {
-  it("returns 401 when Stellar signature headers are missing", async () => {
-    const app = await getApp();
-    const { body: created } = await request(app).post("/api/bounties").send({
-      repo: "owner/repo",
-      issueNumber: 123,
-      title: "Test bounty",
-      summary: "Add test coverage to ensure auth middleware rejects unsigned requests.",
-      maintainer: validMaintainerPublicKey,
-      tokenSymbol: "XLM",
-      amount: 10,
-      deadlineDays: 14,
-    }).expect(201);
+function bountyCreationCanonical(body: {
+  repo: string;
+  issueNumber: number;
+  amount: number;
+  tokenSymbol: string;
+  deadlineDays: number;
+}) {
+  return {
+    repo: body.repo,
+    issueNumber: body.issueNumber,
+    amount: body.amount,
+    tokenSymbol: body.tokenSymbol,
+    deadline: body.deadlineDays,
+  };
+}
 
-    const id = created.data.id as string;
+const baseCreateBody = {
+  repo: "owner/repo",
+  issueNumber: 123,
+  title: "Test bounty",
+  summary: "Add test coverage to ensure auth middleware rejects unsigned requests.",
+  maintainer: validMaintainerPublicKey,
+  tokenSymbol: "XLM",
+  amount: 10,
+  deadlineDays: 14,
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function createSignedBounty(app: any) {
+  const canonical = bountyCreationCanonical(baseCreateBody);
+  const signature = signPayload(signingKeypair, canonical);
+  const { body } = await request(app)
+    .post("/api/bounties")
+    .set("X-Stellar-Signature", signature)
+    .send({ ...baseCreateBody, maintainer: validMaintainerPublicKey })
+    .expect(201);
+  return body.data.id as string;
+}
+
+describe("POST /api/bounties — Stellar signature requirement (#366)", () => {
+  it("returns 401 when x-stellar-signature header is missing", async () => {
+    const app = await getApp();
+    const res = await request(app)
+      .post("/api/bounties")
+      .send(baseCreateBody)
+      .expect(401);
+    expect(res.body.error).toMatch(/missing.*x-stellar-signature/i);
+  });
+
+  it("returns 401 when signature is signed by a key that does not match maintainer", async () => {
+    const app = await getApp();
+    const canonical = bountyCreationCanonical(baseCreateBody);
+    // Signed by mismatchedKeypair, but maintainer in body is validMaintainerPublicKey
+    const signature = signPayload(mismatchedKeypair, canonical);
+    const res = await request(app)
+      .post("/api/bounties")
+      .set("X-Stellar-Signature", signature)
+      .send(baseCreateBody)
+      .expect(401);
+    expect(res.body.error).toMatch(/invalid.*signature|signer.*maintainer/i);
+  });
+
+  it("creates bounty when signer public key matches maintainer address", async () => {
+    const app = await getApp();
+    const canonical = bountyCreationCanonical(baseCreateBody);
+    const signature = signPayload(signingKeypair, canonical);
+    const res = await request(app)
+      .post("/api/bounties")
+      .set("X-Stellar-Signature", signature)
+      .send(baseCreateBody)
+      .expect(201);
+    expect(res.body.data.status).toBe("open");
+    expect(res.body.data.maintainer).toBe(validMaintainerPublicKey);
+  });
+});
+
+describe("Stellar auth middleware — release/refund routes", () => {
+  it("returns 401 when Stellar signature headers are missing on release", async () => {
+    const app = await getApp();
+    const id = await createSignedBounty(app);
 
     const res = await request(app)
       .post(`/api/bounties/${id}/release`)
@@ -73,18 +139,7 @@ describe("Stellar auth middleware", () => {
 
   it("allows release when Stellar payload is signed by the configured maintainer key", async () => {
     const app = await getApp();
-    const { body: created } = await request(app).post("/api/bounties").send({
-      repo: "owner/repo",
-      issueNumber: 123,
-      title: "Test bounty",
-      summary: "Confirm signed release payload passes auth middleware.",
-      maintainer: validMaintainerPublicKey,
-      tokenSymbol: "XLM",
-      amount: 10,
-      deadlineDays: 14,
-    }).expect(201);
-
-    const id = created.data.id as string;
+    const id = await createSignedBounty(app);
 
     await request(app).post(`/api/bounties/${id}/reserve`).send({ contributor: validMaintainerPublicKey }).expect(200);
     await request(app)
@@ -93,7 +148,7 @@ describe("Stellar auth middleware", () => {
       .expect(200);
 
     const payload = { maintainer: validMaintainerPublicKey, transactionHash: "a".repeat(64) };
-    const signature = signJsonPayload(payload);
+    const signature = signPayload(signingKeypair, payload);
 
     const res = await request(app)
       .post(`/api/bounties/${id}/release`)


### PR DESCRIPTION
## Summary

- Add `createBountyCreationSignatureMiddleware` that enforces `x-stellar-signature` on `POST /api/bounties`
- The canonical signed payload is `{ repo, issueNumber, amount, tokenSymbol, deadline }` — the signer's public key must match the `maintainer` field in the request body
- Missing signature header returns `401`; mismatched signer returns `401`
- Wire `createStellarSignatureAuthMiddleware` to `POST /api/bounties/:id/release` and `POST /api/bounties/:id/refund` to protect maintainer-only actions
- Integration tests: valid signer creates bounty (201); mismatched signer returns 401; missing header returns 401; signed release succeeds; unsigned release returns 401

## Test plan

- [ ] `POST /api/bounties` without `x-stellar-signature` → 401
- [ ] `POST /api/bounties` with signature from a key that does not match `maintainer` → 401
- [ ] `POST /api/bounties` with valid signature over `{ repo, issueNumber, amount, tokenSymbol, deadline }` from the maintainer keypair → 201
- [ ] `POST /api/bounties/:id/release` without signature headers → 401
- [ ] `POST /api/bounties/:id/release` with valid maintainer signature → 200
- [ ] All existing API tests (NODE_ENV=test, middleware skipped) continue to pass

Closes #366
Closes #372
Closes #369
Closes #347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Stellar signature verification to bounty operations (creation, release, and refund) for enhanced security and transaction authentication.

* **Tests**
  * Expanded test coverage for signature validation on bounty-related endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->