### PR TITLE
fix: cap bounty amount in contract

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -703,34 +703,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heapless"
@@ -1233,7 +1208,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.8.22",
  "schemars 0.9.0",
  "schemars 1.2.1",

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -36,6 +36,10 @@ pub struct Bounty {
     pub dispute_raised_at: u64,
 }
 
+// 10B XLM expressed in stroops. This keeps bounty and protocol-fee math inside
+// a documented operational ceiling instead of accepting arbitrary i128 values.
+pub const MAX_BOUNTY_AMOUNT: i128 = 10_000_000_000_0000000;
+
 #[contracttype]
 enum DataKey {
     NextBountyId,
@@ -174,7 +178,7 @@ impl StellarBountyBoardContract {
     ) -> u64 {
         maintainer.require_auth();
 
-        if amount <= 0 {
+        if amount <= 0 || amount > MAX_BOUNTY_AMOUNT {
             panic_error(ContractError::InvalidAmount);
         }
         if deadline <= env.ledger().timestamp() {

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -38,7 +38,7 @@ pub struct Bounty {
 
 // 10B XLM expressed in stroops. This keeps bounty and protocol-fee math inside
 // a documented operational ceiling instead of accepting arbitrary i128 values.
-pub const MAX_BOUNTY_AMOUNT: i128 = 10_000_000_000_0000000;
+pub const MAX_BOUNTY_AMOUNT: i128 = 100_000_000_000_000_000;
 
 #[contracttype]
 enum DataKey {

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -182,6 +182,51 @@ fn test_create_bounty_negative_amount() {
 }
 
 #[test]
+fn test_create_bounty_max_amount_allowed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, maintainer, _, token_id, _, _) = setup_test(&env);
+    let token = TokenClient::new(&env, &token_id);
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin.mint(&maintainer, &MAX_BOUNTY_AMOUNT);
+
+    let bounty_id = client.create_bounty(
+        &maintainer,
+        &token_id,
+        &MAX_BOUNTY_AMOUNT,
+        &String::from_str(&env, "repo"),
+        &1,
+        &String::from_str(&env, "title"),
+        &(env.ledger().timestamp() + 1000),
+        &0u32,
+    );
+
+    let bounty = client.get_bounty(&bounty_id);
+    assert_eq!(bounty.amount, MAX_BOUNTY_AMOUNT);
+    assert_eq!(token.balance(&client.address), MAX_BOUNTY_AMOUNT);
+}
+
+#[test]
+#[should_panic(expected = "InvalidAmount")]
+fn test_create_bounty_above_max_amount_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, maintainer, _, token_id, _, _) = setup_test(&env);
+
+    client.create_bounty(
+        &maintainer,
+        &token_id,
+        &(MAX_BOUNTY_AMOUNT + 1),
+        &String::from_str(&env, "repo"),
+        &1,
+        &String::from_str(&env, "title"),
+        &(env.ledger().timestamp() + 1000),
+        &0u32,
+    );
+}
+
+#[test]
 #[should_panic(expected = "DeadlineMustBeInTheFuture")]
 fn test_create_bounty_past_deadline() {
     let env = Env::default();
@@ -608,7 +653,7 @@ fn test_double_reserve_bounty() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (client, maintainer, contributor, token_id) = setup_test(&env);
+    let (client, maintainer, contributor, token_id, _, _) = setup_test(&env);
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
     token_admin.mint(&maintainer, &1000);
 
@@ -620,6 +665,7 @@ fn test_double_reserve_bounty() {
         &1,
         &String::from_str(&env, "title"),
         &(env.ledger().timestamp() + 1000),
+        &0u32,
     );
 
     // First reservation should succeed
@@ -740,32 +786,4 @@ fn test_extend_deadline_earlier() {
     // Attempting to set a deadline earlier than the initial one
     let earlier_deadline = initial_deadline - 100;
     client.extend_deadline(&bounty_id, &maintainer, &earlier_deadline);
-}
-
-#[test]
-
-    let bounty_id = client.create_bounty(
-        &maintainer,
-        &token_id,
-        &500,
-        &String::from_str(&env, "repo"),
-        &1,
-        &String::from_str(&env, "title"),
-
-    let bounty_id = client.create_bounty(
-        &maintainer,
-        &token_id,
-        &500,
-        &String::from_str(&env, "repo"),
-        &1,
-        &String::from_str(&env, "title"),
-
-    let bounty_id = client.create_bounty(
-        &maintainer,
-        &token_id,
-        &500,
-        &String::from_str(&env, "repo"),
-        &1,
-        &String::from_str(&env, "title"),
-
 }


### PR DESCRIPTION
Closes #218.

## Summary

- add a documented `MAX_BOUNTY_AMOUNT` ceiling of `10_000_000_000_0000000` stroops
- reject `create_bounty` amounts above that ceiling with `ContractError::InvalidAmount`
- add coverage for the boundary: max accepted, max + 1 rejected
- fix two baseline contract-test blockers found while validating this change:
  - duplicate package entries in `contracts/Cargo.lock`
  - an incomplete dangling block at the end of `contracts/src/test.rs`

## Verification

- `cargo test` in `contracts/` -> 39 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bounty creation now validates that submitted amounts are positive and do not exceed the maximum allowed limit, improving transaction safety.

* **Tests**
  * Added comprehensive test coverage for bounty amount boundary conditions.
  * Fixed test execution issues to ensure proper bounty validation testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->