### PR TITLE
fix: Add `GitHubIssuePreviewCard` live data fetch from GitHub API

### DIFF
--- a/frontend/src/components/GitHubIssuePreviewCard.tsx
+++ b/frontend/src/components/GitHubIssuePreviewCard.tsx
@@ -1,0 +1,158 @@
+import React, { useEffect, useState } from 'react';
+import { Card, Skeleton, Tag, Typography, Alert, Button, Space, Rate } from 'antd';
+import { GithubOutlined, WarningOutlined, LockOutlined } from '@ant-design/icons';
+import { formatDistanceToNow } from 'date-fns';
+
+const { Text, Title, Paragraph } = Typography;
+
+interface GitHubIssueData {
+  title: string;
+  state: string;
+  labels: Array<{ name: string; color: string }>;
+  created_at: string;
+  html_url: string;
+  number: number;
+  user: { login: string; avatar_url: string };
+}
+
+interface GitHubIssuePreviewCardProps {
+  repo: string;
+  issueNumber: number;
+}
+
+const GitHubIssuePreviewCard: React.FC<GitHubIssuePreviewCardProps> = ({ repo, issueNumber }) => {
+  const [issueData, setIssueData] = useState<GitHubIssueData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isRateLimited, setIsRateLimited] = useState(false);
+
+  useEffect(() => {
+    const fetchIssue = async () => {
+      setLoading(true);
+      setError(null);
+      setIsRateLimited(false);
+
+      try {
+        const response = await fetch(
+          `https://api.github.com/repos/${repo}/issues/${issueNumber}`,
+          {
+            headers: {
+              Accept: 'application/vnd.github.v3+json',
+            },
+          }
+        );
+
+        if (response.status === 403) {
+          setIsRateLimited(true);
+          setError('GitHub API rate limit exceeded. Please try again later.');
+          return;
+        }
+
+        if (response.status === 404) {
+          setError('Issue not found. It may be in a private repository or does not exist.');
+          return;
+        }
+
+        if (!response.ok) {
+          setError(`Failed to fetch issue data (HTTP ${response.status})`);
+          return;
+        }
+
+        const data: GitHubIssueData = await response.json();
+        setIssueData(data);
+      } catch (err) {
+        setError('Network error. Please check your connection and try again.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchIssue();
+  }, [repo, issueNumber]);
+
+  if (loading) {
+    return (
+      <Card style={{ width: 400, margin: '16px 0' }}>
+        <Skeleton active avatar paragraph={{ rows: 3 }} />
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card style={{ width: 400, margin: '16px 0' }}>
+        <Alert
+          message="Issue Load Error"
+          description={
+            <Space direction="vertical">
+              <Text>{error}</Text>
+              {isRateLimited && (
+                <Text type="secondary">
+                  <WarningOutlined /> Unauthenticated requests are limited to 60 per hour.
+                </Text>
+              )}
+              <Button
+                type="primary"
+                icon={<GithubOutlined />}
+                href={`https://github.com/${repo}/issues/${issueNumber}`}
+                target="_blank"
+              >
+                View on GitHub
+              </Button>
+            </Space>
+          }
+          type="error"
+          showIcon
+          icon={isRateLimited ? <WarningOutlined /> : <LockOutlined />}
+        />
+      </Card>
+    );
+  }
+
+  if (!issueData) return null;
+
+  return (
+    <Card
+      style={{ width: 400, margin: '16px 0' }}
+      actions={[
+        <Button
+          type="link"
+          icon={<GithubOutlined />}
+          href={issueData.html_url}
+          target="_blank"
+          key="github"
+        >
+          Open on GitHub
+        </Button>,
+      ]}
+    >
+      <Space direction="vertical" style={{ width: '100%' }}>
+        <Space>
+          <Tag color={issueData.state === 'open' ? 'green' : 'red'}>
+            {issueData.state.toUpperCase()}
+          </Tag>
+          <Text type="secondary">#{issueData.number}</Text>
+        </Space>
+
+        <Title level={5} style={{ margin: 0 }}>
+          {issueData.title}
+        </Title>
+
+        <Space wrap>
+          {issueData.labels.map((label) => (
+            <Tag key={label.name} color={`#${label.color}`}>
+              {label.name}
+            </Tag>
+          ))}
+        </Space>
+
+        <Text type="secondary">
+          Opened {formatDistanceToNow(new Date(issueData.created_at), { addSuffix: true })} by{' '}
+          {issueData.user.login}
+        </Text>
+      </Space>
+    </Card>
+  );
+};
+
+export default GitHubIssuePreviewCard;

--- a/frontend/src/components/__tests__/GitHubIssuePreviewCard.test.tsx
+++ b/frontend/src/components/__tests__/GitHubIssuePreviewCard.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import GitHubIssuePreviewCard from '../GitHubIssuePreviewCard';
+
+const mockIssueData = {
+  title: 'Test Issue Title',
+  state: 'open',
+  labels: [
+    { name: 'bug', color: 'd73a4a' },
+    { name: 'enhancement', color: 'a2eeef' },
+  ],
+  created_at: '2024-01-15T10:00:00Z',
+  html_url: 'https://github.com/test-owner/test-repo/issues/42',
+  number: 42,
+  user: { login: 'testuser', avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4' },
+};
+
+describe('GitHubIssuePreviewCard', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows loading skeleton initially', () => {
+    vi.spyOn(global, 'fetch').mockImplementation(
+      () =>
+        new Promise(() => {}) // never resolves to keep loading state
+    );
+
+    render(<GitHubIssuePreviewCard repo="test-owner/test-repo" issueNumber={42} />);
+    expect(screen.getByText(/loading/i) || document.querySelector('.ant-skeleton')).toBeTruthy();
+  });
+
+  it('renders issue title and labels after successful fetch', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockIssueData,
+    } as Response);
+
+    render(<GitHubIssuePreviewCard repo="test-owner/test-repo" issueNumber={42} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Issue Title')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('bug')).toBeInTheDocument();
+    expect(screen.getByText('enhancement')).toBeInTheDocument();
+    expect(screen.getByText('OPEN')).toBeInTheDocument();
+    expect(screen.getByText('#42')).toBeInTheDocument();
+    expect(screen.getByText(/testuser/)).toBeInTheDocument();
+  });
+
+  it('shows error state with link to GitHub on 404', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    } as Response);
+
+    render(<GitHubIssuePreviewCard repo="test-owner/test-repo" issueNumber={999} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Issue not found/i)).toBeInTheDocument();
+    });
+
+    const githubLink = screen.getByRole('link', { name: /view on github/i });
+    expect(githubLink).toBeInTheDocument();
+    expect(githubLink).toHaveAttribute(
+      'href',
+      'https://github.com/test-owner/test-repo/issues/999'
+    );
+  });
+
+  it('shows rate limit warning on 403', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({}),
+    } as Response);
+
+    render(<GitHubIssuePreviewCard repo="test-owner/test-repo" issueNumber={42} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/rate limit exceeded/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/60 per hour/i)).toBeInTheDocument();
+  });
+
+  it('shows error on network failure', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('Network error'));
+
+    render(<GitHubIssuePreviewCard repo="test-owner/test-repo" issueNumber={42} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Network error/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders closed state correctly', async () => {
+    const closedIssue = {
+      ...mockIssueData,
+      state: 'closed',
+      title: 'Closed Issue',
+    };
+
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => closedIssue,
+    } as Response);
+
+    render(<GitHubIssuePreviewCard repo="test-owner/test-repo" issueNumber={42} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('CLOSED')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Closed Issue')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Changes

- `frontend/src/components/GitHubIssuePreviewCard.tsx`
- `frontend/src/components/__tests__/GitHubIssuePreviewCard.test.tsx`

## Related
Closes #287

---
### Payment
**Stellar Wallet:** `GD5QLPIBQJZVSEMRQ2OOAMRCGE4BJWTAUDBQADYL5E2JQOCXPA4TYJW4`
*Automated bounty submission via AI bot*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GitHub issue preview card that displays issue details including status, title, labels, and timestamp with a link to open issues directly on GitHub.

* **Tests**
  * Added comprehensive test suite for the new GitHub issue preview card component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->