### PR TITLE
Add request id tracing regression coverage

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,8 +1,8 @@
 import cors from "cors";
-import express, { Request, Response, NextFunction } from "express";
-import { randomUUID } from "node:crypto";
+import express, { Request, Response } from "express";
 import swaggerUi from "swagger-ui-express";
 import { buildCorsOptions } from "./middleware/corsOptions";
+import { requestContextMiddleware } from "./middleware/requestContext";
 import { generateOpenApiDocument } from "./docs/openapi";
 
 import {
@@ -28,7 +28,6 @@ import {
   submitBountySchema,
   zodErrorMessage,
 } from "./validation/schemas";
-import { logStructured } from "./logger";
 import { readLimiter, mutationLimiter } from "./utils";
 import {
   captureRawBody,
@@ -36,43 +35,6 @@ import {
 } from "./webhooks/signatureVerification";
 import { createBountyCreationSignatureMiddleware, createStellarSignatureAuthMiddleware } from "./middleware/auth";
 import { handleGitHubPrEvent } from "./webhooks/githubPrHandler";
-
-const INCOMING_REQUEST_ID = /^[a-zA-Z0-9-]{1,128}$/;
-
-
-
-function resolveRequestId(req: Request): string {
-  const raw = req.headers["x-request-id"];
-  if (typeof raw === "string") {
-    const trimmed = raw.trim();
-    if (INCOMING_REQUEST_ID.test(trimmed)) {
-      return trimmed;
-    }
-  }
-  return randomUUID();
-}
-
-function requestContextMiddleware(req: Request, res: Response, next: NextFunction): void {
-  const requestId = resolveRequestId(req);
-  req.requestId = requestId;
-  res.setHeader("X-Request-ID", requestId);
-
-  const start = process.hrtime.bigint();
-
-  res.on("finish", () => {
-    const durationNs = process.hrtime.bigint() - start;
-    const durationMs = Number(durationNs) / 1e6;
-    logStructured("info", "http_request", {
-      requestId,
-      method: req.method,
-      path: req.path || "/",
-      status: res.statusCode,
-      durationMs: Math.round(durationMs * 1000) / 1000,
-    });
-  });
-
-  next();
-}
 
 export const app = express();
 

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -43,6 +43,32 @@ describe("API — health and listing", () => {
     expect(res.body.service).toContain("bounty-board");
   });
 
+  it("echoes a valid X-Request-ID response header", async () => {
+    const app = await getApp();
+    const res = await request(app).get("/api/health").set("X-Request-ID", "trace-123").expect(200);
+    expect(res.headers["x-request-id"]).toBe("trace-123");
+  });
+
+  it("generates an X-Request-ID when the incoming header is invalid", async () => {
+    const app = await getApp();
+    const res = await request(app).get("/api/health").set("X-Request-ID", "bad id with spaces").expect(200);
+    expect(res.headers["x-request-id"]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("includes the requestId from X-Request-ID in JSON error responses", async () => {
+    const app = await getApp();
+    const res = await request(app)
+      .get("/api/bounties/released/export.csv")
+      .query({ issueNumber: "not-a-number" })
+      .set("X-Request-ID", "export-trace-1")
+      .expect(400);
+    expect(res.headers["x-request-id"]).toBe("export-trace-1");
+    expect(res.body.requestId).toBe("export-trace-1");
+    expect(res.body.error).toMatch(/issueNumber/i);
+  });
+
   it("GET /api/bounties returns data array", async () => {
     const app = await getApp();
     const res = await request(app).get("/api/bounties").expect(200);


### PR DESCRIPTION
## Summary
- Reuse the existing `requestContextMiddleware` from `backend/src/middleware/requestContext.ts` instead of keeping a duplicate inline copy in `app.ts`
- Add regression coverage for `X-Request-ID` echoing, invalid incoming header fallback, and `requestId` propagation in JSON error responses

Closes #268

## Verification
- `npm test -- test/api.test.ts -t "X-Request-ID|requestId"` (3 passed)
- Full `npm test -- test/api.test.ts` still has pre-existing amount validation failures unrelated to this change:
  - `POST create with amount above 10000 XLM returns 201 instead of 400`
  - `POST create with more than 7 decimal places returns 201 instead of 400`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added API tests for the health check endpoint to verify request ID tracking and validation.

* **Refactor**
  * Reorganized request context middleware responsibilities for improved code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->