### PR TITLE
Add validateBody middleware for consistent Zod 400 responses

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -19,6 +19,7 @@ import {
   releaseBounty,
   reserveBounty,
   submitBounty,
+  updateBountyNotes,
   getBountyEvents,
   getMaintainerMetrics,
   getGlobalMetrics,
@@ -34,8 +35,8 @@ import {
   reserveBountySchema,
   submitBountySchema,
   updateNotesSchema,
-  zodErrorMessage,
 } from './validation/schemas';
+import { validateBody } from './middleware/validateBody';
 import { isValidStellarAddress } from './utils';
 
 import {
@@ -521,15 +522,9 @@ app.post(
   '/api/bounties',
   mutationLimiter,
   createBountyCreationSignatureMiddleware(),
+  validateBody(createBountySchema),
   async (req: Request, res: Response) => {
-    const parsed = createBountySchema.safeParse(req.body);
-
-    if (!parsed.success) {
-      jsonError(res, req, 400, zodErrorMessage(parsed.error));
-      return;
-    }
-
-    const amountError = validateBountyAmount(parsed.data.amount);
+    const amountError = validateBountyAmount(req.body.amount);
 
     if (amountError) {
       jsonError(res, req, 400, amountError);
@@ -537,7 +532,7 @@ app.post(
     }
 
     try {
-      const bounty = await createBounty(parsed.data);
+      const bounty = await createBounty(req.body);
       res.status(201).json({ data: bounty });
     } catch (error) {
       sendError(res, req, error);
@@ -545,19 +540,12 @@ app.post(
   }
 );
 
-app.post('/api/bounties/:id/reserve', mutationLimiter, idempotencyMiddleware, async (req: Request, res: Response) => {
-  const parsedBody = reserveBountySchema.safeParse(req.body);
-
-  if (!parsedBody.success) {
-    jsonError(res, req, 400, zodErrorMessage(parsedBody.error));
-    return;
-  }
-
+app.post('/api/bounties/:id/reserve', mutationLimiter, idempotencyMiddleware, validateBody(reserveBountySchema), async (req: Request, res: Response) => {
   try {
     const bounty = await reserveBounty(
       parseId(req.params.id),
-      parsedBody.data.contributor,
-      parsedBody.data.expectedVersion
+      req.body.contributor,
+      req.body.expectedVersion
     );
 
     res.json({ data: bounty });
@@ -566,20 +554,13 @@ app.post('/api/bounties/:id/reserve', mutationLimiter, idempotencyMiddleware, as
   }
 });
 
-app.post('/api/bounties/:id/submit', mutationLimiter, idempotencyMiddleware, async (req: Request, res: Response) => {
-  const parsedBody = submitBountySchema.safeParse(req.body);
-
-  if (!parsedBody.success) {
-    jsonError(res, req, 400, zodErrorMessage(parsedBody.error));
-    return;
-  }
-
+app.post('/api/bounties/:id/submit', mutationLimiter, idempotencyMiddleware, validateBody(submitBountySchema), async (req: Request, res: Response) => {
   try {
     const bounty = await submitBounty(
       parseId(req.params.id),
-      parsedBody.data.contributor,
-      parsedBody.data.submissionUrl,
-      parsedBody.data.notes
+      req.body.contributor,
+      req.body.submissionUrl,
+      req.body.notes
     );
 
     res.json({ data: bounty });
@@ -593,19 +574,13 @@ app.post(
   mutationLimiter,
   idempotencyMiddleware,
   createStellarSignatureAuthMiddleware(),
+  validateBody(maintainerActionSchema),
   async (req: Request, res: Response) => {
-    const parsedBody = maintainerActionSchema.safeParse(req.body);
-
-    if (!parsedBody.success) {
-      jsonError(res, req, 400, zodErrorMessage(parsedBody.error));
-      return;
-    }
-
     try {
       const bounty = await releaseBounty(
         parseId(req.params.id),
-        parsedBody.data.maintainer,
-        parsedBody.data.transactionHash
+        req.body.maintainer,
+        req.body.transactionHash
       );
 
       res.json({ data: bounty });
@@ -620,19 +595,13 @@ app.post(
   mutationLimiter,
   idempotencyMiddleware,
   createStellarSignatureAuthMiddleware(),
+  validateBody(maintainerActionSchema),
   async (req: Request, res: Response) => {
-    const parsedBody = maintainerActionSchema.safeParse(req.body);
-
-    if (!parsedBody.success) {
-      jsonError(res, req, 400, zodErrorMessage(parsedBody.error));
-      return;
-    }
-
     try {
       const bounty = await refundBounty(
         parseId(req.params.id),
-        parsedBody.data.maintainer,
-        parsedBody.data.transactionHash
+        req.body.maintainer,
+        req.body.transactionHash
       );
 
       res.json({ data: bounty });
@@ -646,19 +615,13 @@ app.post(
   '/api/bounties/:id/dispute',
   mutationLimiter,
   createStellarSignatureAuthMiddleware(),
+  validateBody(disputeBountySchema),
   async (req: Request, res: Response) => {
-    const parsedBody = disputeBountySchema.safeParse(req.body);
-
-    if (!parsedBody.success) {
-      jsonError(res, req, 400, zodErrorMessage(parsedBody.error));
-      return;
-    }
-
     try {
       const bounty = await disputeBounty(
         parseId(req.params.id),
-        parsedBody.data.contributor,
-        parsedBody.data.reason
+        req.body.contributor,
+        req.body.reason
       );
 
       res.json({ data: bounty });
@@ -672,19 +635,13 @@ app.patch(
   '/api/bounties/:id/notes',
   mutationLimiter,
   createStellarSignatureAuthMiddleware(),
+  validateBody(updateNotesSchema),
   async (req: Request, res: Response) => {
-    const parsedBody = updateNotesSchema.safeParse(req.body);
-
-    if (!parsedBody.success) {
-      jsonError(res, req, 400, zodErrorMessage(parsedBody.error));
-      return;
-    }
-
     try {
       const bounty = await updateBountyNotes(
         parseId(req.params.id),
-        parsedBody.data.maintainer,
-        parsedBody.data.notes
+        req.body.maintainer,
+        req.body.notes
       );
 
       res.json({ data: bounty });

--- a/backend/src/middleware/validateBody.ts
+++ b/backend/src/middleware/validateBody.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from 'express';
+import { ZodSchema } from 'zod';
+
+export function validateBody<T>(schema: ZodSchema<T>) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const result = schema.safeParse(req.body);
+
+    if (!result.success) {
+      res.status(400).json({ error: 'Validation failed', details: result.error.issues });
+      return;
+    }
+
+    req.body = result.data;
+    next();
+  };
+}

--- a/backend/test/validateBody.test.ts
+++ b/backend/test/validateBody.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { z } from 'zod';
+import { validateBody } from '../src/middleware/validateBody';
+
+const schema = z.object({
+  name: z.string().min(1),
+  age: z.number().int().positive(),
+});
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.post('/test', validateBody(schema), (req: Request, res: Response) => {
+    res.json({ received: req.body });
+  });
+  return app;
+}
+
+describe('validateBody middleware', () => {
+  it('passes valid body to next handler', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/test').send({ name: 'Alice', age: 30 }).expect(200);
+    expect(res.body.received).toEqual({ name: 'Alice', age: 30 });
+  });
+
+  it('returns 400 with standardized shape on missing field', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/test').send({ age: 30 }).expect(400);
+    expect(res.body.error).toBe('Validation failed');
+    expect(Array.isArray(res.body.details)).toBe(true);
+    const paths = res.body.details.map((d: { path: string[] }) => d.path.join('.'));
+    expect(paths).toContain('name');
+  });
+
+  it('returns 400 with standardized shape on wrong type', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/test').send({ name: 'Alice', age: 'not-a-number' }).expect(400);
+    expect(res.body.error).toBe('Validation failed');
+    expect(Array.isArray(res.body.details)).toBe(true);
+    const paths = res.body.details.map((d: { path: string[] }) => d.path.join('.'));
+    expect(paths).toContain('age');
+  });
+
+  it('strips extra fields not in schema', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/test')
+      .send({ name: 'Alice', age: 25, extra: 'should-be-removed' })
+      .expect(200);
+    expect(res.body.received).not.toHaveProperty('extra');
+    expect(res.body.received).toEqual({ name: 'Alice', age: 25 });
+  });
+
+  it('does not expose raw ZodError objects to clients', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/test').send({}).expect(400);
+    expect(res.body).not.toHaveProperty('issues');
+    expect(res.body.error).toBe('Validation failed');
+    expect(res.body.details).toBeDefined();
+  });
+
+  it('sets req.body to the parsed/transformed data', async () => {
+    const trimSchema = z.object({ name: z.string().trim() });
+    const trimApp = express();
+    trimApp.use(express.json());
+    trimApp.post('/trim', validateBody(trimSchema), (req: Request, res: Response) => {
+      res.json({ name: req.body.name });
+    });
+    const res = await request(trimApp).post('/trim').send({ name: '  Alice  ' }).expect(200);
+    expect(res.body.name).toBe('Alice');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `validateBody(schema)` middleware in `backend/src/middleware/validateBody.ts` that catches `ZodError` and always returns `{ error: 'Validation failed', details: ZodIssue[] }` with a 400 status
- Replaces all inline `safeParse` + `zodErrorMessage` patterns across every POST/PATCH route in `app.ts` with the new shared middleware
- Fixes missing `updateBountyNotes` import in `app.ts`
- Removes the now-unused `zodErrorMessage` import

## Test plan

- [ ] `backend/test/validateBody.test.ts` — 6 unit tests covering: valid body passthrough, missing field, wrong type, extra field stripping, raw ZodError not exposed, transformed data set on `req.body`
- [ ] Run `npm --prefix backend test` to verify the new tests pass

Closes #270