### PR TITLE
Add GET /api/stats global metrics endpoint

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -22,6 +22,7 @@ import {
   getBountyEvents,
   getMaintainerMetrics,
   getGlobalMetrics,
+  getGlobalMetricsCached,
   getLeaderboard,
   listBountiesCached,
 } from './services/bountyStore';
@@ -611,6 +612,15 @@ app.get('/api/global-metrics', (_req: Request, res: Response) => {
     res.json({ data: metrics });
   } catch (error) {
     sendError(res, _req, error);
+  }
+});
+
+app.get('/api/stats', async (_req: Request, res: Response) => {
+  try {
+    const metrics = await getGlobalMetricsCached();
+    res.json({ data: metrics });
+  } catch (error) {
+    sendError(res, _req, error, 500);
   }
 });
 

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -222,6 +222,42 @@ registry.registerPath({
   },
 });
 
+const globalMetricsSchema = z
+  .object({
+    totalBounties: z.number().int().openapi({ example: 42, description: "Total number of bounties created." }),
+    openCount: z.number().int().openapi({ example: 10, description: "Number of bounties with status 'open'." }),
+    reservedCount: z.number().int().openapi({ example: 5, description: "Number of bounties with status 'reserved'." }),
+    submittedCount: z.number().int().openapi({ example: 3, description: "Number of bounties with status 'submitted'." }),
+    releasedCount: z.number().int().openapi({ example: 20, description: "Number of bounties with status 'released'." }),
+    refundedCount: z.number().int().openapi({ example: 2, description: "Number of bounties with status 'refunded'." }),
+    expiredCount: z.number().int().openapi({ example: 2, description: "Number of bounties with status 'expired'." }),
+    totalFunded: z.number().openapi({ example: 1250.5, description: "Sum of all bounty amounts in XLM." }),
+    totalReleased: z.number().openapi({ example: 850.0, description: "Sum of released bounty amounts in XLM." }),
+    uniqueMaintainers: z.number().int().openapi({ example: 8, description: "Count of unique maintainer addresses." }),
+    uniqueContributors: z.number().int().openapi({ example: 15, description: "Count of unique contributor addresses." }),
+  })
+  .openapi("GlobalMetrics");
+
+registry.register("GlobalMetrics", globalMetricsSchema);
+
+registry.registerPath({
+  method: "get",
+  path: "/api/stats",
+  tags: ["Stats"],
+  summary: "Global platform metrics",
+  description:
+    "Returns aggregate statistics for the entire platform including bounty status counts, " +
+    "total funded and released amounts, and unique participant counts. " +
+    "Response is cached with a **30-second TTL** to reduce computation overhead.",
+  responses: {
+    200: jsonResponse(
+      "Global platform metrics.",
+      z.object({ data: globalMetricsSchema }),
+    ),
+    500: errorResponse("Failed to compute global stats."),
+  },
+});
+
 const leaderboardEntrySchema = z
   .object({
     address: z.string().openapi({ example: "GBBB...BBB", description: "Contributor Stellar address." }),

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -1108,6 +1108,26 @@ export function getGlobalMetrics(): GlobalMetrics {
   };
 }
 
+const GLOBAL_METRICS_CACHE_KEY = "stats:global";
+const GLOBAL_METRICS_TTL_SECONDS = 30;
+
+/**
+ * Cache-backed variant of {@link getGlobalMetrics} with a 30-second TTL.
+ *
+ * @param {CacheAdapter} [cache=getCache()] - The cache adapter to use for caching.
+ * @returns {Promise<GlobalMetrics>} A promise that resolves to the global metrics.
+ */
+export async function getGlobalMetricsCached(
+  cache: CacheAdapter = getCache(),
+): Promise<GlobalMetrics> {
+  const cached = await cache.get(GLOBAL_METRICS_CACHE_KEY);
+  if (cached) {
+    return JSON.parse(cached) as GlobalMetrics;
+  }
+  const metrics = getGlobalMetrics();
+  await cache.set(GLOBAL_METRICS_CACHE_KEY, JSON.stringify(metrics), GLOBAL_METRICS_TTL_SECONDS);
+  return metrics;
+}
 
 export interface LeaderboardEntry {
   /** The Stellar address of the contributor. */

--- a/backend/test/stats.test.ts
+++ b/backend/test/stats.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BountyRecord } from "../src/services/bountyStore";
 import { CONTRIBUTOR, MAINTAINER } from "./fixtures";
 
+let tmpDir: string;
 let storeFile: string;
 
 const now = Math.floor(Date.now() / 1000);
@@ -32,7 +33,8 @@ function makeRecord(overrides: Partial<BountyRecord>): BountyRecord {
 }
 
 beforeEach(() => {
-  storeFile = path.join(os.tmpdir(), `bounty-stats-${randomUUID()}.json`);
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bounty-stats-"));
+  storeFile = path.join(tmpDir, "store.json");
   fs.writeFileSync(storeFile, "[]", "utf8");
   process.env.BOUNTY_STORE_PATH = storeFile;
   vi.resetModules();
@@ -40,8 +42,7 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.BOUNTY_STORE_PATH;
-  try { fs.unlinkSync(storeFile); } catch { /* best-effort */ }
-  try { fs.unlinkSync(storeFile.replace(/\.json$/i, ".audit.json")); } catch { /* best-effort */ }
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best-effort */ }
 });
 
 async function loadStore() {

--- a/backend/test/stats.test.ts
+++ b/backend/test/stats.test.ts
@@ -1,0 +1,149 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BountyRecord } from "../src/services/bountyStore";
+import { CONTRIBUTOR, MAINTAINER } from "./fixtures";
+
+let storeFile: string;
+
+const now = Math.floor(Date.now() / 1000);
+const deadline = now + 86400 * 30;
+
+function makeRecord(overrides: Partial<BountyRecord>): BountyRecord {
+  return {
+    id: `BNT-${randomUUID().slice(0, 4)}`,
+    repo: "owner/repo",
+    issueNumber: 1,
+    title: "Test bounty",
+    summary: "A test bounty for unit testing.",
+    maintainer: MAINTAINER,
+    tokenSymbol: "XLM",
+    amount: 100,
+    labels: [],
+    status: "open",
+    createdAt: now,
+    deadlineAt: deadline,
+    version: 1,
+    events: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  storeFile = path.join(os.tmpdir(), `bounty-stats-${randomUUID()}.json`);
+  fs.writeFileSync(storeFile, "[]", "utf8");
+  process.env.BOUNTY_STORE_PATH = storeFile;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete process.env.BOUNTY_STORE_PATH;
+  try { fs.unlinkSync(storeFile); } catch { /* best-effort */ }
+  try { fs.unlinkSync(storeFile.replace(/\.json$/i, ".audit.json")); } catch { /* best-effort */ }
+});
+
+async function loadStore() {
+  return import("../src/services/bountyStore");
+}
+
+describe("getGlobalMetrics / getGlobalMetricsCached", () => {
+  it("returns zeros for an empty store", async () => {
+    const { getGlobalMetrics, getGlobalMetricsCached } = await loadStore();
+
+    const sync = getGlobalMetrics();
+    const cached = await getGlobalMetricsCached();
+
+    const expected = {
+      totalBounties: 0,
+      openCount: 0,
+      reservedCount: 0,
+      submittedCount: 0,
+      releasedCount: 0,
+      refundedCount: 0,
+      expiredCount: 0,
+      totalFunded: 0,
+      totalReleased: 0,
+      uniqueMaintainers: 0,
+      uniqueContributors: 0,
+    };
+
+    expect(sync).toEqual(expected);
+    expect(cached).toEqual(expected);
+  });
+
+  it("computes correct values for seeded bounties", async () => {
+    const records: BountyRecord[] = [
+      makeRecord({ status: "open", amount: 50, maintainer: MAINTAINER }),
+      makeRecord({ status: "reserved", amount: 75, maintainer: MAINTAINER, contributor: CONTRIBUTOR }),
+      makeRecord({ status: "submitted", amount: 30, maintainer: MAINTAINER, contributor: CONTRIBUTOR }),
+      makeRecord({ status: "released", amount: 200, maintainer: MAINTAINER, contributor: CONTRIBUTOR }),
+      makeRecord({ status: "refunded", amount: 40, maintainer: MAINTAINER }),
+      makeRecord({ status: "expired", amount: 60, maintainer: MAINTAINER }),
+    ];
+    fs.writeFileSync(storeFile, JSON.stringify(records), "utf8");
+
+    const { getGlobalMetrics } = await loadStore();
+    const metrics = getGlobalMetrics();
+
+    expect(metrics.totalBounties).toBe(6);
+    expect(metrics.openCount).toBe(1);
+    expect(metrics.reservedCount).toBe(1);
+    expect(metrics.submittedCount).toBe(1);
+    expect(metrics.releasedCount).toBe(1);
+    expect(metrics.refundedCount).toBe(1);
+    expect(metrics.expiredCount).toBe(1);
+    expect(metrics.totalFunded).toBeCloseTo(50 + 75 + 30 + 200 + 40 + 60);
+    expect(metrics.totalReleased).toBeCloseTo(200);
+    expect(metrics.uniqueMaintainers).toBe(1);
+    expect(metrics.uniqueContributors).toBe(1);
+  });
+
+  it("counts multiple unique maintainers and contributors", async () => {
+    const OTHER_MAINTAINER = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZRCKA2LZZZM3G4EQN2M7";
+    const OTHER_CONTRIBUTOR = "GDQJUTQYK2MQX2JQMDT3JYBPITRZBXBFQ3ZBXJWNMZV5UHGCQ6XZUIP";
+    const records: BountyRecord[] = [
+      makeRecord({ maintainer: MAINTAINER, contributor: CONTRIBUTOR, status: "released" }),
+      makeRecord({ maintainer: OTHER_MAINTAINER, contributor: OTHER_CONTRIBUTOR, status: "released" }),
+      makeRecord({ maintainer: MAINTAINER, contributor: OTHER_CONTRIBUTOR, status: "released" }),
+    ];
+    fs.writeFileSync(storeFile, JSON.stringify(records), "utf8");
+
+    const { getGlobalMetrics } = await loadStore();
+    const metrics = getGlobalMetrics();
+
+    expect(metrics.uniqueMaintainers).toBe(2);
+    expect(metrics.uniqueContributors).toBe(2);
+  });
+
+  it("getGlobalMetricsCached returns same result as getGlobalMetrics", async () => {
+    const records: BountyRecord[] = [
+      makeRecord({ status: "open", amount: 42.5 }),
+      makeRecord({ status: "released", amount: 57.5, contributor: CONTRIBUTOR }),
+    ];
+    fs.writeFileSync(storeFile, JSON.stringify(records), "utf8");
+
+    const { getGlobalMetrics, getGlobalMetricsCached } = await loadStore();
+
+    const sync = getGlobalMetrics();
+    const cached = await getGlobalMetricsCached();
+
+    expect(cached).toEqual(sync);
+  });
+
+  it("getGlobalMetricsCached returns cached result on second call", async () => {
+    const { getGlobalMetricsCached } = await loadStore();
+    const { InMemoryCache } = await import("../src/services/cache");
+
+    const cache = new InMemoryCache();
+    const first = await getGlobalMetricsCached(cache);
+
+    // Modify the store file after caching — cache should still return original
+    const newRecords: BountyRecord[] = [makeRecord({ status: "open", amount: 999 })];
+    fs.writeFileSync(storeFile, JSON.stringify(newRecords), "utf8");
+
+    const second = await getGlobalMetricsCached(cache);
+    expect(second).toEqual(first);
+  });
+});

--- a/docs/openapi.generated.json
+++ b/docs/openapi.generated.json
@@ -57,21 +57,11 @@
             "items": {
               "type": "string"
             },
-            "example": [
-              "bug",
-              "help wanted"
-            ]
+            "example": ["bug", "help wanted"]
           },
           "status": {
             "type": "string",
-            "enum": [
-              "open",
-              "reserved",
-              "submitted",
-              "released",
-              "refunded",
-              "expired"
-            ],
+            "enum": ["open", "reserved", "submitted", "released", "refunded", "expired"],
             "example": "open"
           },
           "createdAt": {
@@ -141,37 +131,17 @@
           },
           "fromStatus": {
             "type": "string",
-            "enum": [
-              "open",
-              "reserved",
-              "submitted",
-              "released",
-              "refunded",
-              "expired"
-            ],
+            "enum": ["open", "reserved", "submitted", "released", "refunded", "expired"],
             "example": "open"
           },
           "toStatus": {
             "type": "string",
-            "enum": [
-              "open",
-              "reserved",
-              "submitted",
-              "released",
-              "refunded",
-              "expired"
-            ],
+            "enum": ["open", "reserved", "submitted", "released", "refunded", "expired"],
             "example": "reserved"
           },
           "transition": {
             "type": "string",
-            "enum": [
-              "reserve",
-              "submit",
-              "release",
-              "refund",
-              "expire"
-            ],
+            "enum": ["reserve", "submit", "release", "refund", "expire"],
             "example": "reserve"
           },
           "actor": {
@@ -211,15 +181,7 @@
             }
           }
         },
-        "required": [
-          "id",
-          "bountyId",
-          "fromStatus",
-          "toStatus",
-          "transition",
-          "actor",
-          "timestamp"
-        ]
+        "required": ["id", "bountyId", "fromStatus", "toStatus", "transition", "actor", "timestamp"]
       },
       "BountyAuditLogPagination": {
         "type": "object",
@@ -245,21 +207,12 @@
             "example": false
           },
           "nextOffset": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "minimum": 0,
             "example": null
           }
         },
-        "required": [
-          "limit",
-          "offset",
-          "total",
-          "hasMore",
-          "nextOffset"
-        ]
+        "required": ["limit", "offset", "total", "hasMore", "nextOffset"]
       },
       "BountyAuditLogListResponse": {
         "type": "object",
@@ -274,10 +227,7 @@
             "$ref": "#/components/schemas/BountyAuditLogPagination"
           }
         },
-        "required": [
-          "data",
-          "pagination"
-        ]
+        "required": ["data", "pagination"]
       },
       "CreateBountyRequest": {
         "type": "object",
@@ -310,8 +260,7 @@
           },
           "maintainer": {
             "type": "string",
-            "pattern": "^G[A-Z2-7]{55}$",
-            "description": "A valid Stellar public key (starts with G, 56 characters).",
+            "description": "A valid Stellar public key (starts with G, 56 characters, checksum verified).",
             "example": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
           },
           "tokenSymbol": {
@@ -322,10 +271,9 @@
           },
           "amount": {
             "type": "number",
-            "minimum": 1,
-            "maximum": 10000,
-            "description": "Bounty amount in XLM (1-10000, up to 7 decimal places).",
-            "example": 100
+            "exclusiveMinimum": 0,
+            "description": "Payout amount in the selected token.",
+            "example": 42.5
           },
           "deadlineDays": {
             "type": "integer",
@@ -344,10 +292,7 @@
             "maxItems": 6,
             "default": [],
             "description": "Up to 6 labels for categorisation.",
-            "example": [
-              "bug",
-              "help wanted"
-            ]
+            "example": ["bug", "help wanted"]
           },
           "reservationTimeoutSeconds": {
             "type": "integer",
@@ -372,7 +317,6 @@
         "properties": {
           "contributor": {
             "type": "string",
-            "pattern": "^G[A-Z2-7]{55}$",
             "description": "Stellar public key of the contributor reserving the bounty.",
             "example": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
           },
@@ -382,24 +326,15 @@
             "example": 1
           }
         },
-        "required": [
-          "contributor"
-        ]
+        "required": ["contributor"]
       },
       "SubmitBountyRequest": {
         "type": "object",
         "properties": {
           "contributor": {
             "type": "string",
-            "pattern": "^G[A-Z2-7]{55}$",
             "description": "Must match the contributor who reserved the bounty.",
             "example": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
-          },
-          "submissionUrl": {
-            "type": "string",
-            "pattern": "^https:\\/\\/github\\.com\\/[a-zA-Z0-9_.-]+\\/[a-zA-Z0-9_.-]+\\/pull\\/\\d+$",
-            "description": "Link to the GitHub pull request.",
-            "example": "https://github.com/owner/repo/pull/99"
           },
           "notes": {
             "type": "string",
@@ -408,17 +343,13 @@
             "example": "Fixed by updating the redirect handler."
           }
         },
-        "required": [
-          "contributor",
-          "submissionUrl"
-        ]
+        "required": ["contributor"]
       },
       "MaintainerActionRequest": {
         "type": "object",
         "properties": {
           "maintainer": {
             "type": "string",
-            "pattern": "^G[A-Z2-7]{55}$",
             "description": "Must match the maintainer address on the bounty.",
             "example": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
           },
@@ -429,9 +360,7 @@
             "example": "0000000000000000000000000000000000000000000000000000000000000000"
           }
         },
-        "required": [
-          "maintainer"
-        ]
+        "required": ["maintainer"]
       },
       "ErrorResponse": {
         "type": "object",
@@ -441,9 +370,7 @@
             "example": "Bounty not found."
           }
         },
-        "required": [
-          "error"
-        ]
+        "required": ["error"]
       },
       "OpenIssue": {
         "type": "object",
@@ -461,10 +388,7 @@
             "items": {
               "type": "string"
             },
-            "example": [
-              "enhancement",
-              "help wanted"
-            ]
+            "example": ["enhancement", "help wanted"]
           },
           "summary": {
             "type": "string",
@@ -472,43 +396,109 @@
           },
           "impact": {
             "type": "string",
-            "enum": [
-              "starter",
-              "core",
-              "advanced"
-            ],
+            "enum": ["starter", "core", "advanced"],
             "example": "core"
           }
         },
-        "required": [
-          "id",
-          "title",
-          "labels",
-          "summary",
-          "impact"
-        ]
+        "required": ["id", "title", "labels", "summary", "impact"]
       },
       "HealthResponse": {
         "type": "object",
+        "properties": {}
+      },
+      "GlobalMetrics": {
+        "type": "object",
         "properties": {
-          "service": {
-            "type": "string",
-            "example": "stellar-bounty-board-backend"
+          "totalBounties": {
+            "type": "integer",
+            "description": "Total number of bounties created.",
+            "example": 42
           },
-          "status": {
-            "type": "string",
-            "example": "ok"
+          "openCount": {
+            "type": "integer",
+            "description": "Number of bounties with status 'open'.",
+            "example": 10
           },
-          "timestamp": {
-            "type": "string",
-            "example": "2026-03-24T19:00:00.000Z"
+          "reservedCount": {
+            "type": "integer",
+            "description": "Number of bounties with status 'reserved'.",
+            "example": 5
+          },
+          "submittedCount": {
+            "type": "integer",
+            "description": "Number of bounties with status 'submitted'.",
+            "example": 3
+          },
+          "releasedCount": {
+            "type": "integer",
+            "description": "Number of bounties with status 'released'.",
+            "example": 20
+          },
+          "refundedCount": {
+            "type": "integer",
+            "description": "Number of bounties with status 'refunded'.",
+            "example": 2
+          },
+          "expiredCount": {
+            "type": "integer",
+            "description": "Number of bounties with status 'expired'.",
+            "example": 2
+          },
+          "totalFunded": {
+            "type": "number",
+            "description": "Sum of all bounty amounts in XLM.",
+            "example": 1250.5
+          },
+          "totalReleased": {
+            "type": "number",
+            "description": "Sum of released bounty amounts in XLM.",
+            "example": 850
+          },
+          "uniqueMaintainers": {
+            "type": "integer",
+            "description": "Count of unique maintainer addresses.",
+            "example": 8
+          },
+          "uniqueContributors": {
+            "type": "integer",
+            "description": "Count of unique contributor addresses.",
+            "example": 15
           }
         },
         "required": [
-          "service",
-          "status",
-          "timestamp"
+          "totalBounties",
+          "openCount",
+          "reservedCount",
+          "submittedCount",
+          "releasedCount",
+          "refundedCount",
+          "expiredCount",
+          "totalFunded",
+          "totalReleased",
+          "uniqueMaintainers",
+          "uniqueContributors"
         ]
+      },
+      "LeaderboardEntry": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "Contributor Stellar address.",
+            "example": "GBBB...BBB"
+          },
+          "totalXlm": {
+            "type": "number",
+            "description": "Total XLM received from released bounties.",
+            "example": 350.5
+          },
+          "bountiesCompleted": {
+            "type": "integer",
+            "description": "Number of released bounties completed.",
+            "example": 3
+          }
+        },
+        "required": ["address", "totalXlm", "bountiesCompleted"]
       }
     },
     "parameters": {}
@@ -516,9 +506,7 @@
   "paths": {
     "/api/health": {
       "get": {
-        "tags": [
-          "System"
-        ],
+        "tags": ["System"],
         "summary": "Health check",
         "description": "Returns the service name and current server timestamp. Use this to verify the API is reachable.",
         "responses": {
@@ -533,9 +521,7 @@
                       "$ref": "#/components/schemas/HealthResponse"
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -545,9 +531,7 @@
     },
     "/api/bounties": {
       "get": {
-        "tags": [
-          "Bounties"
-        ],
+        "tags": ["Bounties"],
         "summary": "List all bounties",
         "description": "Returns every bounty record sorted by creation date (newest first). Bounties whose deadline has passed are automatically transitioned to `expired` before the list is returned.",
         "responses": {
@@ -565,9 +549,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -575,9 +557,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Bounties"
-        ],
+        "tags": ["Bounties"],
         "summary": "Create a bounty",
         "description": "Creates a new open bounty and persists it. Rate-limited to **5 requests per IP per minute**. The `deadlineAt` timestamp is computed as `now + deadlineDays * 86400`.",
         "requestBody": {
@@ -602,9 +582,7 @@
                       "$ref": "#/components/schemas/BountyRecord"
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -624,9 +602,7 @@
     },
     "/api/bounties/{id}/audit-logs": {
       "get": {
-        "tags": [
-          "Bounties"
-        ],
+        "tags": ["Bounties"],
         "summary": "List audit logs for one bounty",
         "description": "Returns ordered status transition history for a bounty. Use `limit` (1-100, default 20) and `offset` (default 0) for pagination.",
         "parameters": [
@@ -689,9 +665,7 @@
     },
     "/api/bounties/{id}/reserve": {
       "post": {
-        "tags": [
-          "Bounties"
-        ],
+        "tags": ["Bounties"],
         "summary": "Reserve a bounty",
         "description": "Assigns a contributor to an `open` bounty, transitioning its status to `reserved`. Only one contributor can hold a reservation at a time. Rate-limited to **5 requests per IP per minute**.",
         "parameters": [
@@ -727,9 +701,7 @@
                       "$ref": "#/components/schemas/BountyRecord"
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -749,9 +721,7 @@
     },
     "/api/bounties/{id}/submit": {
       "post": {
-        "tags": [
-          "Bounties"
-        ],
+        "tags": ["Bounties"],
         "summary": "Submit work for a bounty",
         "description": "Transitions a `reserved` bounty to `submitted` by attaching a submission URL. The `contributor` field must exactly match the address that reserved the bounty. Rate-limited to **5 requests per IP per minute**.",
         "parameters": [
@@ -787,9 +757,7 @@
                       "$ref": "#/components/schemas/BountyRecord"
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -809,9 +777,7 @@
     },
     "/api/bounties/{id}/release": {
       "post": {
-        "tags": [
-          "Bounties"
-        ],
+        "tags": ["Bounties"],
         "summary": "Release payment for a bounty",
         "description": "Transitions a `submitted` bounty to `released`, indicating payment has been sent. Only the maintainer address recorded on the bounty may call this endpoint. Rate-limited to **5 requests per IP per minute**.",
         "parameters": [
@@ -847,9 +813,7 @@
                       "$ref": "#/components/schemas/BountyRecord"
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -869,9 +833,7 @@
     },
     "/api/bounties/{id}/refund": {
       "post": {
-        "tags": [
-          "Bounties"
-        ],
+        "tags": ["Bounties"],
         "summary": "Refund a bounty",
         "description": "Transitions an `open` or `reserved` bounty to `refunded`. Cannot be called on `submitted`, `released`, or already `refunded` bounties. Only the maintainer address recorded on the bounty may call this endpoint. Rate-limited to **5 requests per IP per minute**.",
         "parameters": [
@@ -907,9 +869,7 @@
                       "$ref": "#/components/schemas/BountyRecord"
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -929,9 +889,7 @@
     },
     "/api/open-issues": {
       "get": {
-        "tags": [
-          "Open Issues"
-        ],
+        "tags": ["Open Issues"],
         "summary": "List open feature requests",
         "description": "Returns a curated static list of open feature requests and contribution opportunities for the Stellar Bounty Board project itself.",
         "responses": {
@@ -949,9 +907,70 @@
                       }
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/stats": {
+      "get": {
+        "tags": ["Stats"],
+        "summary": "Global platform metrics",
+        "description": "Returns aggregate statistics for the entire platform including bounty status counts, total funded and released amounts, and unique participant counts. Response is cached with a **30-second TTL** to reduce computation overhead.",
+        "responses": {
+          "200": {
+            "description": "Global platform metrics.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/GlobalMetrics"
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to compute global stats.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/leaderboard": {
+      "get": {
+        "tags": ["Leaderboard"],
+        "summary": "Contributor leaderboard",
+        "description": "Returns the top 10 contributors ranked by total XLM received from released bounties. Ties are broken by the number of bounties completed. Returns an empty array when no bounties have been released yet.",
+        "responses": {
+          "200": {
+            "description": "Top 10 contributors by XLM earned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/LeaderboardEntry"
+                      }
+                    }
+                  },
+                  "required": ["data"]
                 }
               }
             }

--- a/docs/openapi.generated.json
+++ b/docs/openapi.generated.json
@@ -57,11 +57,21 @@
             "items": {
               "type": "string"
             },
-            "example": ["bug", "help wanted"]
+            "example": [
+              "bug",
+              "help wanted"
+            ]
           },
           "status": {
             "type": "string",
-            "enum": ["open", "reserved", "submitted", "released", "refunded", "expired"],
+            "enum": [
+              "open",
+              "reserved",
+              "submitted",
+              "released",
+              "refunded",
+              "expired"
+            ],
             "example": "open"
           },
           "createdAt": {
@@ -131,17 +141,37 @@
           },
           "fromStatus": {
             "type": "string",
-            "enum": ["open", "reserved", "submitted", "released", "refunded", "expired"],
+            "enum": [
+              "open",
+              "reserved",
+              "submitted",
+              "released",
+              "refunded",
+              "expired"
+            ],
             "example": "open"
           },
           "toStatus": {
             "type": "string",
-            "enum": ["open", "reserved", "submitted", "released", "refunded", "expired"],
+            "enum": [
+              "open",
+              "reserved",
+              "submitted",
+              "released",
+              "refunded",
+              "expired"
+            ],
             "example": "reserved"
           },
           "transition": {
             "type": "string",
-            "enum": ["reserve", "submit", "release", "refund", "expire"],
+            "enum": [
+              "reserve",
+              "submit",
+              "release",
+              "refund",
+              "expire"
+            ],
             "example": "reserve"
           },
           "actor": {
@@ -181,7 +211,15 @@
             }
           }
         },
-        "required": ["id", "bountyId", "fromStatus", "toStatus", "transition", "actor", "timestamp"]
+        "required": [
+          "id",
+          "bountyId",
+          "fromStatus",
+          "toStatus",
+          "transition",
+          "actor",
+          "timestamp"
+        ]
       },
       "BountyAuditLogPagination": {
         "type": "object",
@@ -207,12 +245,21 @@
             "example": false
           },
           "nextOffset": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "minimum": 0,
             "example": null
           }
         },
-        "required": ["limit", "offset", "total", "hasMore", "nextOffset"]
+        "required": [
+          "limit",
+          "offset",
+          "total",
+          "hasMore",
+          "nextOffset"
+        ]
       },
       "BountyAuditLogListResponse": {
         "type": "object",
@@ -227,7 +274,10 @@
             "$ref": "#/components/schemas/BountyAuditLogPagination"
           }
         },
-        "required": ["data", "pagination"]
+        "required": [
+          "data",
+          "pagination"
+        ]
       },
       "CreateBountyRequest": {
         "type": "object",
@@ -292,7 +342,10 @@
             "maxItems": 6,
             "default": [],
             "description": "Up to 6 labels for categorisation.",
-            "example": ["bug", "help wanted"]
+            "example": [
+              "bug",
+              "help wanted"
+            ]
           },
           "reservationTimeoutSeconds": {
             "type": "integer",
@@ -326,7 +379,9 @@
             "example": 1
           }
         },
-        "required": ["contributor"]
+        "required": [
+          "contributor"
+        ]
       },
       "SubmitBountyRequest": {
         "type": "object",
@@ -343,7 +398,9 @@
             "example": "Fixed by updating the redirect handler."
           }
         },
-        "required": ["contributor"]
+        "required": [
+          "contributor"
+        ]
       },
       "MaintainerActionRequest": {
         "type": "object",
@@ -360,7 +417,9 @@
             "example": "0000000000000000000000000000000000000000000000000000000000000000"
           }
         },
-        "required": ["maintainer"]
+        "required": [
+          "maintainer"
+        ]
       },
       "ErrorResponse": {
         "type": "object",
@@ -370,7 +429,9 @@
             "example": "Bounty not found."
           }
         },
-        "required": ["error"]
+        "required": [
+          "error"
+        ]
       },
       "OpenIssue": {
         "type": "object",
@@ -388,7 +449,10 @@
             "items": {
               "type": "string"
             },
-            "example": ["enhancement", "help wanted"]
+            "example": [
+              "enhancement",
+              "help wanted"
+            ]
           },
           "summary": {
             "type": "string",
@@ -396,11 +460,21 @@
           },
           "impact": {
             "type": "string",
-            "enum": ["starter", "core", "advanced"],
+            "enum": [
+              "starter",
+              "core",
+              "advanced"
+            ],
             "example": "core"
           }
         },
-        "required": ["id", "title", "labels", "summary", "impact"]
+        "required": [
+          "id",
+          "title",
+          "labels",
+          "summary",
+          "impact"
+        ]
       },
       "HealthResponse": {
         "type": "object",
@@ -498,7 +572,11 @@
             "example": 3
           }
         },
-        "required": ["address", "totalXlm", "bountiesCompleted"]
+        "required": [
+          "address",
+          "totalXlm",
+          "bountiesCompleted"
+        ]
       }
     },
     "parameters": {}
@@ -506,7 +584,9 @@
   "paths": {
     "/api/health": {
       "get": {
-        "tags": ["System"],
+        "tags": [
+          "System"
+        ],
         "summary": "Health check",
         "description": "Returns the service name and current server timestamp. Use this to verify the API is reachable.",
         "responses": {
@@ -521,7 +601,9 @@
                       "$ref": "#/components/schemas/HealthResponse"
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -531,7 +613,9 @@
     },
     "/api/bounties": {
       "get": {
-        "tags": ["Bounties"],
+        "tags": [
+          "Bounties"
+        ],
         "summary": "List all bounties",
         "description": "Returns every bounty record sorted by creation date (newest first). Bounties whose deadline has passed are automatically transitioned to `expired` before the list is returned.",
         "responses": {
@@ -549,7 +633,9 @@
                       }
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -557,7 +643,9 @@
         }
       },
       "post": {
-        "tags": ["Bounties"],
+        "tags": [
+          "Bounties"
+        ],
         "summary": "Create a bounty",
         "description": "Creates a new open bounty and persists it. Rate-limited to **5 requests per IP per minute**. The `deadlineAt` timestamp is computed as `now + deadlineDays * 86400`.",
         "requestBody": {
@@ -582,7 +670,9 @@
                       "$ref": "#/components/schemas/BountyRecord"
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -602,7 +692,9 @@
     },
     "/api/bounties/{id}/audit-logs": {
       "get": {
-        "tags": ["Bounties"],
+        "tags": [
+          "Bounties"
+        ],
         "summary": "List audit logs for one bounty",
         "description": "Returns ordered status transition history for a bounty. Use `limit` (1-100, default 20) and `offset` (default 0) for pagination.",
         "parameters": [
@@ -665,7 +757,9 @@
     },
     "/api/bounties/{id}/reserve": {
       "post": {
-        "tags": ["Bounties"],
+        "tags": [
+          "Bounties"
+        ],
         "summary": "Reserve a bounty",
         "description": "Assigns a contributor to an `open` bounty, transitioning its status to `reserved`. Only one contributor can hold a reservation at a time. Rate-limited to **5 requests per IP per minute**.",
         "parameters": [
@@ -701,7 +795,9 @@
                       "$ref": "#/components/schemas/BountyRecord"
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -721,7 +817,9 @@
     },
     "/api/bounties/{id}/submit": {
       "post": {
-        "tags": ["Bounties"],
+        "tags": [
+          "Bounties"
+        ],
         "summary": "Submit work for a bounty",
         "description": "Transitions a `reserved` bounty to `submitted` by attaching a submission URL. The `contributor` field must exactly match the address that reserved the bounty. Rate-limited to **5 requests per IP per minute**.",
         "parameters": [
@@ -757,7 +855,9 @@
                       "$ref": "#/components/schemas/BountyRecord"
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -777,7 +877,9 @@
     },
     "/api/bounties/{id}/release": {
       "post": {
-        "tags": ["Bounties"],
+        "tags": [
+          "Bounties"
+        ],
         "summary": "Release payment for a bounty",
         "description": "Transitions a `submitted` bounty to `released`, indicating payment has been sent. Only the maintainer address recorded on the bounty may call this endpoint. Rate-limited to **5 requests per IP per minute**.",
         "parameters": [
@@ -813,7 +915,9 @@
                       "$ref": "#/components/schemas/BountyRecord"
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -833,7 +937,9 @@
     },
     "/api/bounties/{id}/refund": {
       "post": {
-        "tags": ["Bounties"],
+        "tags": [
+          "Bounties"
+        ],
         "summary": "Refund a bounty",
         "description": "Transitions an `open` or `reserved` bounty to `refunded`. Cannot be called on `submitted`, `released`, or already `refunded` bounties. Only the maintainer address recorded on the bounty may call this endpoint. Rate-limited to **5 requests per IP per minute**.",
         "parameters": [
@@ -869,7 +975,9 @@
                       "$ref": "#/components/schemas/BountyRecord"
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -889,7 +997,9 @@
     },
     "/api/open-issues": {
       "get": {
-        "tags": ["Open Issues"],
+        "tags": [
+          "Open Issues"
+        ],
         "summary": "List open feature requests",
         "description": "Returns a curated static list of open feature requests and contribution opportunities for the Stellar Bounty Board project itself.",
         "responses": {
@@ -907,7 +1017,9 @@
                       }
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -917,7 +1029,9 @@
     },
     "/api/stats": {
       "get": {
-        "tags": ["Stats"],
+        "tags": [
+          "Stats"
+        ],
         "summary": "Global platform metrics",
         "description": "Returns aggregate statistics for the entire platform including bounty status counts, total funded and released amounts, and unique participant counts. Response is cached with a **30-second TTL** to reduce computation overhead.",
         "responses": {
@@ -932,7 +1046,9 @@
                       "$ref": "#/components/schemas/GlobalMetrics"
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }
@@ -952,7 +1068,9 @@
     },
     "/api/leaderboard": {
       "get": {
-        "tags": ["Leaderboard"],
+        "tags": [
+          "Leaderboard"
+        ],
         "summary": "Contributor leaderboard",
         "description": "Returns the top 10 contributors ranked by total XLM received from released bounties. Ties are broken by the number of bounties completed. Returns an empty array when no bounties have been released yet.",
         "responses": {
@@ -970,7 +1088,9 @@
                       }
                     }
                   },
-                  "required": ["data"]
+                  "required": [
+                    "data"
+                  ]
                 }
               }
             }


### PR DESCRIPTION
Closes #239

## Summary

- Adds `GET /api/stats` endpoint returning the full `GlobalMetrics` shape
- Caches computed metrics with a **30-second TTL** using the existing pluggable cache (in-memory or Redis)
- Documents the endpoint in the OpenAPI spec
- Adds 5 unit tests covering all fields, caching, and edge cases

## API Response Example

```json
{
  "data": {
    "totalBounties": 42,
    "openCount": 10,
    "reservedCount": 5,
    "submittedCount": 3,
    "releasedCount": 20,
    "refundedCount": 2,
    "expiredCount": 2,
    "totalFunded": 1250.5,
    "totalReleased": 850.0,
    "uniqueMaintainers": 8,
    "uniqueContributors": 15
  }
}
```

## Caching Implementation

Added `getGlobalMetricsCached()` in `bountyStore.ts` following the same pattern as `listBountiesCached`. Uses the singleton `CacheAdapter` (in-memory or Redis depending on env) with a 30-second TTL. Cache key: `stats:global`.

## OpenAPI Spec Updates

Added `GlobalMetrics` schema component and registered `GET /api/stats` path under a new `Stats` tag in `backend/src/docs/openapi.ts`.

## Unit Tests (`backend/test/stats.test.ts`)

All 5 tests pass:
- Returns zeros for empty store
- Computes correct counts for seeded bounties across all statuses
- Counts multiple unique maintainers and contributors correctly
- `getGlobalMetricsCached` returns same result as `getGlobalMetrics`
- `getGlobalMetricsCached` returns cached result on second call (TTL behaviour)

## Build & Lint

TypeScript type-check passes (`tsc --noEmit --skipLibCheck`) on all modified files. Lint and build failures are pre-existing in the repository and not introduced by this PR.