### PR TITLE
feat(backend/data): migrate from JSON file persistence to SQLite via Drizzle ORM 

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "target": "ES2021",
     "lib": ["ES2021"],
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "rootDir": "src",
     "outDir": "dist",
     "strict": true,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "ignoreDeprecations": "all"
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "ignoreDeprecations": "all"
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
JSON file persistence in backend/data/bounties.json causes race conditions under concurrent writes and makes queries expensive.


closes #93 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript module system configuration in backend build settings to use Node16 standards.
  * Updated TypeScript compilation configuration in frontend to suppress deprecation warnings and improve compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->