### PR TITLE
feat(security): restrict production cors to ALLOWED_ORIGINS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,14 @@ BOUNTY_AUDIT_STORE_PATH=./data/audit.json
 # Default: development
 NODE_ENV=development
 
-# [OPTIONAL] CORS allowed origins (comma-separated). Default: http://localhost:5173
-CORS_ORIGINS=http://localhost:5173
+# [OPTIONAL] Production CORS allowlist (comma-separated). Required when NODE_ENV=production.
+# Example: ALLOWED_ORIGINS=https://bounty-board.vercel.app
+# ALLOWED_ORIGINS=https://bounty-board.vercel.app
+
+# [OPTIONAL] Development CORS origins. Defaults to permissive wildcard (*) when unset.
+# Use an explicit list to restrict local dev, e.g. http://localhost:3000 (Vite default port).
+# CORS_ORIGINS=*
+# CORS_ORIGINS=http://localhost:3000
 
 # [OPTIONAL] Logging level (debug, info, warn, error). Default: info
 LOG_LEVEL=info

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3,7 +3,7 @@ import cors from 'cors';
 import express, { Request, Response, NextFunction } from 'express';
 import { randomUUID } from 'node:crypto';
 import swaggerUi from 'swagger-ui-express';
-import { buildCorsOptions } from './middleware/corsOptions';
+import { buildCorsOptions, createCorsPreflightGuard, warnIfProductionCorsMisconfigured } from './middleware/corsOptions';
 import { generateOpenApiDocument } from './docs/openapi';
 import { getMetrics, httpRequestDuration } from './metrics';
 
@@ -101,6 +101,8 @@ function requestContextMiddleware(req: Request, res: Response, next: NextFunctio
 
 export const app = express();
 
+warnIfProductionCorsMisconfigured();
+app.use(createCorsPreflightGuard());
 app.use(cors(buildCorsOptions()));
 
 app.use(

--- a/backend/src/middleware/corsOptions.ts
+++ b/backend/src/middleware/corsOptions.ts
@@ -1,43 +1,151 @@
 import type { CorsOptions } from "cors";
+import type { RequestHandler } from "express";
+
+export type CorsMode = "production" | "development";
+
+export interface CorsConfig {
+  mode: CorsMode;
+  /** `null` means permissive — reflect any browser origin (dev wildcard). */
+  allowlist: Set<string> | null;
+}
+
+const CORS_DENIED_MESSAGE = "Origin not allowed by CORS policy.";
 
 /**
- * Build a CORS options object from the `CORS_ORIGINS` environment variable.
- *
- * `CORS_ORIGINS` should be a comma-separated list of allowed origins, e.g.:
- *   CORS_ORIGINS=https://app.example.com,https://staging.example.com
- *
- * When the variable is absent or empty the default origin is `http://localhost:3000`
- * so local development works without any configuration.
- *
- * Requests from origins NOT in the allowlist receive a CORS error (no
- * `Access-Control-Allow-Origin` header), which browsers treat as a 403-equivalent.
+ * Parse a comma-separated origin list into a set of trimmed origin strings.
  */
-export function buildCorsOptions(): CorsOptions {
-  const raw = process.env.CORS_ORIGINS ?? "";
-  const allowlist: Set<string> = new Set(
+export function parseOriginAllowlist(raw: string): Set<string> {
+  return new Set(
     raw
       .split(",")
-      .map((s) => s.trim())
+      .map((entry) => entry.trim())
       .filter(Boolean),
   );
+}
 
-  if (allowlist.size === 0) {
-    allowlist.add("http://localhost:3000");
+function isWildcardOriginConfig(raw: string): boolean {
+  const trimmed = raw.trim();
+  return trimmed === "" || trimmed === "*";
+}
+
+/**
+ * Resolve CORS configuration from environment.
+ *
+ * Production (`NODE_ENV=production`):
+ *   - Uses `ALLOWED_ORIGINS` only (strict allowlist; empty set if unset).
+ *
+ * Development / test:
+ *   - Uses `CORS_ORIGINS`, then `ALLOWED_ORIGINS`, then defaults to `*` (permissive).
+ */
+export function resolveCorsConfig(): CorsConfig {
+  if (process.env.NODE_ENV === "production") {
+    const raw = process.env.ALLOWED_ORIGINS ?? "";
+    return {
+      mode: "production",
+      allowlist: parseOriginAllowlist(raw),
+    };
+  }
+
+  const raw = process.env.CORS_ORIGINS ?? process.env.ALLOWED_ORIGINS ?? "*";
+  if (isWildcardOriginConfig(raw)) {
+    return {
+      mode: "development",
+      allowlist: null,
+    };
   }
 
   return {
+    mode: "development",
+    allowlist: parseOriginAllowlist(raw),
+  };
+}
+
+export function isOriginAllowed(
+  origin: string | undefined,
+  config: CorsConfig = resolveCorsConfig(),
+): boolean {
+  if (!origin) {
+    return true;
+  }
+
+  if (config.allowlist === null) {
+    return true;
+  }
+
+  return config.allowlist.has(origin);
+}
+
+/**
+ * Warn when production is configured without an explicit frontend allowlist.
+ */
+export function warnIfProductionCorsMisconfigured(): void {
+  if (process.env.NODE_ENV !== "production") {
+    return;
+  }
+
+  const raw = process.env.ALLOWED_ORIGINS?.trim();
+  if (!raw) {
+    console.warn(
+      "[cors] NODE_ENV=production but ALLOWED_ORIGINS is unset; browser origins will be rejected.",
+    );
+  }
+}
+
+/**
+ * Reject disallowed production preflight requests with HTTP 403 before the cors
+ * middleware runs.
+ */
+export function createCorsPreflightGuard(): RequestHandler {
+  return (req, res, next) => {
+    const config = resolveCorsConfig();
+
+    if (config.mode !== "production") {
+      next();
+      return;
+    }
+
+    if (req.method !== "OPTIONS") {
+      next();
+      return;
+    }
+
+    const origin = req.headers.origin;
+    if (!origin || typeof origin !== "string") {
+      next();
+      return;
+    }
+
+    if (!config.allowlist?.has(origin)) {
+      res.status(403).json({ error: CORS_DENIED_MESSAGE });
+      return;
+    }
+
+    next();
+  };
+}
+
+/**
+ * Build a CORS options object for the express `cors` middleware.
+ *
+ * Production uses `ALLOWED_ORIGINS`. Development defaults to permissive `*`
+ * behavior (dynamic origin reflection) when unset.
+ */
+export function buildCorsOptions(): CorsOptions {
+  const config = resolveCorsConfig();
+
+  return {
     origin(requestOrigin, callback) {
-      // Non-browser requests (curl, server-to-server) have no Origin header.
       if (!requestOrigin) {
         callback(null, true);
         return;
       }
 
-      if (allowlist.has(requestOrigin)) {
+      if (isOriginAllowed(requestOrigin, config)) {
         callback(null, true);
-      } else {
-        callback(new Error(`Origin "${requestOrigin}" is not allowed by CORS policy.`));
+        return;
       }
+
+      callback(null, false);
     },
     methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allowedHeaders: [

--- a/backend/test/cors.test.ts
+++ b/backend/test/cors.test.ts
@@ -1,0 +1,158 @@
+import cors from "cors";
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildCorsOptions,
+  createCorsPreflightGuard,
+} from "../src/middleware/corsOptions";
+
+const PRODUCTION_ORIGIN = "https://bounty-board.vercel.app";
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete process.env.NODE_ENV;
+  delete process.env.ALLOWED_ORIGINS;
+  delete process.env.CORS_ORIGINS;
+});
+
+function createTestApp() {
+  const app = express();
+  app.use(createCorsPreflightGuard());
+  app.use(cors(buildCorsOptions()));
+  app.get("/api/health", (_req, res) => {
+    res.json({ status: "ok", service: "stellar-bounty-board-api" });
+  });
+  return app;
+}
+
+describe("CORS production allowlist (#256)", () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = "production";
+    process.env.ALLOWED_ORIGINS = PRODUCTION_ORIGIN;
+  });
+
+  it("allows preflight from an allowed production origin", async () => {
+    const app = createTestApp();
+
+    const res = await request(app)
+      .options("/api/health")
+      .set("Origin", PRODUCTION_ORIGIN)
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(res.status).not.toBe(403);
+    expect(res.headers["access-control-allow-origin"]).toBe(PRODUCTION_ORIGIN);
+  });
+
+  it("returns 403 on preflight from an unrecognized production origin", async () => {
+    const app = createTestApp();
+
+    const res = await request(app)
+      .options("/api/health")
+      .set("Origin", "https://evil.example.com")
+      .set("Access-Control-Request-Method", "GET")
+      .expect(403);
+
+    expect(res.body.error).toMatch(/not allowed by CORS policy/i);
+  });
+
+  it("allows GET requests from an allowed production origin", async () => {
+    const app = createTestApp();
+
+    const res = await request(app)
+      .get("/api/health")
+      .set("Origin", PRODUCTION_ORIGIN)
+      .expect(200);
+
+    expect(res.body.status).toBe("ok");
+    expect(res.headers["access-control-allow-origin"]).toBe(PRODUCTION_ORIGIN);
+  });
+
+  it("restricts origins to ALLOWED_ORIGINS in production", async () => {
+    const app = createTestApp();
+
+    const res = await request(app)
+      .get("/api/health")
+      .set("Origin", "https://other.example.com")
+      .expect(200);
+
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+});
+
+describe("CORS development defaults (#256)", () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = "development";
+  });
+
+  it("allows preflight from arbitrary origins when unset (wildcard default)", async () => {
+    const app = createTestApp();
+
+    const res = await request(app)
+      .options("/api/health")
+      .set("Origin", "http://localhost:9999")
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(res.status).not.toBe(403);
+    expect(res.headers["access-control-allow-origin"]).toBe("http://localhost:9999");
+  });
+
+  it("honors CORS_ORIGINS explicit dev allowlist", async () => {
+    process.env.CORS_ORIGINS = "http://localhost:3000";
+    const app = createTestApp();
+
+    const allowed = await request(app)
+      .options("/api/health")
+      .set("Origin", "http://localhost:3000")
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(allowed.status).not.toBe(403);
+    expect(allowed.headers["access-control-allow-origin"]).toBe("http://localhost:3000");
+
+    const blocked = await request(app)
+      .options("/api/health")
+      .set("Origin", "http://localhost:9999")
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(blocked.status).not.toBe(403);
+    expect(blocked.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("falls back to ALLOWED_ORIGINS in development when CORS_ORIGINS is unset", async () => {
+    process.env.ALLOWED_ORIGINS = "http://localhost:3000";
+    const app = createTestApp();
+
+    const res = await request(app)
+      .get("/api/health")
+      .set("Origin", "http://localhost:3000")
+      .expect(200);
+
+    expect(res.headers["access-control-allow-origin"]).toBe("http://localhost:3000");
+  });
+
+  it("treats CORS_ORIGINS=* as permissive in development", async () => {
+    process.env.CORS_ORIGINS = "*";
+    const app = createTestApp();
+
+    const res = await request(app)
+      .get("/api/health")
+      .set("Origin", "http://custom.dev:4321")
+      .expect(200);
+
+    expect(res.headers["access-control-allow-origin"]).toBe("http://custom.dev:4321");
+  });
+});
+
+describe("resolveCorsConfig unit helpers", () => {
+  it("parseOriginAllowlist splits comma-separated values", async () => {
+    const { parseOriginAllowlist } = await import("../src/middleware/corsOptions");
+    const allowlist = parseOriginAllowlist(
+      "https://a.example.com, https://b.example.com ,",
+    );
+
+    expect([...allowlist]).toEqual(["https://a.example.com", "https://b.example.com"]);
+  });
+});

--- a/backend/test/webhookSignature.test.ts
+++ b/backend/test/webhookSignature.test.ts
@@ -8,11 +8,6 @@ import {
 
 const secret = 'github-webhook-secret';
 
-type CorsOriginCallback = (
-  origin: string | undefined,
-  callback: (error: Error | null, allow?: boolean) => void
-) => void;
-
 interface SearchResultBounty {
   title: string;
 }
@@ -182,53 +177,6 @@ describe('GitHub webhook signature edge cases (#90)', () => {
         signatureHeader: [signature, 'sha256=other'],
       })
     ).not.toThrow();
-  });
-});
-
-describe('CORS allowlist middleware (#88)', () => {
-  it('buildCorsOptions uses localhost:3000 as default when CORS_ORIGINS is unset', async () => {
-    delete process.env.CORS_ORIGINS;
-
-    const { buildCorsOptions } = await import('../src/middleware/corsOptions');
-    const options = buildCorsOptions();
-    const origin = options.origin as CorsOriginCallback;
-
-    await new Promise<void>((resolve, reject) => {
-      origin('http://localhost:3000', (error, allow) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-
-        if (!allow) {
-          reject(new Error('expected allowed'));
-          return;
-        }
-
-        resolve();
-      });
-    });
-  });
-
-  it('buildCorsOptions rejects unlisted origins', async () => {
-    process.env.CORS_ORIGINS = 'https://app.example.com';
-
-    const mod = await import('../src/middleware/corsOptions?t=2');
-    const options = mod.buildCorsOptions();
-    const origin = options.origin as CorsOriginCallback;
-
-    await new Promise<void>((resolve, reject) => {
-      origin('https://evil.example.com', (error) => {
-        if (error) {
-          resolve();
-          return;
-        }
-
-        reject(new Error('expected rejection'));
-      });
-    });
-
-    delete process.env.CORS_ORIGINS;
   });
 });
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,3 @@
-
-
 - [Render (Backend) & Vercel (Frontend)](#render-vercel)
 - [Railway One-Click Deployment](#railway)
 
@@ -16,10 +14,9 @@
 5. Health check path: `/api/health`
    - A healthy response: `{ "service": "stellar-bounty-board-backend", "status": "ok", ... }`
 6. Ensure the port is set to `3001` (or use `process.env.PORT` as Render provides).
+7. Set production CORS variables (see [CORS configuration](#cors-configuration) below).
 
 ### Frontend Deployment: Vercel
-
-
 
 ---
 
@@ -54,23 +51,51 @@ Click the button above or follow the manual steps below.
    - Start command (auto-detected): `npm start`
    - Railway assigns a `${{PORT}}` environment variable automatically (overrides the default `3001`)
 
+   | Variable                  | Required      | Example Value                     | Description                                      |
+   | ------------------------- | ------------- | --------------------------------- | ------------------------------------------------ |
+   | `GITHUB_WEBHOOK_SECRET`   | ✅ Yes        | `your_webhook_secret`             | Secret for GitHub webhook verification           |
+   | `NODE_ENV`                | ✅ Yes (prod) | `production`                      | Environment mode                                 |
+   | `ALLOWED_ORIGINS`         | ✅ Yes (prod) | `https://bounty-board.vercel.app` | Production frontend origin allowlist             |
+   | `CORS_ORIGINS`            | ❌ No         | `*` or `http://localhost:3000`    | Development CORS origins (ignored in production) |
+   | `BOUNTY_STORE_PATH`       | ❌ No         | `./data/bounties.json`            | Bounty data file (default)                       |
+   | `BOUNTY_AUDIT_STORE_PATH` | ❌ No         | `./data/audit.json`               | Audit log file (default)                         |
+   | `LOG_LEVEL`               | ❌ No         | `info`                            | Logging level                                    |
 
+---
 
-   | Variable | Required | Example Value | Description |
-   |----------|----------|---------------|-------------|
-   | `GITHUB_WEBHOOK_SECRET` | ✅ Yes | `your_webhook_secret` | Secret for GitHub webhook verification |
-   | `NODE_ENV` | ❌ No | `production` | Environment mode |
-   | `CORS_ORIGINS` | ❌ No | `https://your-frontend.vercel.app` | Allowed CORS origins |
-   | `BOUNTY_STORE_PATH` | ❌ No | `./data/bounties.json` | Bounty data file (default) |
-   | `BOUNTY_AUDIT_STORE_PATH` | ❌ No | `./data/audit.json` | Audit log file (default) |
-   | `LOG_LEVEL` | ❌ No | `info` | Logging level |
+## CORS configuration <a name="cors-configuration"></a>
 
+The backend restricts browser cross-origin access in production using an explicit allowlist.
+
+### Production
+
+Set these on your backend host (Render, Railway, Docker, etc.):
+
+```env
+NODE_ENV=production
+ALLOWED_ORIGINS=https://bounty-board.vercel.app
+```
+
+- `ALLOWED_ORIGINS` is a comma-separated list of frontend URLs allowed to call the API.
+- Requests from unrecognized browser origins receive **HTTP 403** on CORS preflight (`OPTIONS`).
+- If `ALLOWED_ORIGINS` is unset in production, the server logs a warning and rejects browser origins.
+
+### Local development
+
+Development defaults to permissive CORS (`*`) so any local frontend origin works without configuration.
+
+Override with an explicit list when needed:
+
+```env
+NODE_ENV=development
+CORS_ORIGINS=http://localhost:3000
+```
+
+`CORS_ORIGINS` and `ALLOWED_ORIGINS` are both honored in development; `CORS_ORIGINS` takes precedence.
 
 ---
 
 ## Required Environment Variables
-
-
 
 ---
 
@@ -84,7 +109,7 @@ Click the button above or follow the manual steps below.
 ## Common Deployment Issues & Fixes
 
 - **Build fails:** Check Node.js version (18+), install all dependencies, and verify build commands.
-- **API not reachable:** Confirm backend is live and CORS is configured.
+- **API not reachable:** Confirm backend is live and CORS is configured (`ALLOWED_ORIGINS` in production).
 
 - **Frontend shows blank:** Ensure correct output directory (`dist`) and that the API URL is set.
 
@@ -95,6 +120,7 @@ Click the button above or follow the manual steps below.
 ## Docker Deployment
 
 ### Prerequisites
+
 - [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) installed locally or on server
 
 ### Local Full-Stack Development with Docker Compose
@@ -106,6 +132,7 @@ docker-compose up --build
 ```
 
 This starts:
+
 - **Backend:** `http://localhost:3001/api`
 - **Frontend:** `http://localhost:5173`
 
@@ -119,11 +146,13 @@ SOROBAN_RPC_URL=https://rpc-futurenet.stellar.org
 Docker Compose will pass these to the containers automatically.
 
 #### Volume Mounts
+
 - Backend source (`./backend/src`) is mounted, so changes hot-reload during development
 - Frontend source (`./frontend/src`) is mounted similarly
 - Data persists in `./backend/data/`
 
 #### Health Checks
+
 Both services include health checks. The frontend waits for the backend to be healthy before starting:
 
 ```bash
@@ -169,38 +198,45 @@ docker run -d \
 ### Environment Variables (Docker)
 
 **Backend (`Dockerfile`):**
+
 - `NODE_ENV` (default: `production`)
 - `PORT` (default: `3001`)
 - `SOROBAN_CONTRACT_ID` (required if indexing events)
 - `SOROBAN_RPC_URL` (default: `https://rpc-futurenet.stellar.org`)
 
 **Frontend (`frontend/Dockerfile`):**
+
 - `VITE_API_BASE_URL` (required): URL of your backend API
 
 ### Health Check Paths (Docker)
+
 - Backend: `GET http://localhost:3001/api/health`
 - Frontend: `GET http://localhost:5173` (should load the React app)
 
 ### Docker Troubleshooting
 
 **Container fails to start:**
+
 - Check logs: `docker-compose logs backend` or `docker logs <container-id>`
 - Ensure the root `package.json` and all dependencies are present
 
 **API calls fail from frontend:**
+
 - Verify `VITE_API_BASE_URL` is set correctly
 - Ensure backend container is healthy: `docker-compose ps`
-- Check CORS settings in the backend
+- Check CORS settings: set `ALLOWED_ORIGINS` to your deployed frontend URL when `NODE_ENV=production`
 
 **Data not persisting:**
+
 - Verify the volume mount path: `docker volume ls` and `docker volume inspect <volume-name>`
 - Ensure the host directory has write permissions
 
 **Port conflicts:**
+
 - If ports 3001 or 5173 are in use, modify `docker-compose.yml`:
   ```yaml
   ports:
-    - "3001:3001"  # Change left side (host) port
+    - '3001:3001' # Change left side (host) port
   ```
 
 ---


### PR DESCRIPTION
## Description

Restricts production CORS to an explicit frontend origin allowlist while keeping permissive local development defaults (issue #256).

In production (`NODE_ENV=production`), browser requests are allowed only from origins listed in `ALLOWED_ORIGINS` (e.g. `https://bounty-board.vercel.app`). Unrecognized origins receive **HTTP 403** on CORS preflight (`OPTIONS`). In development, `CORS_ORIGINS` and `ALLOWED_ORIGINS` remain backward-compatible, defaulting to permissive wildcard behavior (`*`) when unset.

**Changes:**
- Refactored [`backend/src/middleware/corsOptions.ts`](backend/src/middleware/corsOptions.ts) with `resolveCorsConfig()`, `createCorsPreflightGuard()`, and production/dev origin resolution
- Mounted preflight guard before `cors()` in [`backend/src/app.ts`](backend/src/app.ts); added startup warning when production lacks `ALLOWED_ORIGINS`
- Added [`backend/test/cors.test.ts`](backend/test/cors.test.ts) — 9 supertest cases (allowed/rejected preflight, dev wildcard, explicit lists)
- Removed duplicate callback-only CORS tests from [`backend/test/webhookSignature.test.ts`](backend/test/webhookSignature.test.ts)
- Documented `ALLOWED_ORIGINS` / `CORS_ORIGINS` in [`.env.example`](.env.example) and [`docs/deployment.md`](docs/deployment.md)

Closes #256

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Security Checklist

Please review the [SECURITY_CHECKLIST.md](SECURITY_CHECKLIST.md) and check off any items that apply. Reviewers must sign off on these items before merge.

- [ ] Input validation changed
- [x] Auth modified
- [ ] New external fetch
- [ ] Dependency added
- [ ] Secret handling

## Test plan

- [x] `cd backend && npm test -- test/cors.test.ts` — 9/9 pass (production allowlist, preflight 403, dev wildcard, explicit lists)
- [ ] `cd backend && npm test -- test/webhookSignature.test.ts` — webhook tests unchanged by this PR (CORS callback tests removed)

Manual smoke (production):

```bash
NODE_ENV=production ALLOWED_ORIGINS=https://bounty-board.vercel.app npm run dev

curl -i -X OPTIONS http://localhost:3001/api/health \
  -H "Origin: https://evil.example.com" \
  -H "Access-Control-Request-Method: GET"
# Expect: HTTP 403
```
