### PR TITLE
feat: Add lookup by repo and issue number

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -13,6 +13,7 @@ import {
   listAllAuditLogs,
   listBounties,
   listBountiesCached,
+  findBountyByIssue,
   invalidateBountyCache,
   refundBounty,
   releaseBounty,
@@ -23,6 +24,7 @@ import {
   getGlobalMetrics,
   getLeaderboard,
   listBountiesCached,
+  findBountyByIssue,
 } from './services/bountyStore';
 
 import {
@@ -262,7 +264,26 @@ app.get('/worker/health', (_req: Request, res: Response) => {
 
 app.get('/api/bounties', async (req: Request, res: Response) => {
   const q = typeof req.query.q === 'string' ? req.query.q : undefined;
-  res.json({ data: await listBountiesCached({ q }) });
+  res.json({ data: await listBountiesCached({ q }) })
+
+app.get('/api/bounties/by-issue', (req: Request, res: Response) => {
+  try {
+    const { repo, issue } = req.query;
+    if (!repo || !issue) {
+      jsonError(res, req, 400, 'repo and issue parameters are required.');
+      return;
+    }
+    const bounty = findBountyByIssue(typeof repo === 'string' ? repo : '', Number(issue));
+    if (!bounty) {
+      jsonError(res, req, 404, 'Bounty for this issue not found.');
+      return;
+    }
+    res.json({ data: bounty });
+  } catch (error) {
+    sendError(res, req, error);
+  }
+});
+;
 });
 
 app.get('/api/leaderboard', (req: Request, res: Response) => {

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -436,6 +436,12 @@ function nextId(records: BountyRecord[]): string {
   return `BNT-${String(max + 1).padStart(4, "0")}`;
 }
 
+
+export function findBountyByIssue(repo: string, issueNumber: number): BountyRecord | undefined {
+  const records = listBounties();
+  return records.find((b) => b.repo.toLowerCase() === repo.toLowerCase() && b.issueNumber === issueNumber);
+}
+
 function findBounty(records: BountyRecord[], id: string): BountyRecord {
   const bounty = records.find((record) => record.id === id);
   if (!bounty) {


### PR DESCRIPTION
This PR implements the `GET /api/bounties/by-issue` endpoint as requested in issue #258. It allows direct lookup of a bounty using its GitHub repository and issue number.