### PR TITLE
test(webhooks): add signature verification tests for all GitHub event types

### DIFF
--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -1,7 +1,6 @@
 import { OpenApiGeneratorV31, OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 import {
- import {
   bountyAuditLogListResponseSchema,
   bountyAuditLogPaginationSchema,
   bountyAuditLogSchema,

--- a/backend/test/webhookSignature.test.ts
+++ b/backend/test/webhookSignature.test.ts
@@ -232,6 +232,84 @@ describe('CORS allowlist middleware (#88)', () => {
   });
 });
 
+describe('GitHub webhook signature verification — all GitHub event types (#251)', () => {
+  const wrongSecret = 'definitely-not-the-real-secret';
+
+  const eventPayloads: Record<string, unknown> = {
+    'pull_request.closed': {
+      action: 'closed',
+      pull_request: {
+        html_url: 'https://github.com/owner/repo/pull/42',
+        merged: false,
+      },
+      repository: { full_name: 'owner/repo' },
+    },
+    'issues.closed': {
+      action: 'closed',
+      issue: {
+        number: 10,
+        title: 'Fix the bug',
+        html_url: 'https://github.com/owner/repo/issues/10',
+      },
+      repository: { full_name: 'owner/repo' },
+    },
+    create: {
+      ref_type: 'branch',
+      ref: 'feature/new-branch',
+      master_branch: 'main',
+      repository: { full_name: 'owner/repo' },
+    },
+  };
+
+  for (const [eventName, eventData] of Object.entries(eventPayloads)) {
+    describe(`${eventName} event`, () => {
+      it('accepts a valid signature', () => {
+        const payload = createPayloadBuffer(eventData);
+        expect(() =>
+          verifyGitHubWebhookSignature({
+            payload,
+            secret,
+            signatureHeader: createGitHubSignature(payload),
+          })
+        ).not.toThrow();
+      });
+
+      it('rejects a signature produced with the wrong secret', () => {
+        const payload = createPayloadBuffer(eventData);
+        const wrongSecretSig = signWebhookPayload({
+          payload,
+          secret: wrongSecret,
+          algorithm: githubWebhookSignatureProfile.algorithm,
+          prefix: githubWebhookSignatureProfile.prefix,
+        });
+        // Both sigs are sha256= + 64 hex chars (same length) so timingSafeEqual is exercised
+        expect(() =>
+          verifyGitHubWebhookSignature({
+            payload,
+            secret,
+            signatureHeader: wrongSecretSig,
+          })
+        ).toThrow(/Invalid GitHub webhook signature/i);
+      });
+
+      it('rejects when the payload is truncated (signature was for full payload)', () => {
+        const payload = createPayloadBuffer(eventData);
+        const sigForFullPayload = createGitHubSignature(payload);
+        // Drop the last byte — signature won't match the truncated content
+        const truncated = payload.subarray(0, payload.length - 1);
+        expect(() =>
+          verifyGitHubWebhookSignature({
+            payload: truncated,
+            secret,
+            signatureHeader: sigForFullPayload,
+          })
+        ).toThrow(/Invalid GitHub webhook signature/i);
+      });
+    });
+  }
+
+});
+
 describe('Bounty search with ?q= (#85)', () => {
   it('returns all bounties when q is empty', async () => {
     const { listBounties } = await import('../src/services/bountyStore');


### PR DESCRIPTION
## Summary

- Adds a new test suite in `webhookSignature.test.ts` covering all three GitHub event types the webhook handler processes: `pull_request.closed`, `issues.closed`, and `create`
- For each event type, three scenarios are tested: valid signature (passes), wrong secret (rejects — exercises `timingSafeEqual`), and truncated payload (rejects — signature was computed on full payload)
- Fixes a stray nested `import {` in `openapi.ts` that was breaking `app.ts` test imports

## Test plan

- [x] 9 new unit tests added, all passing (`vitest run test/webhookSignature.test.ts`)
- [x] Each of the 3 event types covered: `pull_request.closed`, `issues.closed`, `create`
- [x] Each event tested with: valid signature → no throw, wrong secret → throws `Invalid GitHub webhook signature`, truncated payload → throws `Invalid GitHub webhook signature`
- [x] `timingSafeEqual` path exercised: wrong-secret sigs are the same byte length as valid sigs (both `sha256=` + 64 hex chars), so the comparison function is always reached

Closes #250
Closes #251
Closes #265