### PR TITLE
feat: graceful shutdown with SIGTERM/SIGINT drain window

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -50,6 +50,7 @@ import { readLimiter, mutationLimiter } from './utils';
 import { logStructured } from './logger';
 import { createAdminApiKeyAuthMiddleware } from './middleware/adminAuth';
 import { handleGitHubPrEvent } from './webhooks/githubPrHandler';
+import { draining } from './shutdown';
 
 const INCOMING_REQUEST_ID = /^[a-zA-Z0-9-]{1,128}$/;
 
@@ -101,6 +102,14 @@ function requestContextMiddleware(req: Request, res: Response, next: NextFunctio
 }
 
 export const app = express();
+
+app.use((_req: Request, res: Response, next: NextFunction) => {
+  if (draining) {
+    res.setHeader('Connection', 'close');
+    return res.status(503).json({ error: 'Service unavailable — server is shutting down' });
+  }
+  next();
+});
 
 app.use(cors(buildCorsOptions()));
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,14 +1,30 @@
 import "dotenv/config";
+import http from "node:http";
+import path from "node:path";
+import { Worker } from "node:worker_threads";
 import { app } from "./app";
 import { logStructured } from "./logger";
+import { invalidateBountyCache } from "./services/bountyStore";
+import { startExpirationJob, stopExpirationJob } from "./services/reservationExpirationJob";
+import { setDraining } from "./shutdown";
 
+const PORT = Number(process.env.PORT ?? 3000);
+const keepAliveTimeout = Number(process.env.KEEP_ALIVE_TIMEOUT ?? 65_000);
+const headersTimeout = Number(process.env.HEADERS_TIMEOUT ?? 66_000);
+const DRAIN_TIMEOUT_MS = 10_000;
 
+const server = http.createServer(app);
+
+server.listen(PORT, () => {
+  logStructured("info", "server_listening", { port: PORT });
 });
 
 server.keepAliveTimeout = keepAliveTimeout;
 server.headersTimeout = headersTimeout;
 
 // Start Soroban indexer in a Worker thread to avoid blocking the event loop.
+let indexerWorker: Worker | null = null;
+
 function startIndexerWorker() {
   const workerPath = path.join(__dirname, "..", "worker", "indexer.js");
   let backoff = 1000;
@@ -16,12 +32,12 @@ function startIndexerWorker() {
 
   const spawn = () => {
     worker = new Worker(workerPath);
+    indexerWorker = worker;
     logStructured("info", "indexer_worker_spawn", { pid: worker.threadId });
 
     worker.on("message", async (msg: any) => {
       if (msg && msg.type === "indexedEvents") {
         try {
-          // Invalidate bounty cache so reads reflect new on-chain events
           await invalidateBountyCache();
         } catch (err) {
           console.warn("Failed to invalidate bounty cache from indexer message:", err);
@@ -50,7 +66,49 @@ function startIndexerWorker() {
   spawn();
 }
 
-// Only start the indexer when running the main server (not in tests)
+// Only start the indexer and expiration job when running the main server (not in tests)
 if (process.env.NODE_ENV !== "test") {
   startIndexerWorker();
+  startExpirationJob();
 }
+
+async function shutdown(signal: string): Promise<void> {
+  logStructured("info", "shutdown_initiated", { signal });
+
+  // Mark server as draining so new requests get 503
+  setDraining();
+
+  // Stop expiration job before draining connections
+  stopExpirationJob();
+
+  // Stop the indexer worker
+  if (indexerWorker) {
+    try {
+      await indexerWorker.terminate();
+    } catch {
+      /* best effort */
+    }
+    indexerWorker = null;
+  }
+
+  // Give in-flight requests up to DRAIN_TIMEOUT_MS to finish
+  const drainTimer = setTimeout(() => {
+    logStructured("error", "shutdown_timeout", { drainMs: DRAIN_TIMEOUT_MS });
+    process.exit(1);
+  }, DRAIN_TIMEOUT_MS);
+
+  // Don't let this timer hold the process open
+  drainTimer.unref();
+
+  server.close((err) => {
+    if (err) {
+      logStructured("error", "shutdown_server_close_error", { message: String(err) });
+      process.exit(1);
+    }
+    logStructured("info", "shutdown_complete");
+    process.exit(0);
+  });
+}
+
+process.once("SIGTERM", () => shutdown("SIGTERM"));
+process.once("SIGINT", () => shutdown("SIGINT"));

--- a/backend/src/shutdown.ts
+++ b/backend/src/shutdown.ts
@@ -1,0 +1,5 @@
+export let draining = false;
+
+export function setDraining(): void {
+  draining = true;
+}


### PR DESCRIPTION
## Summary

- Reconstructs `backend/src/index.ts` which was missing imports and server bootstrap code
- Adds `backend/src/shutdown.ts` — shared drain flag (`draining`) that index.ts sets to `true` on signal
- On `SIGTERM` / `SIGINT`: marks server draining, stops reservation expiration job, terminates indexer worker, calls `server.close()` with a 10-second drain window
- New requests during drain receive `503 Service Unavailable` with `Connection: close` header
- Clean shutdown exits with code `0`; drain timeout (10 s) forces exit with code `1`
- Starts reservation expiration job on server boot

## Issues closed

Closes #266
Closes #269
Closes #273
Closes #249