### PR TITLE
feat(config): add ARBITER_ADDRESS env var, deep health check, and arbitration docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,13 @@ LOG_LEVEL=info
 # If absent, the server will log a warning on startup and the endpoint returns 500.
 ADMIN_API_KEY_HASH=
 
+# [REQUIRED for disputes] Stellar public key of the trusted arbiter account.
+# The arbiter is the only address authorised to call `dispute_bounty` on the contract.
+# It is set during contract initialisation (the `arbiter` argument to `initialize`).
+# If absent, the /api/health/deep endpoint will report arbiter as "missing".
+# Example: ARBITER_ADDRESS=GARBITER...XXXXXXXXXXXXXXXXXXXX
+ARBITER_ADDRESS=
+
 
 # ------------------------------------------------------------------------------
 # WORKER CONFIGURATION (SOROBAN)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,45 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for system architecture, data o
 
 The [bounty lifecycle sequence diagram](docs/ARCHITECTURE.md#bounty-lifecycle-sequence) shows the create, reserve, submit, release, refund, dispute, and resolution flows across Maintainer, Contributor, Arbiter, Backend, and Contract actors.
 
+## Arbitration Flow
+
+Stellar Bounty Board uses an on-chain arbiter to resolve disputes fairly without requiring either party to trust the other.
+
+### Roles
+
+| Role | Description |
+|---|---|
+| **Maintainer** | Creates and funds the bounty escrow. |
+| **Contributor** | Reserves the bounty and submits a pull request for review. |
+| **Arbiter** | A trusted third-party address that resolves disputes. Configured once at contract initialisation. |
+
+### Configuration
+
+Set the arbiter's Stellar public key in your environment before starting the backend:
+
+```
+# .env
+ARBITER_ADDRESS=G...your_arbiter_stellar_public_key...
+```
+
+Verify it is recognised by the running server:
+
+```bash
+curl http://localhost:3001/api/health/deep
+# { "components": { "arbiter": "configured" } }
+```
+
+If `arbiter` is `"missing"`, the dispute flow will fail at the contract level.
+
+### Dispute lifecycle
+
+1. **Maintainer raises a dispute** — after the work is submitted, the maintainer can open a dispute within the on-chain dispute window.
+2. **Arbiter reviews** — the arbiter examines the submitted work off-chain (PR, deliverables, communication).
+3. **Arbiter resolves on-chain** — the arbiter calls `dispute_bounty` on the Soroban contract with the bounty ID and their address. The contract verifies the caller matches the stored `ARBITER_ADDRESS`.
+4. **Funds are released** — the contract releases the escrowed tokens to either the contributor (work accepted) or the maintainer (work rejected / refund).
+
+The arbiter address is immutable after `initialize` is called on the contract — rotate it only by redeploying the contract.
+
 ## Deployment Guide
 
 See [docs/deployment.md](docs/deployment.md) for step-by-step instructions to deploy the backend on Render and the frontend on Vercel, including required environment variables, health check paths, and troubleshooting tips.

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -263,12 +263,22 @@ const healthHandler = (_req: Request, res: Response) => {
     service: 'stellar-bounty-board-api',
     status: 'ok',
     timestamp: new Date().toISOString(),
-
   });
 };
 
 app.get('/api/health', healthHandler);
-app.get('/api/health/deep', healthHandler);
+
+app.get('/api/health/deep', (_req: Request, res: Response) => {
+  const arbiterConfigured = Boolean(process.env.ARBITER_ADDRESS?.trim());
+  res.json({
+    service: 'stellar-bounty-board-api',
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    components: {
+      arbiter: arbiterConfigured ? 'configured' : 'missing',
+    },
+  });
+});
 
 app.get('/worker/health', (_req: Request, res: Response) => {
   res.json({

--- a/backend/src/docs/openapi.ts
+++ b/backend/src/docs/openapi.ts
@@ -80,6 +80,35 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/api/health/deep",
+  tags: ["System"],
+  summary: "Deep health check",
+  description:
+    "Extended health check that verifies critical configuration is in place. " +
+    "Returns component-level status including whether the arbiter address is configured. " +
+    "The arbiter is a trusted Stellar account that mediates bounty disputes: when a maintainer " +
+    "raises a dispute, only the configured arbiter may call `dispute_bounty` on the Soroban contract " +
+    "to resolve it in favour of either the contributor or the maintainer. " +
+    "If `components.arbiter` is `\"missing\"`, set `ARBITER_ADDRESS` in your environment.",
+  responses: {
+    200: jsonResponse(
+      "Service is healthy with component details.",
+      z.object({
+        service: z.string(),
+        status: z.string(),
+        timestamp: z.string(),
+        components: z.object({
+          arbiter: z.enum(["configured", "missing"]).openapi({
+            description: "Whether ARBITER_ADDRESS is set in the server environment.",
+          }),
+        }),
+      }),
+    ),
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/api/bounties",
   tags: ["Bounties"],
   summary: "List all bounties",


### PR DESCRIPTION
Closes #225
Closes #229
Closes #230
Closes #280

## Summary

- Add `ARBITER_ADDRESS` to `.env.example` with a comment explaining the arbiter role, how it maps to the `initialize` contract argument, and what happens when it is absent
- Upgrade `GET /api/health/deep` to return `{ components: { arbiter: 'configured' | 'missing' } }` by checking `process.env.ARBITER_ADDRESS` — the shallow `/api/health` route is unchanged
- Add `/api/health/deep` to the OpenAPI spec (`backend/src/docs/openapi.ts`) with a full description of the arbitration role and the `components.arbiter` response field
- Add **Arbitration Flow** section to `README.md` documenting the three roles (Maintainer / Contributor / Arbiter), configuration steps, deep health check verification, the end-to-end dispute lifecycle (raise → review → resolve on-chain → release funds), and the immutability note

## Test plan

- [ ] `ARBITER_ADDRESS=G...` set → `GET /api/health/deep` returns `{ components: { arbiter: "configured" } }`
- [ ] `ARBITER_ADDRESS` unset → `GET /api/health/deep` returns `{ components: { arbiter: "missing" } }`
- [ ] `GET /api/health` is unchanged (no `components` field)
- [ ] OpenAPI spec regenerates without errors
- [ ] README arbitration section renders correctly in GitHub