### PR TITLE
fix: enforce per-bounty reservation timeouts

### DIFF
--- a/backend/src/services/reservationExpirationJob.ts
+++ b/backend/src/services/reservationExpirationJob.ts
@@ -24,6 +24,19 @@ function getReservationTtlSeconds(): number {
   return Math.floor(days * 24 * 60 * 60);
 }
 
+function getBountyReservationTtlSeconds(
+  bounty: BountyRecord,
+  fallbackTtlSeconds: number
+): number {
+  const ttlSeconds = bounty.reservationTimeoutSeconds;
+
+  if (typeof ttlSeconds === 'number' && Number.isFinite(ttlSeconds) && ttlSeconds > 0) {
+    return Math.floor(ttlSeconds);
+  }
+
+  return fallbackTtlSeconds;
+}
+
 function getStorePath(): string {
   if (process.env.BOUNTY_STORE_PATH?.trim()) {
     return path.resolve(process.env.BOUNTY_STORE_PATH.trim());
@@ -87,10 +100,11 @@ export function expireStaleReservations(ttlSeconds?: number): ExpirationResult {
   const expiredBountyIds: string[] = [];
 
   const updated = bounties.map((bounty) => {
+    const reservationTtlSeconds = getBountyReservationTtlSeconds(bounty, ttl);
     const isStaleReservation =
       bounty.status === 'reserved' &&
       typeof bounty.reservedAt === 'number' &&
-      checkedAt - bounty.reservedAt > ttl;
+      checkedAt - bounty.reservedAt > reservationTtlSeconds;
 
     if (!isStaleReservation) {
       return bounty;
@@ -106,7 +120,7 @@ export function expireStaleReservations(ttlSeconds?: number): ExpirationResult {
 
     expiredBountyIds.push(bounty.id);
 
-    return expireReservation(bounty, checkedAt, ttl);
+    return expireReservation(bounty, checkedAt, reservationTtlSeconds);
   });
 
   writeBounties(updated);

--- a/backend/test/reservationExpirationJob.test.ts
+++ b/backend/test/reservationExpirationJob.test.ts
@@ -32,10 +32,6 @@ afterEach(() => {
   }
 });
 
-async function loadStore() {
-  return import('../src/services/bountyStore');
-}
-
 async function loadJob() {
   return import('../src/services/reservationExpirationJob');
 }
@@ -44,10 +40,10 @@ function nowSeconds() {
   return Math.floor(Date.now() / 1000);
 }
 
-function makeReservedBounty(reservedSecondsAgo: number) {
+function makeReservedBounty(reservedSecondsAgo: number, reservationTimeoutSeconds?: number) {
   const now = nowSeconds();
 
-  return {
+  const bounty = {
     id: `BNT-TEST-${randomUUID()}`,
     repo: 'test/repo',
     issueNumber: 1,
@@ -71,15 +67,17 @@ function makeReservedBounty(reservedSecondsAgo: number) {
         actor: CONTRIBUTOR,
       },
     ],
-    reservationTimeoutSeconds: 999999999,
   };
+
+  return reservationTimeoutSeconds === undefined
+    ? bounty
+    : { ...bounty, reservationTimeoutSeconds };
 }
 
 describe('expireStaleReservations', () => {
   it('does not expire a fresh reservation', async () => {
-    const store = await loadStore();
-
-    await store.reserveBounty(bounty.id, CONTRIBUTOR);
+    const fresh = makeReservedBounty(1 * 24 * 60 * 60);
+    fs.writeFileSync(storeFile, JSON.stringify([fresh], null, 2));
 
     const { expireStaleReservations } = await loadJob();
     const result = expireStaleReservations(7 * 24 * 60 * 60);
@@ -87,7 +85,8 @@ describe('expireStaleReservations', () => {
     expect(result.expiredCount).toBe(0);
     expect(result.expiredBountyIds).toHaveLength(0);
 
-    const after = store.listBounties().find((item) => item.id === bounty.id);
+    const raw = JSON.parse(fs.readFileSync(storeFile, 'utf8'));
+    const after = raw.find((item: { id: string }) => item.id === fresh.id);
     expect(after?.status).toBe('reserved');
   });
 
@@ -157,17 +156,55 @@ describe('expireStaleReservations', () => {
     expect(result.expiredBountyIds).toContain(stale.id);
   });
 
-  it('does not touch submitted bounties', async () => {
-    const store = await loadStore();
+  it('prefers each bounty reservationTimeoutSeconds over the global TTL', async () => {
+    const shortTimeout = makeReservedBounty(90, 60);
+    const longTimeout = makeReservedBounty(90, 120);
+    fs.writeFileSync(storeFile, JSON.stringify([shortTimeout, longTimeout], null, 2));
 
+    const { expireStaleReservations } = await loadJob();
+    const result = expireStaleReservations(7 * 24 * 60 * 60);
+
+    expect(result.expiredCount).toBe(1);
+    expect(result.expiredBountyIds).toContain(shortTimeout.id);
+    expect(result.expiredBountyIds).not.toContain(longTimeout.id);
+
+    const raw = JSON.parse(fs.readFileSync(storeFile, 'utf8'));
+    const expired = raw.find((item: { id: string }) => item.id === shortTimeout.id);
+    const stillReserved = raw.find((item: { id: string }) => item.id === longTimeout.id);
+
+    expect(expired.status).toBe('open');
+    expect(expired.events.at(-1).details.ttlSeconds).toBe(60);
+    expect(stillReserved.status).toBe('reserved');
+  });
+
+  it('falls back to the global TTL when a bounty has no reservationTimeoutSeconds', async () => {
+    const stale = makeReservedBounty(8 * 24 * 60 * 60);
+    fs.writeFileSync(storeFile, JSON.stringify([stale], null, 2));
+
+    const { expireStaleReservations } = await loadJob();
+    const result = expireStaleReservations(7 * 24 * 60 * 60);
+
+    expect(result.expiredCount).toBe(1);
+    expect(result.expiredBountyIds).toContain(stale.id);
+  });
+
+  it('does not touch submitted bounties', async () => {
+    const submitted = {
+      ...makeReservedBounty(8 * 24 * 60 * 60),
+      status: 'submitted' as const,
+      submittedAt: nowSeconds(),
+      submissionUrl: 'https://github.com/test/repo/pull/1',
+    };
+    fs.writeFileSync(storeFile, JSON.stringify([submitted], null, 2));
 
     const { expireStaleReservations } = await loadJob();
     const result = expireStaleReservations(0);
 
-    const after = store.listBounties().find((item) => item.id === bounty.id);
+    const raw = JSON.parse(fs.readFileSync(storeFile, 'utf8'));
+    const after = raw.find((item: { id: string }) => item.id === submitted.id);
 
     expect(after?.status).toBe('submitted');
-    expect(result.expiredBountyIds).not.toContain(bounty.id);
+    expect(result.expiredBountyIds).not.toContain(submitted.id);
   });
 
   it('returns checkedAt timestamp', async () => {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,40 +75,43 @@ This document describes the system architecture of Stellar Bounty Board, includi
 
 React + Vite application serving as the maintainer and contributor dashboard.
 
-| File | Responsibility |
-|------|----------------|
-| `src/App.tsx` | Main dashboard component, bounty list and action buttons |
-| `src/api.ts` | HTTP client wrapping all backend API calls |
-| `src/types.ts` | TypeScript interfaces (`Bounty`, `BountyStatus`, `OpenIssue`) |
-| `vite.config.ts` | Dev server config with API proxy to backend |
+| File             | Responsibility                                                |
+| ---------------- | ------------------------------------------------------------- |
+| `src/App.tsx`    | Main dashboard component, bounty list and action buttons      |
+| `src/api.ts`     | HTTP client wrapping all backend API calls                    |
+| `src/types.ts`   | TypeScript interfaces (`Bounty`, `BountyStatus`, `OpenIssue`) |
+| `vite.config.ts` | Dev server config with API proxy to backend                   |
 
 ### Backend (`backend/`)
 
 Express REST API managing bounty state with JSON file persistence.
 
-| File | Responsibility |
-|------|----------------|
-| `src/index.ts` | Express app, route handlers, middleware setup |
-| `src/services/bountyStore.ts` | CRUD operations, status transitions, file I/O |
-| `src/services/openIssues.ts` | Serves contribution-ready issue drafts |
-| `src/validation/schemas.ts` | Zod schemas for request validation |
-| `src/utils.ts` | Rate limiter and helpers |
-| `data/bounties.json` | Persistent bounty storage |
+| File                                       | Responsibility                                   |
+| ------------------------------------------ | ------------------------------------------------ |
+| `src/index.ts`                             | Express app, route handlers, middleware setup    |
+| `src/services/bountyStore.ts`              | CRUD operations, status transitions, file I/O    |
+| `src/services/reservationExpirationJob.ts` | Expires stale `reserved` bounties back to `open` |
+| `src/services/openIssues.ts`               | Serves contribution-ready issue drafts           |
+| `src/validation/schemas.ts`                | Zod schemas for request validation               |
+| `src/utils.ts`                             | Rate limiter and helpers                         |
+| `data/bounties.json`                       | Persistent bounty storage                        |
+
+Reservation expiration uses `reservationTimeoutSeconds` on an individual bounty when present. Bounties without a custom timeout fall back to the global `RESERVATION_TTL_DAYS` setting.
 
 ### Smart Contract (`contracts/`)
 
 Soroban contract implementing on-chain escrow logic for trustless bounty payouts.
 
-| Element | Purpose |
-|---------|---------|
-| `BountyStatus` enum | Open, Reserved, Submitted, Released, Refunded, Expired |
-| `Bounty` struct | On-chain bounty record with maintainer, contributor, token, amount |
-| `create_bounty` | Transfers tokens from maintainer to contract escrow |
-| `reserve_bounty` | Locks bounty to a specific contributor |
-| `submit_bounty` | Marks work submitted (links PR off-chain) |
-| `release_bounty` | Pays out escrowed tokens to contributor |
-| `refund_bounty` | Returns escrowed tokens to maintainer |
-| Contract events | Emitted on each state transition for indexers |
+| Element             | Purpose                                                            |
+| ------------------- | ------------------------------------------------------------------ |
+| `BountyStatus` enum | Open, Reserved, Submitted, Released, Refunded, Expired             |
+| `Bounty` struct     | On-chain bounty record with maintainer, contributor, token, amount |
+| `create_bounty`     | Transfers tokens from maintainer to contract escrow                |
+| `reserve_bounty`    | Locks bounty to a specific contributor                             |
+| `submit_bounty`     | Marks work submitted (links PR off-chain)                          |
+| `release_bounty`    | Pays out escrowed tokens to contributor                            |
+| `refund_bounty`     | Returns escrowed tokens to maintainer                              |
+| Contract events     | Emitted on each state transition for indexers                      |
 
 ## Bounty Lifecycle
 
@@ -234,25 +237,25 @@ sequenceDiagram
 ```mermaid
 stateDiagram-v2
     [*] --> Open : create_bounty
-    
+
     Open --> Reserved : reserve_bounty
     Open --> Expired : expire_if_needed
     Open --> Refunded : refund_bounty
-    
+
     Reserved --> Submitted : submit_bounty
     Reserved --> Expired : expire_if_needed
     Reserved --> Refunded : refund_bounty
-    
+
     Submitted --> Released : release_bounty
     Submitted --> Disputed : dispute_bounty
     Submitted --> Refunded : refund_bounty
-    
+
     Disputed --> Released : resolve_dispute(release=true)
     Disputed --> Refunded : resolve_dispute(release=false)
     Disputed --> Refunded : refund_bounty
-    
+
     Expired --> Refunded : refund_bounty
-    
+
     note right of Released
         Invalid transitions explicitly excluded:
         - Released -> Refunded (Terminal state)
@@ -341,7 +344,7 @@ sequenceDiagram
     Backend-->>Frontend: 200 { data: released bounty }
     deactivate Backend
     Frontend-->>Maintainer: Show "Released"<br/>Payout processed ✓
-    
+
     Note over Maintainer,Soroban Contract<br/>(Future): When wallet auth is live:<br/>Backend will call Soroban contract<br/>to transfer escrowed tokens to contributor
 ```
 
@@ -437,35 +440,35 @@ sequenceDiagram
 
 ### Data Field Mapping
 
-| Data Field | Current Owner | Future Owner | Notes |
-|------------|---------------|--------------|-------|
-| `id` | Backend JSON | Backend (read from contract) | Unique identifier, never changes |
-| `maintainer` | Backend JSON | Soroban Contract | Stored on-chain for escrow validation |
-| `contributor` | Backend JSON | Soroban Contract | Stored on-chain for payout routing |
-| `amount` | Backend JSON | Soroban Contract | Token amount in escrow, validated by contract |
-| `token` | Backend JSON | Soroban Contract | Token address in escrow |
-| `status` | Backend JSON | Soroban Contract | State machine transitions: OPEN → RESERVED → SUBMITTED → RELEASED |
-| `submissionUrl` (PR link) | Backend JSON | Backend JSON | Off-chain metadata; not stored on contract |
-| `createdAt` timestamp | Backend JSON | Backend JSON | For UI and ordering; not critical on-chain |
-| `releaseTime` | Backend JSON | Soroban Contract | Payout confirmation; emitted as contract event |
-| `refundTime` | Backend JSON | Soroban Contract | Cancellation confirmation; emitted as contract event |
+| Data Field                | Current Owner | Future Owner                 | Notes                                                             |
+| ------------------------- | ------------- | ---------------------------- | ----------------------------------------------------------------- |
+| `id`                      | Backend JSON  | Backend (read from contract) | Unique identifier, never changes                                  |
+| `maintainer`              | Backend JSON  | Soroban Contract             | Stored on-chain for escrow validation                             |
+| `contributor`             | Backend JSON  | Soroban Contract             | Stored on-chain for payout routing                                |
+| `amount`                  | Backend JSON  | Soroban Contract             | Token amount in escrow, validated by contract                     |
+| `token`                   | Backend JSON  | Soroban Contract             | Token address in escrow                                           |
+| `status`                  | Backend JSON  | Soroban Contract             | State machine transitions: OPEN → RESERVED → SUBMITTED → RELEASED |
+| `submissionUrl` (PR link) | Backend JSON  | Backend JSON                 | Off-chain metadata; not stored on contract                        |
+| `createdAt` timestamp     | Backend JSON  | Backend JSON                 | For UI and ordering; not critical on-chain                        |
+| `releaseTime`             | Backend JSON  | Soroban Contract             | Payout confirmation; emitted as contract event                    |
+| `refundTime`              | Backend JSON  | Soroban Contract             | Cancellation confirmation; emitted as contract event              |
 
 ### State Transition Authority
 
-| Transition | Initiated By | Current Authority | Future Authority |
-|-----------|--------------|-------------------|------------------|
-| OPEN → RESERVED | Contributor | Backend validates claim | Contract validates claim + signature |
-| RESERVED → SUBMITTED | Contributor | Backend records PR URL | Backend records PR URL (contract confirms RESERVED status) |
-| SUBMITTED → RELEASED | Maintainer | Backend approves & updates | Contract escrow release (after backend approval) |
-| SUBMITTED → REFUNDED | Maintainer | Backend approves & updates | Contract escrow return (after backend approval) |
-| OPEN → EXPIRED | System (deadline) | Backend cron/timer | Contract timelock expiration check |
-| Any → RELEASED or REFUNDED | Wallet signature | Not applicable | Wallet-signed transaction for funds release |
+| Transition                 | Initiated By      | Current Authority          | Future Authority                                           |
+| -------------------------- | ----------------- | -------------------------- | ---------------------------------------------------------- |
+| OPEN → RESERVED            | Contributor       | Backend validates claim    | Contract validates claim + signature                       |
+| RESERVED → SUBMITTED       | Contributor       | Backend records PR URL     | Backend records PR URL (contract confirms RESERVED status) |
+| SUBMITTED → RELEASED       | Maintainer        | Backend approves & updates | Contract escrow release (after backend approval)           |
+| SUBMITTED → REFUNDED       | Maintainer        | Backend approves & updates | Contract escrow return (after backend approval)            |
+| OPEN → EXPIRED             | System (deadline) | Backend cron/timer         | Contract timelock expiration check                         |
+| Any → RELEASED or REFUNDED | Wallet signature  | Not applicable             | Wallet-signed transaction for funds release                |
 
 ### Migration Path Notes
 
 1. **Phase 1 (Current):** Backend JSON is the source of truth. Contract exists but is not actively used for state transitions.
 
-2. **Phase 2 (Planned):** Backend listens for contract events (via Soroban event indexer). Bounty status can be updated by both backend API *and* on-chain events.
+2. **Phase 2 (Planned):** Backend listens for contract events (via Soroban event indexer). Bounty status can be updated by both backend API _and_ on-chain events.
 
 3. **Phase 3 (Target):** Contract is the authoritative state machine. Backend acts as a read-only cache and metadata store for:
    - `submissionUrl` (PR links)


### PR DESCRIPTION
## Summary
- Expire reservations using each bounty's `reservationTimeoutSeconds` when it is set.
- Fall back to the global reservation TTL for bounties without a custom timeout.
- Add regression coverage for mixed per-bounty timeouts and note the behavior in architecture docs.

## Test Plan
- [x] `npm --prefix backend test -- --run test/reservationExpirationJob.test.ts`

## Notes
- `npm --prefix backend run typecheck` currently fails on unrelated existing syntax errors in `src/app.ts`, `src/index.ts`, and `src/validation/schemas.ts`.

Closes #244


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bounties now support custom reservation timeout configuration on a per-bounty basis, with automatic fallback to the global TTL when not specified
  * Reservation expiration events now record and track the specific TTL value that was applied during expiration

* **Documentation**
  * Updated architecture documentation to clarify per-bounty reservation timeout precedence and fallback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->