### PR TITLE
feat: Add update_metadata function for maintainers

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,4 +1,20 @@
-import compression from 'compression';
+i
+
+app.patch('/api/bounties/:id/metadata', async (req: Request, res: Response) => {
+  try {
+    const id = parseId(req.params.id);
+    const { maintainer, title } = req.body;
+    if (!maintainer || !title) {
+      jsonError(res, req, 400, 'maintainer and title are required.');
+      return;
+    }
+    const updated = await updateBountyMetadata(id, maintainer, title);
+    res.json({ data: updated });
+  } catch (error) {
+    sendError(res, req, error);
+  }
+});
+mport compression from 'compression';
 import cors from 'cors';
 import express, { Request, Response, NextFunction } from 'express';
 import { randomUUID } from 'node:crypto';
@@ -22,6 +38,7 @@ import {
   getMaintainerMetrics,
   getGlobalMetrics,
   getLeaderboard,
+  updateBountyMetadata,
   listBountiesCached,
 } from './services/bountyStore';
 

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -549,6 +549,53 @@ async function withGlobalLock<T>(fn: () => T | Promise<T>): Promise<T> {
   }
 }
 
+
+export async function updateBountyMetadata(
+  id: string,
+  maintainer: string,
+  newTitle: string,
+): Promise<BountyRecord> {
+  return withGlobalLock(async () => {
+    const records = listBounties();
+    const bounty = findBounty(records, id);
+
+    if (bounty.maintainer !== maintainer) {
+      throw new Error('Only the original maintainer can update metadata.');
+    }
+    if (['released', 'refunded', 'expired'].includes(bounty.status)) {
+      throw new Error('Cannot update metadata for finalized bounties.');
+    }
+
+    const updated: BountyRecord = {
+      ...bounty,
+      title: newTitle,
+      version: bounty.version + 1,
+      events: [
+        ...bounty.events,
+        { 
+          type: 'updated' as any, 
+          timestamp: Math.floor(Date.now() / 1000), 
+          details: { oldTitle: bounty.title, newTitle } 
+        },
+      ],
+    };
+
+    const persisted = persistUpdated(records, updated);
+    appendAuditLogs([
+      {
+        bountyId: id,
+        fromStatus: bounty.status,
+        toStatus: bounty.status,
+        transition: 'update' as any,
+        actor: maintainer,
+        metadata: { oldTitle: bounty.title, newTitle },
+      },
+    ]);
+    await invalidateBountyCache();
+    return persisted;
+  });
+}
+
 export async function createBounty(
   input: CreateBountyInput,
 ): Promise<BountyRecord> {


### PR DESCRIPTION
This PR implements the `update_metadata` functionality as requested in issue #231. It allows maintainers to correct the title of non-finalized bounties via a new `PATCH /api/bounties/:id/metadata` endpoint.