### PR TITLE
feat(contracts): add get_version view function (#228)

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -531,6 +531,10 @@ impl StellarBountyBoardContract {
             .get(&DataKey::NextBountyId)
             .unwrap_or(0)
     }
+
+    pub fn get_version(env: Env) -> String {
+        String::from_slice(&env, env!(\"CARGO_PKG_VERSION\"))
+    }
 }
 
 fn read_bounty(env: &Env, bounty_id: u64) -> Bounty {


### PR DESCRIPTION
- Adds a  view function returning the contract version from Cargo.toml\n- Uses the  macro for compile-time version injection\n- Addresses issue requirement for version introspection on deployed contracts\n\nCloses #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new method to query the contract's version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->