### PR TITLE
feat(api): add server-side pagination to GET /api/bounties

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -261,8 +261,22 @@ app.get('/worker/health', (_req: Request, res: Response) => {
 });
 
 app.get('/api/bounties', async (req: Request, res: Response) => {
-  const q = typeof req.query.q === 'string' ? req.query.q : undefined;
-  res.json({ data: await listBountiesCached({ q }) });
+  try {
+    const q = typeof req.query.q === 'string' ? req.query.q : undefined;
+    const page = parsePaginationValue(req.query.page, 'page', 1, 1);
+    const pageSize = parsePaginationValue(req.query.pageSize, 'pageSize', 20, 1, 100);
+
+    const all = await listBountiesCached({ q });
+    const total = all.length;
+    const start = (page - 1) * pageSize;
+    const data = all.slice(start, start + pageSize);
+    const hasMore = start + data.length < total;
+
+    res.setHeader('X-Total-Count', String(total));
+    res.json({ data, total, page, pageSize, hasMore });
+  } catch (error) {
+    sendError(res, req, error);
+  }
 });
 
 app.get('/api/leaderboard', (req: Request, res: Response) => {

--- a/backend/test/pagination.test.ts
+++ b/backend/test/pagination.test.ts
@@ -1,0 +1,125 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAINTAINER, validCreateBody } from "./fixtures";
+
+let storeFile: string;
+
+beforeEach(async () => {
+  storeFile = path.join(os.tmpdir(), `bounty-pagination-${randomUUID()}.json`);
+  fs.writeFileSync(storeFile, "[]", "utf8");
+  process.env.BOUNTY_STORE_PATH = storeFile;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete process.env.BOUNTY_STORE_PATH;
+  try { fs.unlinkSync(storeFile); } catch { /* best-effort */ }
+  try { fs.unlinkSync(storeFile.replace(/\.json$/i, ".audit.json")); } catch { /* best-effort */ }
+});
+
+async function getApp() {
+  const { app } = await import("../src/app");
+  return app;
+}
+
+async function seedBounties(app: Awaited<ReturnType<typeof getApp>>, count: number) {
+  for (let i = 0; i < count; i++) {
+    await request(app)
+      .post("/api/bounties")
+      .set("x-maintainer-address", MAINTAINER)
+      .send({ ...validCreateBody, title: `Bounty ${i + 1}` })
+      .expect(201);
+  }
+}
+
+describe("GET /api/bounties — pagination", () => {
+  it("returns default pageSize=20 and pagination metadata", async () => {
+    const app = await getApp();
+    await seedBounties(app, 25);
+
+    const res = await request(app).get("/api/bounties").expect(200);
+
+    expect(res.body.data).toHaveLength(20);
+    expect(res.body.total).toBe(25);
+    expect(res.body.page).toBe(1);
+    expect(res.body.pageSize).toBe(20);
+    expect(res.body.hasMore).toBe(true);
+    expect(res.headers["x-total-count"]).toBe("25");
+  });
+
+  it("returns second page with remaining items", async () => {
+    const app = await getApp();
+    await seedBounties(app, 25);
+
+    const res = await request(app).get("/api/bounties?page=2&pageSize=20").expect(200);
+
+    expect(res.body.data).toHaveLength(5);
+    expect(res.body.page).toBe(2);
+    expect(res.body.hasMore).toBe(false);
+  });
+
+  it("hasMore is false on the last page", async () => {
+    const app = await getApp();
+    await seedBounties(app, 10);
+
+    const res = await request(app).get("/api/bounties?page=1&pageSize=10").expect(200);
+
+    expect(res.body.data).toHaveLength(10);
+    expect(res.body.hasMore).toBe(false);
+  });
+
+  it("returns empty data array when page is beyond total", async () => {
+    const app = await getApp();
+    await seedBounties(app, 5);
+
+    const res = await request(app).get("/api/bounties?page=99&pageSize=20").expect(200);
+
+    expect(res.body.data).toHaveLength(0);
+    expect(res.body.hasMore).toBe(false);
+    expect(res.body.total).toBe(5);
+  });
+
+  it("returns 400 when pageSize exceeds maximum of 100", async () => {
+    const app = await getApp();
+    const res = await request(app).get("/api/bounties?pageSize=101").expect(400);
+    expect(res.body.error).toMatch(/pageSize/i);
+  });
+
+  it("returns 400 for non-integer pageSize", async () => {
+    const app = await getApp();
+    const res = await request(app).get("/api/bounties?pageSize=abc").expect(400);
+    expect(res.body.error).toMatch(/pageSize/i);
+  });
+
+  it("accepts custom pageSize within bounds", async () => {
+    const app = await getApp();
+    await seedBounties(app, 10);
+
+    const res = await request(app).get("/api/bounties?pageSize=5").expect(200);
+
+    expect(res.body.data).toHaveLength(5);
+    expect(res.body.pageSize).toBe(5);
+    expect(res.body.hasMore).toBe(true);
+  });
+
+  it("combines ?q filter with pagination", async () => {
+    const app = await getApp();
+    await seedBounties(app, 5);
+    // Seed a uniquely-titled bounty for filter testing
+    await request(app)
+      .post("/api/bounties")
+      .set("x-maintainer-address", MAINTAINER)
+      .send({ ...validCreateBody, title: "UniqueFilterTarget" })
+      .expect(201);
+
+    const res = await request(app).get("/api/bounties?q=UniqueFilterTarget&pageSize=20").expect(200);
+
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.total).toBe(1);
+    expect(res.body.hasMore).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #248
Closes #240
Closes #243
Closes #238

## What was done

### `backend/src/app.ts` — pagination added to `GET /api/bounties`

The endpoint previously returned every record in a single `{ data }` payload. It now accepts `?page` and `?pageSize` query parameters and returns a paginated response.

**Query parameters**

| Param | Default | Min | Max |
|-------|---------|-----|-----|
| `page` | `1` | `1` | — |
| `pageSize` | `20` | `1` | `100` |

Both parameters are validated using the existing `parsePaginationValue` helper (already used by the audit-logs and leaderboard endpoints) so the error format is consistent across the API. Passing `pageSize > 100` returns a `400` response.

**Response shape**

```json
{
  "data": [...],
  "total": 42,
  "page": 1,
  "pageSize": 20,
  "hasMore": true
}
```

`X-Total-Count` is also set on every successful response for clients that only need the count without parsing the body.

**Implementation detail**

The full filtered list is still fetched from `listBountiesCached` (5s Redis TTL unchanged), then sliced in-process. This keeps the cache hit-rate high — the cache key doesn't need to include pagination params — while the slice itself is O(pageSize).

### `backend/test/pagination.test.ts` (new)

8 integration tests using supertest against a temp-file store (same pattern as `api.test.ts`):

| Test | What it checks |
|------|---------------|
| default page | 20 items returned, `total=25`, `hasMore=true`, `X-Total-Count=25` |
| second page | 5 remaining items, `hasMore=false` |
| exact last page | `hasMore=false` when items fit precisely |
| page beyond total | empty `data`, `hasMore=false`, correct `total` |
| `pageSize=101` | 400 with error message mentioning `pageSize` |
| non-integer pageSize | 400 with error mentioning `pageSize` |
| custom pageSize in bounds | slice respected, `hasMore=true` |
| `?q` + pagination | filtered total reflected in `total` and `hasMore` |