### PR TITLE
Add contributor filter to bounty listing

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -36,6 +36,7 @@ import {
   updateNotesSchema,
   zodErrorMessage,
 } from './validation/schemas';
+import { isValidStellarAddress } from './utils';
 
 import {
   captureRawBody,
@@ -271,6 +272,10 @@ app.get('/worker/health', (_req: Request, res: Response) => {
 app.get('/api/bounties', async (req: Request, res: Response) => {
   try {
     const q = typeof req.query.q === 'string' ? req.query.q : undefined;
+    const contributor =
+      typeof req.query.contributor === 'string' && req.query.contributor.trim()
+        ? req.query.contributor.trim()
+        : undefined;
     const page = parsePaginationValue(req.query.page, 'page', 1, 1);
     const pageSize = parsePaginationValue(req.query.pageSize, 'pageSize', 20, 1, 100);
 
@@ -292,7 +297,11 @@ app.get('/api/bounties', async (req: Request, res: Response) => {
       deadlineAfter = Math.floor(date.getTime() / 1000);
     }
 
-    const all = await listBountiesCached({ q, deadlineBefore, deadlineAfter });
+    if (contributor && !isValidStellarAddress(contributor)) {
+      throw new Error('contributor must be a valid Stellar public key');
+    }
+
+    const all = await listBountiesCached({ q, contributor, deadlineBefore, deadlineAfter });
     const total = all.length;
     const start = (page - 1) * pageSize;
     const data = all.slice(start, start + pageSize);

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -91,6 +91,9 @@ registry.registerPath({
       q: z.string().optional().openapi({
         description: "Case-insensitive substring filter applied to title, summary, and labels.",
       }),
+      contributor: z.string().optional().openapi({
+        description: "Exact Stellar public key filter applied to the bounty contributor.",
+      }),
       deadlineBefore: z.string().optional().openapi({
         description: "Filter bounties with deadline before this ISO 8601 date string.",
         example: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -465,6 +465,8 @@ function persistUpdated(
 export interface ListBountiesOptions {
   /** Case-insensitive substring filter applied to title, summary, and labels. */
   q?: string;
+  /** Exact Stellar address filter applied to contributor. */
+  contributor?: string;
   /** Filter bounties with deadlineBefore (unix timestamp in seconds). */
   deadlineBefore?: number;
   /** Filter bounties with deadlineAfter (unix timestamp in seconds). */
@@ -474,6 +476,7 @@ export interface ListBountiesOptions {
 export function listBounties(options: ListBountiesOptions = {}): BountyRecord[] {
   const records = normalizeRecords(readStore());
   const q = options.q?.trim().toLowerCase();
+  const contributor = options.contributor?.trim();
   const deadlineBefore = options.deadlineBefore;
   const deadlineAfter = options.deadlineAfter;
 
@@ -486,9 +489,10 @@ export function listBounties(options: ListBountiesOptions = {}): BountyRecord[] 
       b.title.toLowerCase().includes(q) ||
       b.summary.toLowerCase().includes(q) ||
       b.labels.some((l) => l.toLowerCase().includes(q));
+    const passesContributor = !contributor || b.contributor === contributor;
     const passesDeadlineBefore = deadlineBefore === undefined || b.deadlineAt < deadlineBefore;
     const passesDeadlineAfter = deadlineAfter === undefined || b.deadlineAt > deadlineAfter;
-    if (passesQ && passesDeadlineBefore && passesDeadlineAfter) {
+    if (passesQ && passesContributor && passesDeadlineBefore && passesDeadlineAfter) {
       result.push(b);
     }
   }
@@ -526,6 +530,7 @@ export async function listBountiesCached(
   }
 
   const q = options.q?.trim().toLowerCase();
+  const contributor = options.contributor?.trim();
   const deadlineBefore = options.deadlineBefore;
   const deadlineAfter = options.deadlineAfter;
 
@@ -535,9 +540,10 @@ export async function listBountiesCached(
       b.title.toLowerCase().includes(q) ||
       b.summary.toLowerCase().includes(q) ||
       b.labels.some((l) => l.toLowerCase().includes(q));
+    const passesContributor = !contributor || b.contributor === contributor;
     const passesDeadlineBefore = deadlineBefore === undefined || b.deadlineAt < deadlineBefore;
     const passesDeadlineAfter = deadlineAfter === undefined || b.deadlineAt > deadlineAfter;
-    return passesQ && passesDeadlineBefore && passesDeadlineAfter;
+    return passesQ && passesContributor && passesDeadlineBefore && passesDeadlineAfter;
   });
 }
 

--- a/backend/test/api.test.ts
+++ b/backend/test/api.test.ts
@@ -209,6 +209,55 @@ describe("API — bounty list deadline filters", () => {
   });
 });
 
+describe("API — bounty list contributor filter", () => {
+  it("filters bounties by exact contributor address", async () => {
+    const app = await getApp();
+    const created = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+    const bountyId = created.body.data.id;
+
+    await request(app)
+      .post(`/api/bounties/${bountyId}/reserve`)
+      .send({ contributor: CONTRIBUTOR })
+      .expect(200);
+
+    const matched = await request(app)
+      .get("/api/bounties")
+      .query({ contributor: CONTRIBUTOR })
+      .expect(200);
+
+    expect(matched.body.data.some((b: any) => b.id === bountyId)).toBe(true);
+  });
+
+  it("returns no bounties when no contributor matches", async () => {
+    const app = await getApp();
+    const created = await request(app).post("/api/bounties").send(validCreateBody).expect(201);
+    const bountyId = created.body.data.id;
+
+    await request(app)
+      .post(`/api/bounties/${bountyId}/reserve`)
+      .send({ contributor: CONTRIBUTOR })
+      .expect(200);
+
+    const matched = await request(app)
+      .get("/api/bounties")
+      .query({ contributor: OTHER_ACCOUNT })
+      .expect(200);
+
+    expect(matched.body.data).toHaveLength(0);
+  });
+
+  it("rejects invalid contributor addresses", async () => {
+    const app = await getApp();
+
+    const res = await request(app)
+      .get("/api/bounties")
+      .query({ contributor: "not-a-valid-address" })
+      .expect(400);
+
+    expect(res.body.error).toMatch(/contributor|Stellar public key/i);
+  });
+});
+
 describe("API — admin audit log endpoint", () => {
   it("GET /api/audit-log returns all audit logs", async () => {
     const app = await getApp();

--- a/docs/openapi.generated.json
+++ b/docs/openapi.generated.json
@@ -550,6 +550,61 @@
         ],
         "summary": "List all bounties",
         "description": "Returns every bounty record sorted by creation date (newest first). Bounties whose deadline has passed are automatically transitioned to `expired` before the list is returned.",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Case-insensitive substring filter applied to title, summary, and labels."
+          },
+          {
+            "name": "contributor",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Exact Stellar public key filter applied to the bounty contributor."
+          },
+          {
+            "name": "deadlineBefore",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter bounties with deadline before this ISO 8601 date string.",
+            "example": "2026-07-26T19:13:30.142Z"
+          },
+          {
+            "name": "deadlineAfter",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter bounties with deadline after this ISO 8601 date string.",
+            "example": "2026-06-26T19:13:30.142Z"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "Page number (starts at 1, default 1)."
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "description": "Number of items per page (max 100, default 20)."
+          }
+        ],
         "responses": {
           "200": {
             "description": "Array of all bounty records.",


### PR DESCRIPTION
Closes #246
Closes #262 
Closes #219 
Closes #244 

Changes:
- Add exact contributor filtering to GET /api/bounties in both the live and cached list paths.
- Validate the contributor query as a Stellar public key and document the new filter in OpenAPI.
- Add API tests for matching, non-matching, and invalid contributor queries.

Testing:
- git diff --check