### PR TITLE
Add deep dependency health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Base URL:
 Routes:
 
 - `GET /api/health`
+- `GET /api/health/deep`
 - `GET /api/bounties`
 - `POST /api/bounties`
 - `POST /api/bounties/:id/reserve`
@@ -79,6 +80,10 @@ Routes:
 - `POST /api/bounties/:id/release`
 - `POST /api/bounties/:id/refund`
 - `GET /api/open-issues`
+
+`GET /api/health/deep` returns dependency status for the JSON store, Soroban
+RPC, contract configuration, and auth configuration. It responds with `503` when
+any critical component is down and is excluded from API rate limiting.
 
 ## Run Locally
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,10 +2,14 @@ import compression from 'compression';
 import cors from 'cors';
 import express, { Request, Response, NextFunction } from 'express';
 import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
 import swaggerUi from 'swagger-ui-express';
 import { buildCorsOptions } from './middleware/corsOptions';
 import { generateOpenApiDocument } from './docs/openapi';
+import { logStructured } from './logger';
 import { getMetrics, httpRequestDuration } from './metrics';
+import { mutationLimiter, readLimiter } from './utils';
 
 import {
   createBounty,
@@ -22,7 +26,6 @@ import {
   getMaintainerMetrics,
   getGlobalMetrics,
   getLeaderboard,
-  listBountiesCached,
 } from './services/bountyStore';
 
 import {
@@ -32,6 +35,7 @@ import {
   reserveBountySchema,
   submitBountySchema,
   zodErrorMessage,
+} from './validation/schemas';
 
 import {
   captureRawBody,
@@ -44,6 +48,92 @@ import {
 import { handleGitHubPrEvent } from './webhooks/githubPrHandler';
 
 const INCOMING_REQUEST_ID = /^[a-zA-Z0-9-]{1,128}$/;
+const DEFAULT_SOROBAN_RPC_URL = 'https://rpc-futurenet.stellar.org';
+
+type ComponentStatus = 'up' | 'down';
+
+interface DeepHealthResponse {
+  overall: ComponentStatus;
+  components: {
+    store: ComponentStatus;
+    soroban: ComponentStatus;
+    contract: ComponentStatus;
+    auth: ComponentStatus;
+  };
+}
+
+function resolveStorePath(): string {
+  if (process.env.BOUNTY_STORE_PATH?.trim()) {
+    return path.resolve(process.env.BOUNTY_STORE_PATH.trim());
+  }
+
+  return path.resolve(__dirname, '../data/bounties.json');
+}
+
+function checkStoreHealth(): ComponentStatus {
+  const storePath = resolveStorePath();
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+
+  if (!fs.existsSync(storePath)) {
+    fs.writeFileSync(storePath, '[]\n', 'utf8');
+  }
+
+  const raw = fs.readFileSync(storePath, 'utf8');
+  JSON.parse(raw.trim() || '[]');
+  fs.writeFileSync(storePath, raw, 'utf8');
+
+  return 'up';
+}
+
+async function checkSorobanHealth(): Promise<ComponentStatus> {
+  const rpcUrl = process.env.SOROBAN_RPC_URL?.trim() || DEFAULT_SOROBAN_RPC_URL;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 2000);
+
+  try {
+    const response = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 'health', method: 'getHealth' }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return 'down';
+    }
+
+    const body = (await response.json()) as { error?: unknown };
+    return body.error ? 'down' : 'up';
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function hasAnyEnv(...names: string[]): boolean {
+  return names.some((name) => Boolean(process.env[name]?.trim()));
+}
+
+async function buildDeepHealth(): Promise<DeepHealthResponse> {
+  const checks = await Promise.allSettled([checkStoreHealth(), checkSorobanHealth()]);
+  const store = checks[0].status === 'fulfilled' ? checks[0].value : 'down';
+  const soroban = checks[1].status === 'fulfilled' ? checks[1].value : 'down';
+  const contract = hasAnyEnv('CONTRACT_ID', 'SOROBAN_CONTRACT_ID') ? 'up' : 'down';
+  const auth =
+    hasAnyEnv('MAINTAINER_PUBLIC_KEY', 'MAINTAINER_PUBLIC_KEYS') &&
+    hasAnyEnv('ARBITER_ADDRESS')
+      ? 'up'
+      : 'down';
+
+  const components = { store, soroban, contract, auth };
+  const overall = Object.values(components).every((status) => status === 'up') ? 'up' : 'down';
+
+  return { overall, components };
+}
+
+async function deepHealthHandler(_req: Request, res: Response): Promise<void> {
+  const health = await buildDeepHealth();
+  res.status(health.overall === 'up' ? 200 : 503).json(health);
+}
 
 function resolveRequestId(req: Request): string {
   const raw = req.headers['x-request-id'];
@@ -103,6 +193,7 @@ app.use(
 );
 
 app.use(requestContextMiddleware);
+app.get('/api/health/deep', deepHealthHandler);
 app.use(readLimiter);
 
 const swaggerDoc = generateOpenApiDocument();
@@ -250,7 +341,6 @@ const healthHandler = (_req: Request, res: Response) => {
 };
 
 app.get('/api/health', healthHandler);
-app.get('/api/health/deep', healthHandler);
 
 app.get('/worker/health', (_req: Request, res: Response) => {
   res.json({

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -49,6 +49,7 @@ import { handleGitHubPrEvent } from './webhooks/githubPrHandler';
 
 const INCOMING_REQUEST_ID = /^[a-zA-Z0-9-]{1,128}$/;
 const DEFAULT_SOROBAN_RPC_URL = 'https://rpc-futurenet.stellar.org';
+const DEEP_HEALTH_CACHE_MS = 10_000;
 
 type ComponentStatus = 'up' | 'down';
 
@@ -61,6 +62,8 @@ interface DeepHealthResponse {
     auth: ComponentStatus;
   };
 }
+
+let deepHealthCache: { expiresAt: number; value: DeepHealthResponse } | null = null;
 
 function resolveStorePath(): string {
   if (process.env.BOUNTY_STORE_PATH?.trim()) {
@@ -114,7 +117,10 @@ function hasAnyEnv(...names: string[]): boolean {
 }
 
 async function buildDeepHealth(): Promise<DeepHealthResponse> {
-  const checks = await Promise.allSettled([checkStoreHealth(), checkSorobanHealth()]);
+  const checks = await Promise.allSettled([
+    Promise.resolve().then(() => checkStoreHealth()),
+    Promise.resolve().then(() => checkSorobanHealth()),
+  ]);
   const store = checks[0].status === 'fulfilled' ? checks[0].value : 'down';
   const soroban = checks[1].status === 'fulfilled' ? checks[1].value : 'down';
   const contract = hasAnyEnv('CONTRACT_ID', 'SOROBAN_CONTRACT_ID') ? 'up' : 'down';
@@ -130,8 +136,21 @@ async function buildDeepHealth(): Promise<DeepHealthResponse> {
   return { overall, components };
 }
 
+async function getDeepHealthCached(): Promise<DeepHealthResponse> {
+  const now = Date.now();
+
+  if (deepHealthCache && deepHealthCache.expiresAt > now) {
+    return deepHealthCache.value;
+  }
+
+  const value = await buildDeepHealth();
+  deepHealthCache = { value, expiresAt: now + DEEP_HEALTH_CACHE_MS };
+
+  return value;
+}
+
 async function deepHealthHandler(_req: Request, res: Response): Promise<void> {
-  const health = await buildDeepHealth();
+  const health = await getDeepHealthCached();
   res.status(health.overall === 'up' ? 200 : 503).json(health);
 }
 

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -6,6 +6,7 @@ import {
   bountyAuditLogSchema,
   bountyRecordSchema,
   createBountySchema,
+  deepHealthResponseSchema,
   errorResponseSchema,
   healthResponseSchema,
   maintainerActionSchema,
@@ -30,6 +31,7 @@ registry.register("MaintainerActionRequest", maintainerActionSchema);
 registry.register("ErrorResponse", errorResponseSchema);
 registry.register("OpenIssue", openIssueSchema);
 registry.register("HealthResponse", healthResponseSchema);
+registry.register("DeepHealthResponse", deepHealthResponseSchema);
 
 // ---------------------------------------------------------------------------
 // Reusable inline helpers
@@ -72,6 +74,20 @@ registry.registerPath({
   description: "Returns the service name and current server timestamp. Use this to verify the API is reachable.",
   responses: {
     200: jsonResponse("Service is healthy.", z.object({ data: healthResponseSchema })),
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/api/health/deep",
+  tags: ["System"],
+  summary: "Deep dependency health check",
+  description:
+    "Checks JSON store read/write, Soroban RPC reachability, contract ID configuration, " +
+    "and maintainer/arbiter auth configuration. This endpoint is excluded from rate limiting.",
+  responses: {
+    200: jsonResponse("All critical components are up.", deepHealthResponseSchema),
+    503: jsonResponse("At least one critical component is down.", deepHealthResponseSchema),
   },
 });
 

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -257,9 +257,44 @@ export const bountyAuditLogListResponseSchema = z
 
 export const healthResponseSchema = z
   .object({
-
+    service: z.string().openapi({ example: 'stellar-bounty-board-api' }),
+    status: z.string().openapi({ example: 'ok' }),
+    timestamp: z.string().openapi({ example: '2026-03-24T19:00:00.000Z' }),
   })
   .openapi('HealthResponse');
+
+const componentHealthSchema = z.enum(['up', 'down']);
+
+export const deepHealthResponseSchema = z
+  .object({
+    overall: componentHealthSchema.openapi({
+      example: 'up',
+      description: 'Overall status. Down when any critical component is down.',
+    }),
+    components: z
+      .object({
+        store: componentHealthSchema.openapi({
+          example: 'up',
+          description: 'JSON bounty store read/write health.',
+        }),
+        soroban: componentHealthSchema.openapi({
+          example: 'up',
+          description: 'Soroban RPC getHealth reachability.',
+        }),
+        contract: componentHealthSchema.openapi({
+          example: 'up',
+          description: 'Required contract ID configuration presence.',
+        }),
+        auth: componentHealthSchema.openapi({
+          example: 'up',
+          description: 'Required maintainer and arbiter auth configuration presence.',
+        }),
+      })
+      .openapi({
+        description: 'Per-component dependency status.',
+      }),
+  })
+  .openapi('DeepHealthResponse');
 
 export function zodErrorMessage(error: z.ZodError): string {
   return error.issues

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -17,6 +17,13 @@ beforeEach(async () => {
 
 afterEach(() => {
   delete process.env.BOUNTY_STORE_PATH;
+  delete process.env.SOROBAN_RPC_URL;
+  delete process.env.CONTRACT_ID;
+  delete process.env.SOROBAN_CONTRACT_ID;
+  delete process.env.MAINTAINER_PUBLIC_KEY;
+  delete process.env.MAINTAINER_PUBLIC_KEYS;
+  delete process.env.ARBITER_ADDRESS;
+  vi.unstubAllGlobals();
   try {
     fs.unlinkSync(storeFile);
   } catch {
@@ -41,6 +48,59 @@ describe("API — health and listing", () => {
     const res = await request(app).get("/api/health").expect(200);
     expect(res.body.status).toBe("ok");
     expect(res.body.service).toContain("bounty-board");
+  });
+
+  it("GET /api/health/deep returns component status when dependencies are healthy", async () => {
+    process.env.SOROBAN_RPC_URL = "https://rpc.example.test";
+    process.env.CONTRACT_ID = "contract-123";
+    process.env.MAINTAINER_PUBLIC_KEY = MAINTAINER;
+    process.env.ARBITER_ADDRESS = OTHER_ACCOUNT;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: "health", result: "healthy" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    const app = await getApp();
+    const res = await request(app).get("/api/health/deep").expect(200);
+
+    expect(res.body).toEqual({
+      overall: "up",
+      components: {
+        store: "up",
+        soroban: "up",
+        contract: "up",
+        auth: "up",
+      },
+    });
+  });
+
+  it("GET /api/health/deep returns 503 when critical config is missing", async () => {
+    process.env.SOROBAN_RPC_URL = "https://rpc.example.test";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: "health", result: "healthy" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    const app = await getApp();
+    const res = await request(app).get("/api/health/deep").expect(503);
+
+    expect(res.body.overall).toBe("down");
+    expect(res.body.components).toMatchObject({
+      store: "up",
+      soroban: "up",
+      contract: "down",
+      auth: "down",
+    });
   });
 
   it("GET /api/bounties returns data array", async () => {

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -77,6 +77,9 @@ describe("API — health and listing", () => {
         auth: "up",
       },
     });
+
+    await request(app).get("/api/health/deep").expect(200);
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 
   it("GET /api/health/deep returns 503 when critical config is missing", async () => {
@@ -100,6 +103,34 @@ describe("API — health and listing", () => {
       soroban: "up",
       contract: "down",
       auth: "down",
+    });
+  });
+
+  it("GET /api/health/deep returns 503 when the bounty store is malformed", async () => {
+    fs.writeFileSync(storeFile, "{not-json", "utf8");
+    process.env.SOROBAN_RPC_URL = "https://rpc.example.test";
+    process.env.CONTRACT_ID = "contract-123";
+    process.env.MAINTAINER_PUBLIC_KEY = MAINTAINER;
+    process.env.ARBITER_ADDRESS = OTHER_ACCOUNT;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: "health", result: "healthy" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    const app = await getApp();
+    const res = await request(app).get("/api/health/deep").expect(503);
+
+    expect(res.body.overall).toBe("down");
+    expect(res.body.components).toMatchObject({
+      store: "down",
+      soroban: "up",
+      contract: "up",
+      auth: "up",
     });
   });
 

--- a/docs/openapi.generated.json
+++ b/docs/openapi.generated.json
@@ -493,7 +493,7 @@
         "properties": {
           "service": {
             "type": "string",
-            "example": "stellar-bounty-board-backend"
+            "example": "stellar-bounty-board-api"
           },
           "status": {
             "type": "string",
@@ -508,6 +508,72 @@
           "service",
           "status",
           "timestamp"
+        ]
+      },
+      "DeepHealthResponse": {
+        "type": "object",
+        "properties": {
+          "overall": {
+            "type": "string",
+            "enum": [
+              "up",
+              "down"
+            ],
+            "example": "up",
+            "description": "Overall status. Down when any critical component is down."
+          },
+          "components": {
+            "type": "object",
+            "description": "Per-component dependency status.",
+            "properties": {
+              "store": {
+                "type": "string",
+                "enum": [
+                  "up",
+                  "down"
+                ],
+                "example": "up",
+                "description": "JSON bounty store read/write health."
+              },
+              "soroban": {
+                "type": "string",
+                "enum": [
+                  "up",
+                  "down"
+                ],
+                "example": "up",
+                "description": "Soroban RPC getHealth reachability."
+              },
+              "contract": {
+                "type": "string",
+                "enum": [
+                  "up",
+                  "down"
+                ],
+                "example": "up",
+                "description": "Required contract ID configuration presence."
+              },
+              "auth": {
+                "type": "string",
+                "enum": [
+                  "up",
+                  "down"
+                ],
+                "example": "up",
+                "description": "Required maintainer and arbiter auth configuration presence."
+              }
+            },
+            "required": [
+              "store",
+              "soroban",
+              "contract",
+              "auth"
+            ]
+          }
+        },
+        "required": [
+          "overall",
+          "components"
         ]
       }
     },
@@ -952,6 +1018,37 @@
                   "required": [
                     "data"
                   ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/health/deep": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Deep dependency health check",
+        "description": "Checks JSON store read/write, Soroban RPC reachability, contract ID configuration, and maintainer/arbiter auth configuration. This endpoint is excluded from rate limiting.",
+        "responses": {
+          "200": {
+            "description": "All critical components are up.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeepHealthResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "At least one critical component is down.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeepHealthResponse"
                 }
               }
             }


### PR DESCRIPTION
## Summary
- Add a real `GET /api/health/deep` handler with component-level `store`, `soroban`, `contract`, and `auth` checks plus 503 overall-down behavior.
- Register the deep health route before the read limiter so it is excluded from rate limiting.
- Document the endpoint in README and OpenAPI, including the generated OpenAPI JSON, and add API tests for healthy and missing-config responses.

/claim #253

Payout address: `0xe80506A1431B3B4aAca8B260838481deBbdF75Ab`

## Verification
- `git diff --check -- README.md backend/src/app.ts backend/src/docs/openapi.ts backend/src/validation/schemas.ts backend/test/api.test.ts docs/openapi.generated.json`
- `node -e "JSON.parse(require('fs').readFileSync('docs/openapi.generated.json','utf8')); console.log('openapi json ok')"`

Not run: backend typecheck/test suite because this environment has no installed project dependencies, and `npm install` did not complete before hanging on network/dependency resolution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deep health check endpoint that reports overall and per-component (store, RPC, contract, auth) statuses and returns 503 when any critical component is down; excluded from API rate limiting.

* **Documentation**
  * README and API docs updated to describe the deep health endpoint, response shape, examples, timestamp and 503 behavior.

* **Tests**
  * Added tests covering healthy, misconfigured, and corrupted-store scenarios; expanded test cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->