### PR TITLE
feat(backend): validate LOG_LEVEL env and enforce no-console in src 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,8 @@ BOUNTY_AUDIT_STORE_PATH=./data/audit.json
 # [OPTIONAL] CORS allowed origins (comma-separated). Default: http://localhost:5173
 CORS_ORIGINS=http://localhost:5173
 
-# [OPTIONAL] Logging level (debug, info, warn, error). Default: info
+# [OPTIONAL] Logging level. One of: trace, debug, info, warn, error, fatal, silent.
+# Invalid values fall back to "info" with a startup warning. Default: info
 LOG_LEVEL=info
 
 # [OPTIONAL] Bcrypt hash of the admin API key used to access GET /api/audit-log.

--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "env": {
+    "node": true,
+    "es2022": true
+  },
+  "ignorePatterns": ["dist", "node_modules", "*.config.js", "*.config.ts", "*.d.ts"],
+  "overrides": [
+    {
+      "files": ["src/**/*.ts"],
+      "rules": {
+        "no-console": "error"
+      }
+    },
+    {
+      "files": ["test/**/*.ts"],
+      "rules": {
+        "no-console": "off"
+      }
+    }
+  ]
+}

--- a/backend/src/docs/writeOpenApi.ts
+++ b/backend/src/docs/writeOpenApi.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { generateOpenApiDocument } from "./openapi";
+import { logger } from "../logger";
 
 const outputPath = path.resolve(process.cwd(), "../docs/openapi.generated.json");
 const document = generateOpenApiDocument();
@@ -8,4 +9,7 @@ const document = generateOpenApiDocument();
 fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 fs.writeFileSync(outputPath, `${JSON.stringify(document, null, 2)}\n`, "utf8");
 
-console.log(`Generated OpenAPI spec at ${path.relative(path.resolve(process.cwd(), ".."), outputPath)}`);
+logger.info(
+  { outputPath: path.relative(path.resolve(process.cwd(), ".."), outputPath) },
+  "Generated OpenAPI spec",
+);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -40,7 +40,9 @@ function startIndexerWorker() {
         try {
           await invalidateBountyCache();
         } catch (err) {
-          console.warn("Failed to invalidate bounty cache from indexer message:", err);
+          logStructured("warn", "indexer_cache_invalidation_failed", {
+            message: err instanceof Error ? err.message : String(err),
+          });
         }
       }
     });

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -46,9 +46,54 @@ export function redactStellarSecrets(value: unknown, seen = new WeakSet<object>(
  *    (`S...`, 56 chars) that slips into a message string or nested object,
  *    even when the field name is not in the redact path list (#381).
  */
+/**
+ * Pino's standard log levels, ordered by severity. `silent` disables output.
+ * Custom levels are not supported here; operators choose from this set via the
+ * `LOG_LEVEL` env var.
+ */
+export const VALID_LOG_LEVELS = [
+  "trace",
+  "debug",
+  "info",
+  "warn",
+  "error",
+  "fatal",
+  "silent",
+] as const;
+
+export const DEFAULT_LOG_LEVEL = "info";
+
+/**
+ * Resolve the effective log level from `LOG_LEVEL`.
+ *
+ * - Unset → defaults to `info`.
+ * - A recognized level (case-insensitive) → used as-is.
+ * - Anything else → falls back to `info` and the rejected value is reported
+ *   on `invalidValue` so the caller can emit a warning once the logger exists.
+ *
+ * Validating here (rather than passing the raw env var to pino) means an
+ * operator typo like `LOG_LEVEL=verbose` degrades to sane output instead of
+ * throwing at startup.
+ */
+export function resolveLogLevel(raw: string | undefined): {
+  level: string;
+  invalidValue?: string;
+} {
+  if (raw === undefined || raw === "") {
+    return { level: DEFAULT_LOG_LEVEL };
+  }
+  const normalized = raw.trim().toLowerCase();
+  if ((VALID_LOG_LEVELS as readonly string[]).includes(normalized)) {
+    return { level: normalized };
+  }
+  return { level: DEFAULT_LOG_LEVEL, invalidValue: raw };
+}
+
+const resolvedLevel = resolveLogLevel(process.env.LOG_LEVEL);
+
 /** Base pino options (exported so tests can build an identical logger). */
 export const baseLoggerOptions: pino.LoggerOptions = {
-  level: process.env.LOG_LEVEL ?? "info",
+  level: resolvedLevel.level,
   redact: {
     paths: [
       "req.headers.authorization",
@@ -84,6 +129,15 @@ export const logger = pino(
       })
     : undefined,
 );
+
+// Report an unusable LOG_LEVEL once the logger exists, so operators see why
+// their configured verbosity was ignored (#257).
+if (resolvedLevel.invalidValue !== undefined) {
+  logger.warn(
+    { invalidLogLevel: resolvedLevel.invalidValue, validLevels: VALID_LOG_LEVELS, fallback: DEFAULT_LOG_LEVEL },
+    `Invalid LOG_LEVEL "${resolvedLevel.invalidValue}"; falling back to "${DEFAULT_LOG_LEVEL}"`,
+  );
+}
 
 // ── Legacy shim ─────────────────────────────────────────────────────────────
 // Keeps existing callers of `logStructured` working without changes.

--- a/backend/src/services/bountyStore.ts
+++ b/backend/src/services/bountyStore.ts
@@ -619,7 +619,11 @@ export async function createBounty(
       amount: bounty.amount,
       tokenSymbol: bounty.tokenSymbol,
     }).catch((err) =>
-      console.warn("[createBounty] Notification failed (non-blocking):", err),
+      logStructured("warn", "notification_failed", {
+        operation: "createBounty",
+        bountyId: bounty.id,
+        message: err instanceof Error ? err.message : String(err),
+      }),
     );
 
     return bounty;
@@ -948,7 +952,11 @@ export async function disputeBounty(
       reason,
       disputedAt: now,
     }).catch((err) =>
-      console.warn("[disputeBounty] Notification failed (non-blocking):", err),
+      logStructured("warn", "notification_failed", {
+        operation: "disputeBounty",
+        bountyId: id,
+        message: err instanceof Error ? err.message : String(err),
+      }),
     );
 
     return persisted;

--- a/backend/test/logger.test.ts
+++ b/backend/test/logger.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 import pino from "pino";
 import { Keypair } from "@stellar/stellar-sdk";
-import { baseLoggerOptions, redactStellarSecrets } from "../src/logger";
+import {
+  baseLoggerOptions,
+  redactStellarSecrets,
+  resolveLogLevel,
+  DEFAULT_LOG_LEVEL,
+  VALID_LOG_LEVELS,
+} from "../src/logger";
 
 const SECRET = Keypair.random().secret(); // valid Stellar seed: S + 55 base32 chars
 
@@ -54,5 +60,37 @@ describe("logger redaction (pino)", () => {
     expect(entry.wallet.secretKey).toBe("[redacted]");
     expect(entry.wallet.privateKey).toBe("[redacted]");
     expect(entry.wallet.seed).toBe("[redacted]");
+  });
+});
+
+describe("resolveLogLevel", () => {
+  it("defaults to info when LOG_LEVEL is unset", () => {
+    expect(resolveLogLevel(undefined)).toEqual({ level: DEFAULT_LOG_LEVEL });
+  });
+
+  it("defaults to info when LOG_LEVEL is an empty string", () => {
+    expect(resolveLogLevel("")).toEqual({ level: DEFAULT_LOG_LEVEL });
+  });
+
+  it("accepts every valid pino level", () => {
+    for (const level of VALID_LOG_LEVELS) {
+      expect(resolveLogLevel(level)).toEqual({ level });
+    }
+  });
+
+  it("enables debug-level logging when LOG_LEVEL=debug", () => {
+    expect(resolveLogLevel("debug")).toEqual({ level: "debug" });
+  });
+
+  it("is case-insensitive and trims surrounding whitespace", () => {
+    expect(resolveLogLevel("  DEBUG  ")).toEqual({ level: "debug" });
+    expect(resolveLogLevel("Info")).toEqual({ level: "info" });
+  });
+
+  it("falls back to info and reports the rejected value for an invalid level", () => {
+    expect(resolveLogLevel("verbose")).toEqual({
+      level: DEFAULT_LOG_LEVEL,
+      invalidValue: "verbose",
+    });
   });
 });


### PR DESCRIPTION
## Description

Closes #257 

Makes pino log verbosity operator-configurable via `LOG_LEVEL` and safe against invalid values, and enforces no stray `console.*` in backend source.

- **`backend/src/logger.ts`** — added `resolveLogLevel()` that validates `LOG_LEVEL` against pino's standard levels (`trace`, `debug`, `info`, `warn`, `error`, `fatal`, `silent`), case-insensitive and whitespace-trimmed, defaulting to `info`. Invalid values fall back to `info` and emit a startup warning naming the rejected value. Previously the raw env var was passed straight to pino, so an unknown level threw on boot.
- **Removed `console.*` from `src/`** — migrated the remaining calls to the shared logger in `index.ts`, `services/bountyStore.ts`, and `docs/writeOpenApi.ts`.
- **`backend/.eslintrc.json`** (new) — wires the TypeScript parser and enables `no-console: error` for `src/**` (off for `test/**`). The previous setup had no parser, so backend lint emitted parse errors.
- **`.env.example`** — documented the valid levels and fallback behavior.
- **`backend/test/logger.test.ts`** — added unit tests for `resolveLogLevel` (unset, empty, all valid levels, `debug`, case/whitespace normalization, invalid → fallback).

### Acceptance criteria

- [x] `LOG_LEVEL=debug` enables debug-level logging
- [x] Invalid log levels fall back to `info` with a warning
- [x] All route handlers and services use the shared pino instance
- [x] No `console.log` calls