### PR TITLE
feat: add POST /api/bounties/:id/dispute route and reservationExpirat…

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,6 +9,7 @@ import { getMetrics, httpRequestDuration } from './metrics';
 
 import {
   createBounty,
+  disputeBounty,
   listBountyAuditLogs,
   listAllAuditLogs,
   listBounties,
@@ -28,10 +29,12 @@ import {
 import {
   bountyIdSchema,
   createBountySchema,
+  disputeBountySchema,
   maintainerActionSchema,
   reserveBountySchema,
   submitBountySchema,
   zodErrorMessage,
+} from './validation/schemas';
 
 import {
   captureRawBody,
@@ -468,6 +471,32 @@ app.post(
         parseId(req.params.id),
         parsedBody.data.maintainer,
         parsedBody.data.transactionHash
+      );
+
+      res.json({ data: bounty });
+    } catch (error) {
+      sendError(res, req, error);
+    }
+  }
+);
+
+app.post(
+  '/api/bounties/:id/dispute',
+  mutationLimiter,
+  createStellarSignatureAuthMiddleware(),
+  async (req: Request, res: Response) => {
+    const parsedBody = disputeBountySchema.safeParse(req.body);
+
+    if (!parsedBody.success) {
+      jsonError(res, req, 400, zodErrorMessage(parsedBody.error));
+      return;
+    }
+
+    try {
+      const bounty = await disputeBounty(
+        parseId(req.params.id),
+        parsedBody.data.contributor,
+        parsedBody.data.reason
       );
 
       res.json({ data: bounty });

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -26,7 +26,8 @@ export type BountyStatus =
   | "submitted"
   | "released"
   | "refunded"
-  | "expired";
+  | "expired"
+  | "disputed";
 
 
 /**
@@ -45,7 +46,8 @@ export type BountyTransitionType =
   | "submit"
   | "release"
   | "refund"
-  | "expire";
+  | "expire"
+  | "dispute";
 
 /**
  * Represents a historical event in the lifecycle of a bounty.
@@ -129,6 +131,10 @@ export interface BountyRecord {
   submissionUrl?: string;
   /** Submission notes left by the contributor. */
   notes?: string;
+  /** Unix timestamp in seconds of when the bounty was disputed. */
+  disputedAt?: number;
+  /** Reason provided by the contributor for disputing the bounty. */
+  disputeReason?: string;
   // Race condition prevention
   /** Version number of the record used for optimistic locking. */
   version: number;
@@ -843,6 +849,90 @@ export async function refundBounty(
       },
     ]);
     await invalidateBountyCache();
+    return persisted;
+  });
+}
+
+/**
+ * Disputes a submitted bounty, transitioning it to "disputed" status.
+ *
+ * Acquires a global lock during execution. Only the contributor who submitted
+ * the bounty can dispute it, and only when the bounty is in "submitted" status.
+ *
+ * @param {string} id - The unique ID of the bounty.
+ * @param {string} contributor - The Stellar address of the contributor disputing the bounty.
+ * @param {string} reason - The reason for disputing the bounty.
+ * @returns {Promise<BountyRecord>} A promise that resolves to the updated bounty record.
+ * @throws {Error} If the bounty is not found.
+ * @throws {Error} If the contributor address does not match the bounty's contributor.
+ * @throws {Error} If the bounty status is not "submitted".
+ */
+export async function disputeBounty(
+  id: string,
+  contributor: string,
+  reason: string,
+): Promise<BountyRecord> {
+  return withGlobalLock(async () => {
+    const records = listBounties();
+    const bounty = findBounty(records, id);
+
+    if (bounty.status !== "submitted") {
+      throw new Error("Only submitted bounties can be disputed.");
+    }
+    if (bounty.contributor !== contributor) {
+      throw new Error("Only the contributor who submitted this bounty can dispute it.");
+    }
+
+    const now = nowInSeconds();
+    const updated: BountyRecord = {
+      ...bounty,
+      status: "disputed",
+      disputedAt: now,
+      disputeReason: reason,
+      version: bounty.version + 1,
+      events: [
+        ...bounty.events,
+        {
+          type: "disputed",
+          timestamp: now,
+          actor: contributor,
+          details: { reason },
+        },
+      ],
+    };
+
+    const persisted = persistUpdated(records, updated);
+    appendAuditLogs([
+      {
+        bountyId: id,
+        fromStatus: bounty.status,
+        toStatus: "disputed",
+        transition: "dispute",
+        actor: contributor,
+        metadata: {
+          reason,
+        },
+      },
+    ]);
+    await invalidateBountyCache();
+
+    // Notify maintainer and arbiter about the dispute
+    const recipients: NotificationRecipient[] = [
+      { role: "maintainer", address: bounty.maintainer },
+    ];
+    if (bounty.contributor) {
+      recipients.push({ role: "contributor", address: bounty.contributor });
+    }
+
+    sendNotification(recipients, "bounty_disputed", {
+      bountyId: id,
+      contributor,
+      reason,
+      disputedAt: now,
+    }).catch((err) =>
+      console.warn("[disputeBounty] Notification failed (non-blocking):", err),
+    );
+
     return persisted;
   });
 }

--- a/backend/src/validation/schemas.ts
+++ b/backend/src/validation/schemas.ts
@@ -124,6 +124,23 @@ export const submitBountySchema = z
   })
   .openapi('SubmitBountyRequest');
 
+export const disputeBountySchema = z
+  .object({
+    contributor: stellarAccountSchema.openapi({
+      description: 'Stellar public key of the contributor disputing the bounty.',
+    }),
+    reason: z
+      .string()
+      .trim()
+      .min(1, 'Reason is required.')
+      .max(500, 'Reason must be at most 500 characters.')
+      .openapi({
+        example: 'The submitted solution was not reviewed within the agreed timeframe.',
+        description: 'Reason for disputing the bounty (1–500 chars).',
+      }),
+  })
+  .openapi('DisputeBountyRequest');
+
 export const maintainerActionSchema = z
   .object({
     maintainer: stellarAccountSchema.openapi({

--- a/backend/test/api.dispute.test.ts
+++ b/backend/test/api.dispute.test.ts
@@ -1,0 +1,165 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CONTRIBUTOR, MAINTAINER, OTHER_ACCOUNT, validCreateBody } from "./fixtures";
+
+let storeFile: string;
+
+beforeEach(async () => {
+  storeFile = path.join(os.tmpdir(), `bounty-api-dispute-${randomUUID()}.json`);
+  fs.writeFileSync(storeFile, "[]", "utf8");
+  process.env.BOUNTY_STORE_PATH = storeFile;
+  process.env.NODE_ENV = "test";
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete process.env.BOUNTY_STORE_PATH;
+  try {
+    fs.unlinkSync(storeFile);
+  } catch {
+    /* best-effort */
+  }
+  try {
+    const auditStorePath = storeFile.replace(/\.json$/i, ".audit.json");
+    fs.unlinkSync(auditStorePath);
+  } catch {
+    /* best-effort */
+  }
+});
+
+async function getApp() {
+  const { app } = await import("../src/app");
+  return app;
+}
+
+/**
+ * Seed bounties through the store directly (bypass middleware) so we can test
+ * the dispute route in isolation. Returns the bounty IDs in order.
+ */
+async function seedBounty(
+  app: Express.Application,
+  overrides: Record<string, unknown> = {},
+): Promise<string> {
+  const body = { ...validCreateBody, ...overrides };
+  const res = await request(app).post("/api/bounties").send(body).expect(201);
+  return res.body.data.id as string;
+}
+
+async function fullCycle(app: Express.Application): Promise<string> {
+  const id = await seedBounty(app);
+  await request(app)
+    .post(`/api/bounties/${id}/reserve`)
+    .send({ contributor: CONTRIBUTOR })
+    .expect(200);
+  await request(app)
+    .post(`/api/bounties/${id}/submit`)
+    .send({
+      contributor: CONTRIBUTOR,
+      submissionUrl: "https://github.com/owner/repo/pull/1",
+    })
+    .expect(200);
+  return id;
+}
+
+describe("POST /api/bounties/:id/dispute", () => {
+  it("disputes a submitted bounty successfully", async () => {
+    const app = await getApp();
+    const id = await fullCycle(app);
+
+    const res = await request(app)
+      .post(`/api/bounties/${id}/dispute`)
+      .send({ contributor: CONTRIBUTOR, reason: "Maintainer did not review within the agreed timeframe." })
+      .expect(200);
+
+    expect(res.body.data.status).toBe("disputed");
+    expect(res.body.data.disputeReason).toBe("Maintainer did not review within the agreed timeframe.");
+    expect(res.body.data.disputedAt).toBeGreaterThan(0);
+    expect(res.body.data.version).toBeGreaterThan(1);
+
+    // Verify the event log contains the disputed event
+    const eventsRes = await request(app).get(`/api/bounties/${id}/events`).expect(200);
+    const disputedEvent = eventsRes.body.data.find(
+      (e: { type: string }) => e.type === "disputed",
+    );
+    expect(disputedEvent).toBeDefined();
+    expect(disputedEvent.actor).toBe(CONTRIBUTOR);
+    expect(disputedEvent.details.reason).toBe("Maintainer did not review within the agreed timeframe.");
+
+    // Verify audit log
+    const auditRes = await request(app)
+      .get(`/api/bounties/${id}/audit-logs`)
+      .query({ limit: 10, offset: 0 })
+      .expect(200);
+    const disputeAudit = auditRes.body.data.find(
+      (entry: { transition: string }) => entry.transition === "dispute",
+    );
+    expect(disputeAudit).toBeDefined();
+    expect(disputeAudit.fromStatus).toBe("submitted");
+    expect(disputeAudit.toStatus).toBe("disputed");
+    expect(disputeAudit.actor).toBe(CONTRIBUTOR);
+  });
+
+  it("returns 400 when contributor does not match the bounty contributor", async () => {
+    const app = await getApp();
+    const id = await fullCycle(app);
+
+    const res = await request(app)
+      .post(`/api/bounties/${id}/dispute`)
+      .send({ contributor: OTHER_ACCOUNT, reason: "Not my bounty." })
+      .expect(400);
+
+    expect(res.body.error).toMatch(/Only the contributor/i);
+  });
+
+  it("returns 400 when bounty status is not submitted", async () => {
+    const app = await getApp();
+    const id = await seedBounty(app);
+
+    // Bounty is 'open' - should fail
+    const res = await request(app)
+      .post(`/api/bounties/${id}/dispute`)
+      .send({ contributor: MAINTAINER, reason: "Wrong status." })
+      .expect(400);
+
+    expect(res.body.error).toMatch(/Only submitted bounties can be disputed/i);
+  });
+
+  it("returns 400 when reason is empty", async () => {
+    const app = await getApp();
+    const id = await fullCycle(app);
+
+    const res = await request(app)
+      .post(`/api/bounties/${id}/dispute`)
+      .send({ contributor: CONTRIBUTOR, reason: "" })
+      .expect(400);
+
+    expect(res.body.error).toBeDefined();
+  });
+
+  it("returns 400 when contributor address is invalid", async () => {
+    const app = await getApp();
+    const id = await fullCycle(app);
+
+    const res = await request(app)
+      .post(`/api/bounties/${id}/dispute`)
+      .send({ contributor: "not-a-valid-address", reason: "Test reason." })
+      .expect(400);
+
+    expect(res.body.error).toMatch(/public key|Must be valid/i);
+  });
+
+  it("returns 400 for unknown bounty id", async () => {
+    const app = await getApp();
+
+    const res = await request(app)
+      .post("/api/bounties/BNT-9999/dispute")
+      .send({ contributor: CONTRIBUTOR, reason: "Bounty not found." })
+      .expect(400);
+
+    expect(res.body.error).toMatch(/not found/i);
+  });
+});

--- a/backend/test/reservationExpirationJob.partialFailure.test.ts
+++ b/backend/test/reservationExpirationJob.partialFailure.test.ts
@@ -1,0 +1,203 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CONTRIBUTOR, MAINTAINER } from './fixtures';
+
+let storeFile: string;
+
+beforeEach(() => {
+  storeFile = path.join(os.tmpdir(), `expiration-partial-failure-${randomUUID()}.json`);
+  fs.writeFileSync(storeFile, '[]', 'utf8');
+  process.env.BOUNTY_STORE_PATH = storeFile;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete process.env.BOUNTY_STORE_PATH;
+  delete process.env.RESERVATION_TTL_DAYS;
+
+  try {
+    fs.unlinkSync(storeFile);
+  } catch {
+    // best-effort cleanup
+  }
+
+  try {
+    fs.unlinkSync(storeFile.replace(/\.json$/i, '.audit.json'));
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+async function loadJob() {
+  return import('../src/services/reservationExpirationJob');
+}
+
+function nowSeconds() {
+  return Math.floor(Date.now() / 1000);
+}
+
+function makeReservedBounty(id: string, reservedSecondsAgo: number) {
+  const now = nowSeconds();
+
+  return {
+    id,
+    repo: 'test/repo',
+    issueNumber: 1,
+    title: 'Test bounty for partial failure',
+    summary: 'Testing partial failure recovery in expiration job.',
+    maintainer: MAINTAINER,
+    contributor: CONTRIBUTOR,
+    tokenSymbol: 'XLM',
+    amount: 100,
+    labels: [],
+    status: 'reserved' as const,
+    createdAt: now - reservedSecondsAgo - 100,
+    deadlineAt: now + 9999999,
+    reservedAt: now - reservedSecondsAgo,
+    version: 1,
+    events: [
+      { type: 'created' as const, timestamp: now - reservedSecondsAgo - 100 },
+      {
+        type: 'reserved' as const,
+        timestamp: now - reservedSecondsAgo,
+        actor: CONTRIBUTOR,
+      },
+    ],
+    reservationTimeoutSeconds: 999999999,
+  };
+}
+
+describe('ExpirationJob — partial failure recovery', () => {
+  it('continues processing remaining bounties when one has a corrupt reservedAt', async () => {
+    const now = nowSeconds();
+
+    // Bounty 1: expired (8 days old)
+    const bounty1 = makeReservedBounty('BNT-PARTIAL-001', 8 * 24 * 60 * 60);
+
+    // Bounty 2: corrupt reservedAt (null instead of number)
+    const bounty2 = makeReservedBounty('BNT-PARTIAL-002', 8 * 24 * 60 * 60);
+    (bounty2 as Record<string, unknown>).reservedAt = 'corrupt-string';
+
+    // Bounty 3: expired (10 days old)
+    const bounty3 = makeReservedBounty('BNT-PARTIAL-003', 10 * 24 * 60 * 60);
+
+    fs.writeFileSync(storeFile, JSON.stringify([bounty1, bounty2, bounty3], null, 2));
+
+    const { expireStaleReservations } = await loadJob();
+    const result = expireStaleReservations(7 * 24 * 60 * 60);
+
+    // The job should have expired the 2 valid ones and skipped the corrupt one
+    expect(result.expiredCount).toBe(2);
+    expect(result.expiredBountyIds).toContain(bounty1.id);
+    expect(result.expiredBountyIds).toContain(bounty3.id);
+    expect(result.expiredBountyIds).not.toContain(bounty2.id);
+
+    // Read the updated store and verify
+    const raw = JSON.parse(fs.readFileSync(storeFile, 'utf8'));
+
+    const updatedBounty1 = raw.find((item: { id: string }) => item.id === bounty1.id);
+    expect(updatedBounty1.status).toBe('open');
+
+    const updatedBounty2 = raw.find((item: { id: string }) => item.id === bounty2.id);
+    // Corrupt bounty should still be 'reserved' since it could not be evaluated
+    expect(updatedBounty2.status).toBe('reserved');
+
+    const updatedBounty3 = raw.find((item: { id: string }) => item.id === bounty3.id);
+    expect(updatedBounty3.status).toBe('open');
+  });
+
+  it('handles missing reservedAt field gracefully', async () => {
+    const now = nowSeconds();
+
+    // Bounty with no reservedAt at all
+    const noReservedAt = {
+      id: 'BNT-NO-RESERVED',
+      repo: 'test/repo',
+      issueNumber: 1,
+      title: 'No reservedAt',
+      summary: 'Bounty missing reservedAt field.',
+      maintainer: MAINTAINER,
+      contributor: CONTRIBUTOR,
+      tokenSymbol: 'XLM',
+      amount: 100,
+      labels: [],
+      status: 'reserved' as const,
+      createdAt: now - 20 * 24 * 60 * 60,
+      deadlineAt: now + 9999999,
+      version: 1,
+      events: [
+        { type: 'created' as const, timestamp: now - 20 * 24 * 60 * 60 },
+        {
+          type: 'reserved' as const,
+          timestamp: now - 20 * 24 * 60 * 60,
+          actor: CONTRIBUTOR,
+        },
+      ],
+      reservationTimeoutSeconds: 999999999,
+    };
+
+    // Valid expired bounty
+    const validExpired = makeReservedBounty('BNT-VALID-EXPIRED', 8 * 24 * 60 * 60);
+
+    fs.writeFileSync(storeFile, JSON.stringify([noReservedAt, validExpired], null, 2));
+
+    const { expireStaleReservations } = await loadJob();
+    const result = expireStaleReservations(7 * 24 * 60 * 60);
+
+    // Only the valid expired bounty should be expired
+    expect(result.expiredCount).toBe(1);
+    expect(result.expiredBountyIds).toContain(validExpired.id);
+    expect(result.expiredBountyIds).not.toContain(noReservedAt.id);
+
+    // The corrupt bounty should remain unchanged
+    const raw = JSON.parse(fs.readFileSync(storeFile, 'utf8'));
+    const unchanged = raw.find((item: { id: string }) => item.id === noReservedAt.id);
+    expect(unchanged.status).toBe('reserved');
+
+    const valid = raw.find((item: { id: string }) => item.id === validExpired.id);
+    expect(valid.status).toBe('open');
+  });
+
+  it('does not crash when the store contains non-reserved bounties with missing fields', async () => {
+    const now = nowSeconds();
+
+    // A malformed bounty with status 'open' but no version field
+    const malformed = {
+      id: 'BNT-MALFORMED',
+      repo: 'test/repo',
+      issueNumber: 1,
+      title: 'Malformed',
+      summary: 'A malformed bounty record.',
+      maintainer: MAINTAINER,
+      tokenSymbol: 'XLM',
+      amount: 100,
+      labels: [],
+      status: 'open' as const,
+      createdAt: now - 100,
+      deadlineAt: now + 9999999,
+      events: [{ type: 'created' as const, timestamp: now - 100 }],
+    };
+
+    // Valid expired bounty
+    const validStale = makeReservedBounty('BNT-STALE', 8 * 24 * 60 * 60);
+
+    fs.writeFileSync(storeFile, JSON.stringify([malformed, validStale], null, 2));
+
+    const { expireStaleReservations } = await loadJob();
+    const result = expireStaleReservations(7 * 24 * 60 * 60);
+
+    // Should have expired the valid stale bounty
+    expect(result.expiredCount).toBe(1);
+    expect(result.expiredBountyIds).toContain(validStale.id);
+
+    const raw = JSON.parse(fs.readFileSync(storeFile, 'utf8'));
+    const updatedStale = raw.find((item: { id: string }) => item.id === validStale.id);
+    expect(updatedStale.status).toBe('open');
+
+    const preservedMalformed = raw.find((item: { id: string }) => item.id === malformed.id);
+    expect(preservedMalformed.status).toBe('open');
+  });
+});


### PR DESCRIPTION
Both tasks have been implemented:
closes #242 
closes #275 
## Task #242: POST /api/bounties/:id/dispute backend route

**Files modified:**
- `backend/src/services/bountyStore.ts` — Added `"disputed"` to `BountyStatus`, `"dispute"` to `BountyTransitionType`, added `disputedAt` and `disputeReason` fields to `BountyRecord`, and added the `disputeBounty()` function that:
  - Validates bounty is in `"submitted"` status
  - Validates the caller is the bounty's contributor
  - Records `disputeReason` and `disputedAt`
  - Emits a `"disputed"` event in the bounty event log with reason details
  - Records a `"dispute"` audit log entry
  - Fires notifications to maintainer and contributor
  - Uses global lock for concurrency safety

- `backend/src/validation/schemas.ts` — Added `disputeBountySchema` with `contributor` (Stellar address) and `reason` (1-500 chars) validation

- `backend/src/app.ts` — Added `POST /api/bounties/:id/dispute` route with:
  - `mutationLimiter` for rate limiting
  - `createStellarSignatureAuthMiddleware()` for signature verification via `x-stellar-signature` header
  - Zod schema validation of request body
  - Calls `disputeBounty()` from bountyStore

**New test file:** `backend/test/api.dispute.test.ts` — Covers:
  - ✅ Success path: submitted → disputed with event log & audit log verification
  - ✅ Wrong signer (different contributor) returns 400
  - ✅ Wrong status (open instead of submitted) returns 400
  - ✅ Empty reason returns 400
  - ✅ Invalid contributor address returns 400
  - ✅ Unknown bounty ID returns 400

## Task #275: reservationExpirationJob partial failure recovery test

**New test file:** `backend/test/reservationExpirationJob.partialFailure.test.ts` — Covers:
  - ✅ 3 bounties: 2 expired, 1 with corrupt `reservedAt` (string instead of number) — job expires the 2 valid ones, skips the corrupt one
  - ✅ Bounty with missing `reservedAt` field — skipped gracefully, other bounties still expired
  - ✅ Malformed non-reserved bounty record — doesn't crash the job, valid expired bounties still processed

All tests are designed to pass since the existing `expireStaleReservations` implementation gracefully handles non-number `reservedAt` values via the `typeof bounty.reservedAt === 'number'` guard, and `map()` naturally continues iteration after each item without throwing on individual item failures.