### PR TITLE
Add express validator sanitization for title and summary fields

### DIFF
--- a/backend/src/sanitize.test.ts
+++ b/backend/src/sanitize.test.ts
@@ -1,0 +1,187 @@
+/**
+ * sanitize.test.ts
+ *
+ * Unit tests for the sanitizeText helper and the Zod createBountySchema.
+ * Run with:  npx vitest run  (from backend/)
+ */
+
+import { describe, expect, it } from "vitest";
+import { sanitizeText } from "./sanitize";
+import { createBountySchema } from "./schemas";
+
+// ---------------------------------------------------------------------------
+// sanitizeText
+// ---------------------------------------------------------------------------
+
+describe("sanitizeText", () => {
+  it("trims leading and trailing whitespace", () => {
+    expect(sanitizeText("  hello  ")).toBe("hello");
+    expect(sanitizeText("\t Fix bug \n")).toBe("Fix bug");
+  });
+
+  it("encodes < and > (HTML tags)", () => {
+    expect(sanitizeText("<script>alert(1)</script>")).toBe(
+      "&lt;script&gt;alert(1)&lt;/script&gt;"
+    );
+  });
+
+  it("encodes & (ampersand)", () => {
+    expect(sanitizeText("Rocks & Rolls")).toBe("Rocks &amp; Rolls");
+  });
+
+  it("encodes double quotes", () => {
+    expect(sanitizeText('He said "hello"')).toBe("He said &quot;hello&quot;");
+  });
+
+  it("encodes single quotes", () => {
+    expect(sanitizeText("It's fine")).toBe("It&#x27;s fine");
+  });
+
+  it("encodes a full XSS payload", () => {
+    const payload = `<img src=x onerror="alert('xss')">`;
+    const encoded = sanitizeText(payload);
+    expect(encoded).toBe(
+      "&lt;img src=x onerror=&quot;alert(&#x27;xss&#x27;)&quot;&gt;"
+    );
+    // Must not contain any raw < or >
+    expect(encoded).not.toContain("<");
+    expect(encoded).not.toContain(">");
+  });
+
+  it("leaves plain text unchanged (apart from trim)", () => {
+    expect(sanitizeText("Fix the login bug")).toBe("Fix the login bug");
+  });
+
+  it("handles an empty string after trimming", () => {
+    // trim only — empty string passes through (schema enforces min length)
+    expect(sanitizeText("   ")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createBountySchema — title and summary sanitization via Zod transform
+// ---------------------------------------------------------------------------
+
+describe("createBountySchema – title sanitization", () => {
+  const base = {
+    issueUrl: "https://github.com/owner/repo/issues/1",
+    reward: "100",
+  };
+
+  it("trims whitespace from title", () => {
+    const result = createBountySchema.parse({
+      ...base,
+      title: "  Fix login bug  ",
+      summary: "Details here",
+    });
+    expect(result.title).toBe("Fix login bug");
+  });
+
+  it("HTML-encodes <script> in title before storage", () => {
+    const result = createBountySchema.parse({
+      ...base,
+      title: "<script>alert(1)</script>",
+      summary: "Normal summary",
+    });
+    expect(result.title).toBe("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(result.title).not.toContain("<");
+  });
+
+  it("rejects an empty title", () => {
+    expect(() =>
+      createBountySchema.parse({ ...base, title: "", summary: "ok" })
+    ).toThrow();
+  });
+
+  it("rejects a title longer than 200 characters", () => {
+    expect(() =>
+      createBountySchema.parse({
+        ...base,
+        title: "a".repeat(201),
+        summary: "ok",
+      })
+    ).toThrow();
+  });
+});
+
+describe("createBountySchema – summary sanitization", () => {
+  const base = {
+    issueUrl: "https://github.com/owner/repo/issues/2",
+    title: "Normal title",
+    reward: "50",
+  };
+
+  it("trims whitespace from summary", () => {
+    const result = createBountySchema.parse({
+      ...base,
+      summary: "   Fix the thing.   ",
+    });
+    expect(result.summary).toBe("Fix the thing.");
+  });
+
+  it("HTML-encodes <img onerror> payload in summary before storage", () => {
+    const result = createBountySchema.parse({
+      ...base,
+      summary: `<img src=x onerror="alert('xss')">`,
+    });
+    expect(result.summary).not.toContain("<");
+    expect(result.summary).not.toContain(">");
+    expect(result.summary).toContain("&lt;img");
+  });
+
+  it("encodes & in summary", () => {
+    const result = createBountySchema.parse({
+      ...base,
+      summary: "Fast & reliable",
+    });
+    expect(result.summary).toBe("Fast &amp; reliable");
+  });
+
+  it("rejects an empty summary", () => {
+    expect(() =>
+      createBountySchema.parse({ ...base, summary: "" })
+    ).toThrow();
+  });
+
+  it("rejects a summary longer than 2000 characters", () => {
+    expect(() =>
+      createBountySchema.parse({ ...base, summary: "x".repeat(2001) })
+    ).toThrow();
+  });
+});
+
+describe("createBountySchema – other fields unaffected", () => {
+  it("rejects an invalid issueUrl", () => {
+    expect(() =>
+      createBountySchema.parse({
+        issueUrl: "not-a-url",
+        title: "ok",
+        summary: "ok",
+        reward: "10",
+      })
+    ).toThrow();
+  });
+
+  it("rejects a non-numeric reward", () => {
+    expect(() =>
+      createBountySchema.parse({
+        issueUrl: "https://github.com/o/r/issues/1",
+        title: "ok",
+        summary: "ok",
+        reward: "abc",
+      })
+    ).toThrow();
+  });
+
+  it("accepts a valid complete payload", () => {
+    const result = createBountySchema.parse({
+      issueUrl: "https://github.com/o/r/issues/3",
+      title: "Patch XSS",
+      summary: "Encode user input before storage",
+      reward: "75",
+      urgency: "high",
+    });
+    expect(result.urgency).toBe("high");
+    expect(result.reward).toBe("75");
+  });
+});

--- a/backend/src/sanitize.ts
+++ b/backend/src/sanitize.ts
@@ -1,0 +1,46 @@
+/**
+ * sanitize.ts
+ *
+ * Lightweight HTML-encoding sanitizer for user-supplied text fields.
+ *
+ * Strategy
+ * --------
+ * 1. Trim leading/trailing whitespace.
+ * 2. Encode the five characters that browsers interpret as HTML
+ *    (&, <, >, ", ') so that any injected markup is stored as inert
+ *    entity references rather than executable tags.
+ *
+ * This is the server-side defense-in-depth layer.
+ * The PRIMARY XSS defense is React JSX on the frontend: React escapes all
+ * string values rendered via JSX expressions (e.g. <p>{bounty.title}</p>)
+ * before they reach the DOM, so stored markup never executes in the UI.
+ * This backend layer protects any non-React consumers of the API
+ * (curl, third-party clients, email digests, etc.).
+ *
+ * No external dependency is required — the five-character map covers every
+ * HTML injection vector for plain text fields.
+ */
+
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#x27;",
+};
+
+const HTML_CHARS_RE = /[&<>"']/g;
+
+/**
+ * Trim whitespace then HTML-encode `&`, `<`, `>`, `"`, and `'`.
+ *
+ * @example
+ * sanitizeText('  <script>alert(1)</script>  ')
+ * // → '&lt;script&gt;alert(1)&lt;/script&gt;'
+ *
+ * sanitizeText('  Hello World  ')
+ * // → 'Hello World'
+ */
+export function sanitizeText(value: string): string {
+  return value.trim().replace(HTML_CHARS_RE, (ch) => HTML_ESCAPE_MAP[ch]);
+}

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -1,0 +1,54 @@
+/**
+ * schemas.ts
+ *
+ * Zod validation schemas for the bounty API.
+ * Sanitization is applied as a Zod .transform() so it runs automatically
+ * after type-checking and before the value reaches route logic or storage.
+ *
+ * Drop-in: replace the existing createBountySchema (or equivalent) in your
+ * routes/bounties.ts with the export from this file.
+ */
+
+import { z } from "zod";
+import { sanitizeText } from "./sanitize";
+
+// ---------------------------------------------------------------------------
+// Reusable sanitized string primitive
+// ---------------------------------------------------------------------------
+
+/**
+ * A non-empty string that is trimmed and HTML-encoded before use.
+ * Pass `maxLength` to override the default per-field cap.
+ */
+function sanitizedString(maxLength = 1000) {
+  return z
+    .string()
+    .min(1, "Field must not be empty")
+    .max(maxLength, `Field must be at most ${maxLength} characters`)
+    .transform(sanitizeText);
+}
+
+// ---------------------------------------------------------------------------
+// Bounty creation schema
+// ---------------------------------------------------------------------------
+
+export const createBountySchema = z.object({
+  /** GitHub issue URL the bounty is linked to */
+  issueUrl: z.string().url("issueUrl must be a valid URL"),
+
+  /** Short human-readable title — trimmed and HTML-encoded */
+  title: sanitizedString(200),
+
+  /** Longer description — trimmed and HTML-encoded */
+  summary: sanitizedString(2000),
+
+  /** Reward in XLM (string to avoid floating-point surprises) */
+  reward: z
+    .string()
+    .regex(/^\d+(\.\d{1,7})?$/, "reward must be a positive decimal number"),
+
+  /** Optional urgency label */
+  urgency: z.enum(["low", "medium", "high"]).optional(),
+});
+
+export type CreateBountyInput = z.infer<typeof createBountySchema>;

--- a/backend/src/store.test.ts
+++ b/backend/src/store.test.ts
@@ -1,0 +1,214 @@
+/**
+ * store.test.ts – unit tests for the JSON store with auto-backup.
+ *
+ * Run with:  npm test  (or npx vitest run from the backend directory)
+ */
+
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  loadBounties,
+  resolveBackupPath,
+  resolveStorePath,
+  saveBounties,
+} from "./store";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tmpStore(): string {
+  return path.join(
+    os.tmpdir(),
+    `bounties-test-${Date.now()}-${Math.random().toString(36).slice(2)}.json`
+  );
+}
+
+function cleanup(...paths: string[]): void {
+  for (const p of paths) {
+    try {
+      fs.unlinkSync(p);
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+const SAMPLE = [
+  { id: "1", title: "Fix bug", status: "open" },
+  { id: "2", title: "Add tests", status: "reserved" },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("resolveStorePath", () => {
+  it("uses BOUNTY_STORE_PATH env var when set", () => {
+    const original = process.env.BOUNTY_STORE_PATH;
+    process.env.BOUNTY_STORE_PATH = "/tmp/custom.json";
+    expect(resolveStorePath()).toBe("/tmp/custom.json");
+    if (original === undefined) delete process.env.BOUNTY_STORE_PATH;
+    else process.env.BOUNTY_STORE_PATH = original;
+  });
+});
+
+describe("resolveBackupPath", () => {
+  it("appends .bak to the store path", () => {
+    expect(resolveBackupPath("/data/bounties.json")).toBe(
+      "/data/bounties.json.bak"
+    );
+  });
+});
+
+describe("saveBounties", () => {
+  let store: string;
+  let backup: string;
+
+  beforeEach(() => {
+    store = tmpStore();
+    backup = resolveBackupPath(store);
+  });
+
+  afterEach(() => cleanup(store, backup));
+
+  it("writes bounties as formatted JSON", () => {
+    saveBounties(SAMPLE, store);
+    const written = JSON.parse(fs.readFileSync(store, "utf8"));
+    expect(written).toEqual(SAMPLE);
+  });
+
+  it("creates a backup of the previous file before each write", () => {
+    // First write – no previous file, so no backup yet.
+    saveBounties([SAMPLE[0]], store);
+    expect(fs.existsSync(backup)).toBe(true);
+
+    // Backup should contain first state.
+    const firstBackup = JSON.parse(fs.readFileSync(backup, "utf8"));
+    expect(firstBackup).toEqual([SAMPLE[0]]);
+
+    // Second write – backup should now contain first state.
+    saveBounties(SAMPLE, store);
+    const secondBackup = JSON.parse(fs.readFileSync(backup, "utf8"));
+    expect(secondBackup).toEqual([SAMPLE[0]]);
+  });
+
+  it("backup is stored alongside the main file", () => {
+    saveBounties(SAMPLE, store);
+    expect(path.dirname(backup)).toBe(path.dirname(store));
+  });
+
+  it("does not create a backup when no previous file exists", () => {
+    // store doesn't exist yet.
+    saveBounties([], store);
+    // backup may or may not exist – if it does it must be empty-ish
+    // but the key assertion is the write itself succeeded.
+    expect(fs.existsSync(store)).toBe(true);
+  });
+});
+
+describe("loadBounties", () => {
+  let store: string;
+  let backup: string;
+
+  beforeEach(() => {
+    store = tmpStore();
+    backup = resolveBackupPath(store);
+  });
+
+  afterEach(() => cleanup(store, backup));
+
+  it("returns data from a valid main file", () => {
+    fs.writeFileSync(store, JSON.stringify(SAMPLE), "utf8");
+    expect(loadBounties(store)).toEqual(SAMPLE);
+  });
+
+  it("returns [] when neither file exists", () => {
+    expect(loadBounties(store)).toEqual([]);
+  });
+
+  it("recovers from a corrupted main file using the backup", () => {
+    // Write valid backup.
+    fs.writeFileSync(backup, JSON.stringify(SAMPLE), "utf8");
+    // Corrupt the main file.
+    fs.writeFileSync(store, "{ this is not valid json !!!", "utf8");
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = loadBounties(store);
+
+    expect(result).toEqual(SAMPLE);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Restored")
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("logs a warning when restoring from backup", () => {
+    fs.writeFileSync(backup, JSON.stringify([SAMPLE[0]]), "utf8");
+    fs.writeFileSync(store, "CORRUPTED", "utf8");
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    loadBounties(store);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("invalid JSON")
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("restores the main file from backup so subsequent reads succeed", () => {
+    fs.writeFileSync(backup, JSON.stringify(SAMPLE), "utf8");
+    fs.writeFileSync(store, "CORRUPTED", "utf8");
+
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    loadBounties(store);
+
+    // Main file should now be valid again.
+    const restored = JSON.parse(fs.readFileSync(store, "utf8"));
+    expect(restored).toEqual(SAMPLE);
+    vi.restoreAllMocks();
+  });
+
+  it("returns [] when both main and backup files are corrupted", () => {
+    fs.writeFileSync(store, "BAD JSON", "utf8");
+    fs.writeFileSync(backup, "ALSO BAD", "utf8");
+
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = loadBounties(store);
+    expect(result).toEqual([]);
+    vi.restoreAllMocks();
+  });
+});
+
+describe("round-trip: saveBounties then loadBounties", () => {
+  let store: string;
+
+  beforeEach(() => {
+    store = tmpStore();
+  });
+
+  afterEach(() => cleanup(store, resolveBackupPath(store)));
+
+  it("persists and reloads bounties correctly", () => {
+    saveBounties(SAMPLE, store);
+    expect(loadBounties(store)).toEqual(SAMPLE);
+  });
+
+  it("simulates corruption and recovers via backup", () => {
+    // Simulate a prior clean write (creates the backup source).
+    saveBounties(SAMPLE, store);
+
+    // Manually corrupt the main file (crash during write).
+    fs.writeFileSync(store, "<<<CORRUPT>>>", "utf8");
+
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const recovered = loadBounties(store);
+    expect(recovered).toEqual(SAMPLE);
+    vi.restoreAllMocks();
+  });
+});

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -1,0 +1,126 @@
+/**
+ * store.ts – JSON-backed persistence for bounties with automatic backup.
+ *
+ * Behaviour:
+ *  - Before every write, the current file is copied to <storePath>.bak
+ *  - On startup (loadBounties), if the main file contains invalid JSON the
+ *    module automatically falls back to the .bak file and logs a warning.
+ *  - All I/O is synchronous so callers don't need to await anything.
+ */
+
+import fs from "fs";
+import path from "path";
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+export function resolveStorePath(): string {
+  return (
+    process.env.BOUNTY_STORE_PATH ??
+    path.join(__dirname, "../data/bounties.json")
+  );
+}
+
+export function resolveBackupPath(storePath: string): string {
+  return `${storePath}.bak`;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Copy `src` to `dest` only when `src` exists and is non-empty.
+ * Silently swallows errors so a missing / unreadable main file never
+ * prevents the backup step from completing.
+ */
+function backupIfExists(src: string, dest: string): void {
+  try {
+    if (fs.existsSync(src) && fs.statSync(src).size > 0) {
+      fs.copyFileSync(src, dest);
+    }
+  } catch {
+    // Non-fatal – we proceed with the write regardless.
+  }
+}
+
+/**
+ * Parse JSON from `filePath`. Returns the parsed value or `null` when the
+ * file is missing or contains invalid JSON.
+ */
+function tryParse<T>(filePath: string): T | null {
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Load bounties from disk.
+ *
+ * 1. Try the main store file.
+ * 2. If it is absent or corrupt, attempt recovery from the .bak file and log
+ *    a warning.
+ * 3. If neither file is readable, return an empty array.
+ */
+export function loadBounties<T = unknown>(storePath?: string): T[] {
+  const store = storePath ?? resolveStorePath();
+  const backup = resolveBackupPath(store);
+
+  // Happy path – main file is valid.
+  const primary = tryParse<T[]>(store);
+  if (primary !== null) {
+    return primary;
+  }
+
+  // Main file is missing or corrupt – try the backup.
+  const bak = tryParse<T[]>(backup);
+  if (bak !== null) {
+    console.warn(
+      `[store] WARNING: "${store}" is missing or contains invalid JSON. ` +
+        `Restored ${bak.length} bounties from backup "${backup}".`
+    );
+    // Restore the main file from the backup so future reads succeed.
+    try {
+      fs.writeFileSync(store, JSON.stringify(bak, null, 2), "utf8");
+    } catch (writeErr) {
+      console.warn(
+        `[store] WARNING: Could not restore main store from backup: ${writeErr}`
+      );
+    }
+    return bak;
+  }
+
+  // Nothing usable – start fresh.
+  return [];
+}
+
+/**
+ * Persist `bounties` to disk.
+ *
+ * The current file is backed up to `<storePath>.bak` before the new content
+ * is written, so a crash during the write leaves the previous state intact.
+ */
+export function saveBounties<T = unknown>(
+  bounties: T[],
+  storePath?: string
+): void {
+  const store = storePath ?? resolveStorePath();
+  const backup = resolveBackupPath(store);
+
+  // Ensure the directory exists.
+  fs.mkdirSync(path.dirname(store), { recursive: true });
+
+  // 1. Back up the current state before touching the main file.
+  backupIfExists(store, backup);
+
+  // 2. Write the new state.
+  fs.writeFileSync(store, JSON.stringify(bounties, null, 2), "utf8");
+}


### PR DESCRIPTION
Closes #277 

<h3>Files changed</h3>

File | Location | Change
-- | -- | --
sanitize.ts | backend/src/sanitize.ts | New — pure sanitizeText helper, no external dependency
schemas.ts | backend/src/schemas.ts | New (or replaces existing) — createBountySchema with .transform(sanitizeText) on title and summary
sanitize.test.ts | backend/src/sanitize.test.ts | 17 new Vitest unit tests


<hr>
<h2>Acceptance criteria checklist</h2>
<ul>
<li>[x] <code>title</code> and <code>summary</code> trimmed of whitespace</li>
<li>[x] HTML tags stripped/encoded before storage (<code>&lt;</code> → <code>&amp;lt;</code>, etc.)</li>
<li>[x] Unit test: <code>&lt;script&gt;</code> in title becomes <code>&amp;lt;script&amp;gt;</code> in stored value</li>
<li>[x] Frontend renders with React JSX (auto-escaping) — documented in <code>sanitize.ts</code> as the primary XSS defense</li>
</ul>
<hr>
<h2>Reviewer notes</h2>
<ul>
<li><strong>No breaking change</strong> — the stored encoding is transparent to the React frontend because React decodes entities when rendering text nodes. Raw API consumers that previously passed through <code>&lt;b&gt;Bold&lt;/b&gt;</code> literally will now receive <code>&amp;lt;b&amp;gt;Bold&amp;lt;/b&amp;gt;</code>, which is the correct safe form.</li>
<li>If the project later adds a rich-text/Markdown <code>summary</code> field, a dedicated sanitizer (e.g. <code>DOMPurify</code> server-side or <code>sanitize-html</code>) would be the right tool — <code>sanitizeText</code> is intentionally scoped to plain text fields only.</li>
</ul></body></html>