### PR TITLE
feat: implement bounty board smart contract and project configuration

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -10,7 +10,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -124,6 +124,7 @@ pub enum ContractError {
     MissingContributor,
     BountyAlreadyFinalized,
     BountyNotExpiredYet,
+    BountyExpired,
     DeadlineMustAdvance,
     CannotExtendFinalizedBounty,
     BountyNotFound,
@@ -413,6 +414,11 @@ impl StellarBountyBoardContract {
 
     pub fn dispute_bounty(env: Env, bounty_id: u64, arbiter: Address) {
         let mut bounty = read_bounty(&env, bounty_id);
+
+        if env.ledger().timestamp() > bounty.deadline {
+            panic_error(ContractError::BountyExpired);
+        }
+
         let contributor = bounty
             .contributor
             .clone()

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -743,7 +743,15 @@ fn test_extend_deadline_earlier() {
 }
 
 #[test]
+fn test_dispute_before_deadline_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
 
+    let (client, maintainer, contributor, token_id, _fee_recipient, arbiter) = setup_test(&env);
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin.mint(&maintainer, &1000);
+
+    let deadline = env.ledger().timestamp() + 1000;
     let bounty_id = client.create_bounty(
         &maintainer,
         &token_id,
@@ -751,7 +759,30 @@ fn test_extend_deadline_earlier() {
         &String::from_str(&env, "repo"),
         &1,
         &String::from_str(&env, "title"),
+        &deadline,
+        &0u32,
+    );
 
+    client.reserve_bounty(&bounty_id, &contributor);
+    client.submit_bounty(&bounty_id, &contributor);
+
+    // Dispute before deadline should succeed
+    client.dispute_bounty(&bounty_id, &arbiter);
+    let bounty = client.get_bounty(&bounty_id);
+    assert_eq!(bounty.status, BountyStatus::Disputed);
+}
+
+#[test]
+#[should_panic(expected = "BountyExpired")]
+fn test_dispute_after_deadline_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, maintainer, contributor, token_id, _fee_recipient, arbiter) = setup_test(&env);
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin.mint(&maintainer, &1000);
+
+    let deadline = env.ledger().timestamp() + 1000;
     let bounty_id = client.create_bounty(
         &maintainer,
         &token_id,
@@ -759,13 +790,16 @@ fn test_extend_deadline_earlier() {
         &String::from_str(&env, "repo"),
         &1,
         &String::from_str(&env, "title"),
+        &deadline,
+        &0u32,
+    );
 
-    let bounty_id = client.create_bounty(
-        &maintainer,
-        &token_id,
-        &500,
-        &String::from_str(&env, "repo"),
-        &1,
-        &String::from_str(&env, "title"),
+    client.reserve_bounty(&bounty_id, &contributor);
+    client.submit_bounty(&bounty_id, &contributor);
 
+    // Advance ledger timestamp past deadline
+    env.ledger().set_timestamp(deadline + 1);
+
+    // Dispute after deadline should fail
+    client.dispute_bounty(&bounty_id, &arbiter);
 }


### PR DESCRIPTION
## Description
Closes #233 
Here is a completed PR description for the smart contract deadline checks we implemented. 


## Summary
This PR fixes a bug in the smart contract where `dispute_bounty` could theoretically be called on a bounty whose deadline had already expired (if the status was `Submitted`).

**Changes included:**
* Added a new `BountyExpired` variant to the `ContractError` enum.
* Added a deadline guard in `dispute_bounty` that compares `env.ledger().timestamp()` to `bounty.deadline` and panics with `ContractError::BountyExpired` if the deadline has passed.
* Fixed syntax errors in `test.rs` and added two new unit tests: one verifying that a dispute before the deadline succeeds, and another verifying that a dispute after the deadline correctly panics.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Security Checklist

Please review the [SECURITY_CHECKLIST.md](../SECURITY_CHECKLIST.md) and check off any items that apply. Reviewers must sign off on these items before merge.

- [x] Input validation changed
- [ ] Auth modified
- [ ] New external fetch
- [ ] Dependency added
- [ ] Secret handling


