### PR TITLE
feat: Add /api/bounties/:id/audit-log endpoint

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -275,6 +275,18 @@ app.get('/api/leaderboard', (req: Request, res: Response) => {
   }
 });
 
+
+app.get('/api/bounties/:id/audit-log', (req: Request, res: Response) => {
+  try {
+    const limit = parsePaginationValue(req.query.limit, 'limit', 20, 1, 100);
+    const offset = parsePaginationValue(req.query.offset, 'offset', 0, 0);
+    const page = listBountyAuditLogs(parseId(req.params.id), { limit, offset });
+    res.json(page);
+  } catch (error) {
+    sendError(res, req, error);
+  }
+});
+
 app.get('/api/bounties/:id/audit-logs', (req: Request, res: Response) => {
   try {
     const limit = parsePaginationValue(req.query.limit, 'limit', 20, 1, 100);


### PR DESCRIPTION
This PR adds the `GET /api/bounties/:id/audit-log` endpoint as requested in issue #237, providing a paginated view of a bounty's audit trail.